### PR TITLE
fix: verify credentials against Soroban contract in public verify API

### DIFF
--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceRoleClient } from '@/lib/serverAuth';
-import { sorobanServer, activeNetwork, getContractAddress } from '@/lib/stellar';
+import { activeNetwork, getContractAddress, sorobanServer } from '@/lib/stellar';
 import {
+    Account,
     Contract,
     TransactionBuilder,
-    Account,
     TimeoutInfinite,
     nativeToScVal,
     scValToNative,
@@ -18,7 +18,9 @@ const DUMMY_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
 
 async function simulateContractRead(method: string, args: any[]): Promise<any> {
     const contractId = getContractAddress('CREDENTIAL_NFT');
-    if (!contractId) return null;
+    if (!contractId) {
+        throw new Error('Missing contract configuration for CREDENTIAL_NFT');
+    }
 
     const contract = new Contract(contractId);
     const sourceAccount = new Account(DUMMY_ADDRESS, '0');
@@ -41,6 +43,10 @@ async function simulateContractRead(method: string, args: any[]): Promise<any> {
         if (typeof retval === 'string') {
             return scValToNative(xdr.ScVal.fromXDR(retval, 'base64'));
         }
+        // Failsafe for boolean ScVal objects where SDK swallowed the prototype
+        if (typeof retval === 'object' && !retval.switch && retval._switch?.name === 'scvBool') {
+            return retval._value;
+        }
         return scValToNative(retval);
     } catch {
         return null;
@@ -58,6 +64,14 @@ export async function GET(
         if (!token) {
             return NextResponse.json(
                 { success: false, error: 'Token is required' },
+                { status: 400 }
+            );
+        }
+
+        // Validate token is a safe non-negative integer before passing to contract
+        if (!/^\d+$/.test(token) || Number(token) > Number.MAX_SAFE_INTEGER) {
+            return NextResponse.json(
+                { success: false, error: 'Invalid token ID' },
                 { status: 400 }
             );
         }
@@ -94,12 +108,9 @@ export async function GET(
         }
 
         // --- On-chain verification ---
+        // get_credential returns the full struct including revoked; no need for a separate is_revoked call
         const tokenIdArg = nativeToScVal(Number(token), { type: 'u64' });
-
-        const [onChainCredential, onChainRevoked] = await Promise.all([
-            simulateContractRead('get_credential', [tokenIdArg]),
-            simulateContractRead('is_revoked', [tokenIdArg]),
-        ]);
+        const onChainCredential = await simulateContractRead('get_credential', [tokenIdArg]);
 
         // If the contract has no record for this token, the DB row cannot be trusted
         if (onChainCredential === null) {
@@ -109,8 +120,14 @@ export async function GET(
             );
         }
 
-        // On-chain revocation is authoritative — override DB value
-        const isRevoked = onChainRevoked === true || data.revoked === true;
+        // On-chain revocation is authoritative — if the chain result is unreadable, fail safe
+        if (typeof onChainCredential.revoked !== 'boolean') {
+            return NextResponse.json(
+                { success: false, error: 'Unable to determine revocation status from blockchain' },
+                { status: 503 }
+            );
+        }
+        const isRevoked = onChainCredential.revoked === true;
 
         const institution = Array.isArray(data.institution)
             ? data.institution[0]
@@ -134,7 +151,13 @@ export async function GET(
             success: true,
             credential: safeCredential,
         });
-    } catch {
+    } catch (err: any) {
+        if (err?.message?.startsWith('Missing contract configuration')) {
+            return NextResponse.json(
+                { success: false, error: 'Server configuration error' },
+                { status: 500 }
+            );
+        }
         return NextResponse.json(
             { success: false, error: 'Internal server error' },
             { status: 500 }

--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -1,7 +1,51 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceRoleClient } from '@/lib/serverAuth';
+import { sorobanServer, activeNetwork, getContractAddress } from '@/lib/stellar';
+import {
+    Contract,
+    TransactionBuilder,
+    Account,
+    TimeoutInfinite,
+    nativeToScVal,
+    scValToNative,
+    xdr,
+} from '@stellar/stellar-sdk';
 
 export const dynamic = 'force-dynamic';
+
+// Dummy read-only address — no funds needed for simulation
+const DUMMY_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+
+async function simulateContractRead(method: string, args: any[]): Promise<any> {
+    const contractId = getContractAddress('CREDENTIAL_NFT');
+    if (!contractId) return null;
+
+    const contract = new Contract(contractId);
+    const sourceAccount = new Account(DUMMY_ADDRESS, '0');
+
+    const tx = new TransactionBuilder(sourceAccount, {
+        fee: '100',
+        networkPassphrase: activeNetwork.networkPassphrase,
+    })
+        .addOperation(contract.call(method, ...args))
+        .setTimeout(TimeoutInfinite)
+        .build();
+
+    const sim = await sorobanServer.simulateTransaction(tx as any);
+    if ('error' in sim) return null;
+
+    const retval = (sim as any).result?.retval;
+    if (!retval) return null;
+
+    try {
+        if (typeof retval === 'string') {
+            return scValToNative(xdr.ScVal.fromXDR(retval, 'base64'));
+        }
+        return scValToNative(retval);
+    } catch {
+        return null;
+    }
+}
 
 export async function GET(
     _request: NextRequest,
@@ -49,6 +93,25 @@ export async function GET(
             );
         }
 
+        // --- On-chain verification ---
+        const tokenIdArg = nativeToScVal(Number(token), { type: 'u64' });
+
+        const [onChainCredential, onChainRevoked] = await Promise.all([
+            simulateContractRead('get_credential', [tokenIdArg]),
+            simulateContractRead('is_revoked', [tokenIdArg]),
+        ]);
+
+        // If the contract has no record for this token, the DB row cannot be trusted
+        if (onChainCredential === null) {
+            return NextResponse.json(
+                { success: false, error: 'Credential not found on blockchain' },
+                { status: 404 }
+            );
+        }
+
+        // On-chain revocation is authoritative — override DB value
+        const isRevoked = onChainRevoked === true || data.revoked === true;
+
         const institution = Array.isArray(data.institution)
             ? data.institution[0]
             : data.institution;
@@ -57,13 +120,14 @@ export async function GET(
         const safeCredential = {
             tokenId: data.token_id,
             issuedAt: data.issued_at,
-            revoked: data.revoked,
+            revoked: isRevoked,
             revokedAt: data.revoked_at,
             institutionName: institution?.name ?? credentialData.institutionName ?? null,
             credentialType: credentialData.credentialType ?? null,
             degree: credentialData.degree ?? null,
             major: credentialData.major ?? null,
             issueDate: credentialData.issueDate ?? null,
+            onChainVerified: true,
         };
 
         return NextResponse.json({

--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -16,6 +16,9 @@ export const dynamic = 'force-dynamic';
 // Dummy read-only address — no funds needed for simulation
 const DUMMY_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
 
+// Sentinel to distinguish "credential absent from chain" from infrastructure errors
+const NOT_FOUND_ON_CHAIN = Symbol('NOT_FOUND_ON_CHAIN');
+
 async function simulateContractRead(method: string, args: any[]): Promise<any> {
     const contractId = getContractAddress('CREDENTIAL_NFT');
     if (!contractId) {
@@ -33,11 +36,21 @@ async function simulateContractRead(method: string, args: any[]): Promise<any> {
         .setTimeout(TimeoutInfinite)
         .build();
 
+    // Network/RPC errors propagate as thrown exceptions (caller maps to 503)
     const sim = await sorobanServer.simulateTransaction(tx as any);
-    if ('error' in sim) return null;
+
+    if ('error' in sim) {
+        const errStr = String((sim as any).error);
+        // Contract returning "not found" / missing entry is a known absence, not an infra error
+        if (errStr.includes('not found') || errStr.includes('MissingValue') || errStr.includes('KeyNotFound')) {
+            return NOT_FOUND_ON_CHAIN;
+        }
+        throw new Error(`Contract simulation error: ${errStr}`);
+    }
 
     const retval = (sim as any).result?.retval;
-    if (!retval) return null;
+    // No retval on a successful sim means the entry doesn't exist (e.g. Option::None)
+    if (!retval) return NOT_FOUND_ON_CHAIN;
 
     try {
         if (typeof retval === 'string') {
@@ -49,7 +62,8 @@ async function simulateContractRead(method: string, args: any[]): Promise<any> {
         }
         return scValToNative(retval);
     } catch {
-        return null;
+        // Parse failure is an infrastructure problem, not a missing credential
+        throw new Error('Failed to decode contract response');
     }
 }
 
@@ -113,7 +127,7 @@ export async function GET(
         const onChainCredential = await simulateContractRead('get_credential', [tokenIdArg]);
 
         // If the contract has no record for this token, the DB row cannot be trusted
-        if (onChainCredential === null) {
+        if (onChainCredential === NOT_FOUND_ON_CHAIN) {
             return NextResponse.json(
                 { success: false, error: 'Credential not found on blockchain' },
                 { status: 404 }
@@ -138,7 +152,7 @@ export async function GET(
             tokenId: data.token_id,
             issuedAt: data.issued_at,
             revoked: isRevoked,
-            revokedAt: data.revoked_at,
+            revokedAt: isRevoked ? data.revoked_at : null,
             institutionName: institution?.name ?? credentialData.institutionName ?? null,
             credentialType: credentialData.credentialType ?? null,
             degree: credentialData.degree ?? null,
@@ -156,6 +170,12 @@ export async function GET(
             return NextResponse.json(
                 { success: false, error: 'Server configuration error' },
                 { status: 500 }
+            );
+        }
+        if (err?.message?.startsWith('Contract simulation error') || err?.message?.startsWith('Failed to decode')) {
+            return NextResponse.json(
+                { success: false, error: 'Blockchain verification unavailable' },
+                { status: 503 }
             );
         }
         return NextResponse.json(


### PR DESCRIPTION
Closes #7

---

- Call get_credential and is_revoked on-chain via server-side simulation
- Return 404 if token has no on-chain record (DB row alone is not trusted)
- On-chain revocation is authoritative and overrides DB revoked flag
- Add onChainVerified flag to response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential revocation is now verified on-chain and treated as authoritative; responses include onChainVerified and set revoked/revokedAt based on on-chain data.
  * Requests for credentials not found on-chain return 404.

* **Bug Fixes**
  * Improved validation of credential IDs and clearer error mapping: server configuration issues return 500, blockchain verification failures return 503.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soumen0818/ACREDIA-STELLAR/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->