### PR TITLE
fix: persist real Soroban credential token IDs and decode issue_crede…

### DIFF
--- a/frontend/src/lib/contracts.ts
+++ b/frontend/src/lib/contracts.ts
@@ -55,7 +55,7 @@ async function invokeContractMethod(
     method: string,
     args: any[],
     signerAddress: string
-): Promise<string> {
+): Promise<{ transactionHash: string; result: any }> {
     const contract = new Contract(contractId);
     const sourceAccount = await sorobanServer.getAccount(signerAddress);
 
@@ -117,12 +117,45 @@ async function invokeContractMethod(
         );
     }
 
+    const resultValue = getSorobanTransactionResult(simResult);
+
     // Wait for on-chain confirmation
     console.log(`⏳ Waiting for confirmation (hash: ${sendResponse.hash})...`);
     await waitForConfirmation(sendResponse.hash);
     console.log(`✅ ${method} confirmed on-chain.`);
 
-    return sendResponse.hash;
+    return {
+        transactionHash: sendResponse.hash,
+        result: resultValue,
+    };
+}
+
+export function getSorobanTransactionResult(simResult: any): any {
+    const rawResult =
+        simResult?.result?.retval ||
+        simResult?.result?.result?.retval ||
+        simResult?.retval ||
+        simResult?.result?.xdr?.retval;
+
+    if (rawResult == null) {
+        return null;
+    }
+
+    try {
+        if (typeof rawResult === "string") {
+            const scval = xdr.ScVal.fromXDR(rawResult, "base64");
+            return scValToNative(scval);
+        }
+
+        if (typeof rawResult === "object" && (rawResult.switch || rawResult._switch)) {
+            return scValToNative(rawResult);
+        }
+
+        return rawResult;
+    } catch (e) {
+        console.error("DEBUG getSorobanTransactionResult error:", e);
+        return null;
+    }
 }
 
 /**
@@ -152,31 +185,7 @@ async function simulateRead(contractId: string, method: string, args: any[] = []
         return null;
     }
 
-    const resultXdr = (sim as any).result?.retval;
-    console.log("DEBUG simulateRead resultXdr:", resultXdr);
-    if (!resultXdr) {
-        console.error("DEBUG resultXdr is empty.");
-        return null;
-    }
-
-    try {
-        if (typeof resultXdr === "string") {
-            const scval = xdr.ScVal.fromXDR(resultXdr, "base64");
-            return scValToNative(scval);
-        }
-        
-        // Failsafe raw object bypass for booleans (in case browser SDK swallowed prototype)
-        if (typeof resultXdr === 'object' && !resultXdr.switch && resultXdr._switch?.name === 'scvBool') {
-             console.log("DEBUG: Using failsafe boolean bypass");
-             return resultXdr._value;
-        }
-
-        // It's already an xdr.ScVal object in newer stellar-sdk versions
-        return scValToNative(resultXdr);
-    } catch (e) {
-        console.error("DEBUG scValToNative errored:", e);
-        return null;
-    }
+    return getSorobanTransactionResult(sim);
 }
 
 /**
@@ -220,7 +229,30 @@ export async function isAuthorizedIssuer(issuerAddress: string, callerAddress: s
 export async function authorizeIssuer(adminAddress: string, issuerAddress: string): Promise<string> {
     const contractId = getContractAddress("CREDENTIAL_NFT");
     const args = [new Address(issuerAddress).toScVal()];
-    return invokeContractMethod(contractId, "authorize_issuer", args, adminAddress);
+    const { transactionHash } = await invokeContractMethod(contractId, "authorize_issuer", args, adminAddress);
+    return transactionHash;
+}
+
+export function ensureValidTokenId(tokenId: unknown): string {
+    let normalized: string;
+
+    if (typeof tokenId === "bigint") {
+        normalized = tokenId.toString();
+    } else if (typeof tokenId === "number") {
+        normalized = Number.isSafeInteger(tokenId) ? tokenId.toString() : "";
+    } else if (typeof tokenId === "string") {
+        normalized = tokenId;
+    } else {
+        normalized = "";
+    }
+
+    if (!/^[1-9][0-9]*$/.test(normalized)) {
+        throw new Error(
+            `Invalid token ID returned from Soroban contract: ${JSON.stringify(tokenId)}.`
+        );
+    }
+
+    return normalized;
 }
 
 /**
@@ -254,12 +286,14 @@ export async function issueCredentialOnStellar(
         nativeToScVal(ipfsUri, { type: "string" }),
     ];
 
-    const txHash = await invokeContractMethod(contractId, "issue_credential", args, issuerAddress);
+    const { transactionHash, result } = await invokeContractMethod(contractId, "issue_credential", args, issuerAddress);
+    const tokenId = ensureValidTokenId(result);
 
-    console.log("✅ Credential issued on Stellar Network. Tx:", txHash);
+    console.log("✅ Credential issued on Stellar Network. Tx:", transactionHash);
+    console.log("✅ Contract returned token ID:", tokenId);
     return {
-        tokenId: "pending",
-        transactionHash: txHash,
+        tokenId,
+        transactionHash,
     };
 }
 
@@ -269,15 +303,16 @@ export async function issueCredentialOnStellar(
 export async function revokeCredentialOnStellar(tokenId: string, issuerAddress: string): Promise<string> {
     console.log("🗑️ Revoking credential on Stellar Network...");
     const contractId = getContractAddress("CREDENTIAL_NFT");
+    const validatedTokenId = ensureValidTokenId(tokenId);
 
     const args = [
-        nativeToScVal(Number(tokenId), { type: "u64" }),
+        nativeToScVal(Number(validatedTokenId), { type: "u64" }),
         new Address(issuerAddress).toScVal(),
     ];
 
-    const txHash = await invokeContractMethod(contractId, "revoke_credential", args, issuerAddress);
-    console.log("✅ Credential revoked on Stellar Network. Tx:", txHash);
-    return txHash;
+    const { transactionHash } = await invokeContractMethod(contractId, "revoke_credential", args, issuerAddress);
+    console.log("✅ Credential revoked on Stellar Network. Tx:", transactionHash);
+    return transactionHash;
 }
 
 /**

--- a/frontend/src/lib/credentialService.ts
+++ b/frontend/src/lib/credentialService.ts
@@ -157,7 +157,6 @@ export async function issueCredential(
             metadataUrl,
             issuerAddress
         );
-        const resolvedTokenId = tokenId && tokenId !== 'pending' ? tokenId : transactionHash;
         console.log('✅ Credential issued! Token ID:', tokenId);
         console.log('✅ Transaction:', transactionHash);
 
@@ -182,7 +181,7 @@ export async function issueCredential(
             student_wallet_address: data.studentWallet, // Store wallet for lookup
             institution_id: data.institutionId,
             issuer_wallet_address: data.institutionWallet, // Store issuer wallet
-            token_id: resolvedTokenId,
+            token_id: tokenId,
             ipfs_hash: metadataPath, // Store full path (CID/filename)
             blockchain_hash: transactionHash,
             metadata: metadata,
@@ -201,7 +200,7 @@ export async function issueCredential(
         console.log('✅ Credential saved to database');
 
         return {
-            tokenId: resolvedTokenId,
+            tokenId,
             transactionHash,
             ipfsHash: fileCID,
             metadataHash: metadataPath,

--- a/frontend/tests/contracts.test.ts
+++ b/frontend/tests/contracts.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { ensureValidTokenId, getSorobanTransactionResult } from '../src/lib/contracts';
+
+describe('Soroban contract helper functions', () => {
+  it('parses u64 return values from Soroban simulation results', () => {
+    const simResult = {
+      result: {
+        retval: 'AAAABQAAAAAAAAAB',
+      },
+    };
+
+    const parsed = getSorobanTransactionResult(simResult);
+    expect(parsed).toBe(1n);
+  });
+
+  it('rejects invalid token IDs before signing', () => {
+    expect(() => ensureValidTokenId('pending')).toThrow('Invalid token ID');
+    expect(() => ensureValidTokenId('0')).toThrow('Invalid token ID');
+    expect(() => ensureValidTokenId('-1')).toThrow('Invalid token ID');
+    expect(() => ensureValidTokenId('1.5')).toThrow('Invalid token ID');
+  });
+
+  it('accepts valid numeric token IDs', () => {
+    expect(ensureValidTokenId('1')).toBe('1');
+    expect(ensureValidTokenId(2)).toBe('2');
+    expect(ensureValidTokenId(3n)).toBe('3');
+  });
+});


### PR DESCRIPTION
# Return and persist real Soroban credential token IDs after issuance
Closes #15 
## Summary

This update fixes the credential issuance flow so the frontend now stores the actual `u64` token ID returned by the Soroban `issue_credential` contract call, instead of using a placeholder `"pending"` value or the transaction hash.

## Changes

- `frontend/src/lib/contracts.ts`
  - `invokeContractMethod` now returns both:
    - `transactionHash`
    - decoded contract return value
  - added robust Soroban return parsing for `u64`
  - added token ID validation before revocation

- `frontend/src/lib/credentialService.ts`
  - credential creation now stores the real token ID in Supabase
  - `blockchain_hash` remains the transaction hash

- `frontend/tests/contracts.test.ts`
  - added tests for return-value decoding and token ID validation

## Why this matters

- Public verification links now use the real on-chain token ID
- QR code verification works with actual token values
- Credential lookup by `token_id` works correctly
- Revocation now validates token IDs before signing

## Validation

- `npm test` ✅
- `npm run build` ✅

## Branch

`feature/return-soroban-token-id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token ID handling with improved validation during credential issuance and revocation.
  * Added helper functions for more reliable Soroban contract result parsing.

* **Bug Fixes**
  * Credential issuance now returns actual token IDs from the blockchain instead of placeholder values.

* **Tests**
  * Added test suite for contract helper functions and token ID validation.

* **Refactor**
  * Simplified contract result decoding logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soumen0818/ACREDIA-STELLAR/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->