### PR TITLE
fix(admin): restrict /admin route to admin role only

### DIFF
--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -337,7 +337,7 @@ function AdminDashboardContent() {
 
 export default function AdminDashboardPage() {
     return (
-        <ProtectedRoute>
+        <ProtectedRoute allowedRoles={['admin']}>
             <AdminDashboardContent />
         </ProtectedRoute>
     );


### PR DESCRIPTION
Closes #4

---

fix(admin): restrict /admin route to admin role only

* Pass allowedRoles={['admin']} to ProtectedRoute so non-admin
authenticated users (students, institutions) are redirected to
/dashboard instead of seeing the admin