### PR TITLE
fix: prevent re-initialization and fix test_initialize compile error

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -320,11 +320,11 @@ mod tests {
         let client = AcrediaCredentialClient::new(&env, &contract_id);
         let owner = Address::generate(&env);
 
+        env.mock_all_auths();
         client.initialize(&owner);
 
-        let stored_owner = client.get_owner();
-        assert_eq!(stored_owner, owner);
-        assert_eq!(pending_owner, None);
+        assert_eq!(client.get_owner(), owner);
+        assert_eq!(client.get_pending_owner(), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #5

---

## Problem
`initialize(env, owner)` had no guard against being called more than once. A second call would silently overwrite the contract owner and reset `NextTokenId`, corrupting credential token state.

## Root Cause
`DataKey::Initialized` flag and `ContractError::AlreadyInitialized` were already defined, but the `test_initialize` test referenced an undeclared `pending_owner` variable, causing a compile error that prevented the test suite — including `test_initialize_fails_if_called_twice` — from running.

## Changes
- **`contracts/src/lib.rs`**: Fixed `test_initialize` — replaced `assert_eq!(pending_owner, None)` with `assert_eq!(client.get_pending_owner(), None)` and added missing `env.mock_all_auths()`.

## Behavior After Fix
- First call to `initialize` succeeds as before.
- Any subsequent call returns `Err(ContractError::AlreadyInitialized)` (error code 1).
- `test_initialize_fails_if_called_twice` now compiles and validates the guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit tests to properly verify contract initialization behavior with corrected authentication mocking and assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soumen0818/ACREDIA-STELLAR/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->