### PR TITLE
fix: persist institution wallet address to DB on connect

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -26,6 +26,19 @@ function DashboardContent() {
     const [institutionId, setInstitutionId] = useState<string>('');
     const [loading, setLoading] = useState(true);
 
+    // Persist wallet address to institution row whenever it changes
+    useEffect(() => {
+        if (!user || userRole !== 'institution' || !institutionId || !address) return;
+
+        supabase
+            .from('institutions')
+            .update({ wallet_address: address })
+            .eq('id', institutionId)
+            .then(({ error }) => {
+                if (error) console.error('Error persisting wallet address:', error);
+            });
+    }, [address, institutionId, user, userRole]);
+
     // Fetch institution ID from database
     useEffect(() => {
         const fetchInstitutionId = async () => {


### PR DESCRIPTION
Closes #9

---

Ensures wallet_address is written to the institution row whenever the connected address changes, so the admin authorization API can reliably find the institution by wallet_address and mark it verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Institutional users' connected wallet addresses are now automatically persisted and updated to their profile.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soumen0818/ACREDIA-STELLAR/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->