### PR TITLE
Add metadata schema versioning and hashing algorithm to credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,8 @@ credentials
 ├── ipfs_hash (text) - IPFS metadata hash
 ├── blockchain_hash (text) - Transaction hash
 ├── metadata (jsonb) - Credential details
+├── metadata_schema_version (integer) - Canonical metadata schema version
+├── hash_algorithm (text) - Hash algorithm identifier
 ├── issued_at (timestamp)
 ├── revoked (boolean)
 ├── revoked_at (timestamp)
@@ -994,6 +996,19 @@ verification_logs
 ├── verified_at (timestamp)
 └── verification_result (jsonb)
 ```
+
+### Credential Metadata Hashing
+
+Credential hashes are derived from a versioned canonical payload, not directly from raw `JSON.stringify(metadata)`.
+
+- Current schema: `metadata_schema_version = 1`
+- Current algorithm: `hash_algorithm = sha256:canonical-json:v1`
+- Shared implementation: `frontend/src/lib/credentialHash.ts`
+- Test vectors: `frontend/tests/credentialHash.test.ts`
+
+Schema v1 hashes only the credential meaning needed for verification: name, description, image, student wallet/name, credential type, degree, major, GPA, issue date, institution name, and normalized subjects. Optional fields are represented as `null` or empty arrays, numeric-like values are converted to strings where the UI treats them as text, and object keys are serialized in sorted canonical order.
+
+Future metadata fields can be added to stored `metadata` or IPFS display metadata without changing old hashes. To make a new field part of the on-chain digest, add a new schema version and algorithm identifier, keep the v1 builder intact, add new fixed test vectors, store the new version on newly issued credentials, and keep verification dispatching by each row's stored `metadata_schema_version` and `hash_algorithm`.
 
 ---
 

--- a/frontend/sql/add_credential_hash_metadata.sql
+++ b/frontend/sql/add_credential_hash_metadata.sql
@@ -1,0 +1,14 @@
+ALTER TABLE credentials
+ADD COLUMN IF NOT EXISTS metadata_schema_version INTEGER,
+ADD COLUMN IF NOT EXISTS hash_algorithm TEXT;
+
+-- Existing credentials were issued before canonical schema stamping.
+-- Leave them nullable so verification can use the legacy JSON.stringify hash path.
+UPDATE credentials
+SET hash_algorithm = 'sha256:json-stringify'
+WHERE metadata_schema_version IS NULL
+  AND hash_algorithm IS NULL;
+
+ALTER TABLE credentials
+ALTER COLUMN metadata_schema_version SET DEFAULT 1,
+ALTER COLUMN hash_algorithm SET DEFAULT 'sha256:canonical-json:v1';

--- a/frontend/sql/database_schema.sql
+++ b/frontend/sql/database_schema.sql
@@ -136,6 +136,8 @@ CREATE TABLE credentials (
     ipfs_hash TEXT NOT NULL,
     blockchain_hash TEXT NOT NULL,
     metadata JSONB NOT NULL,
+    metadata_schema_version INTEGER NOT NULL DEFAULT 1,
+    hash_algorithm TEXT NOT NULL DEFAULT 'sha256:canonical-json:v1',
     issued_at TIMESTAMP
     WITH
         TIME ZONE DEFAULT NOW(),

--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -1,16 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createHash } from 'crypto';
 import { getServiceRoleClient } from '@/lib/serverAuth';
 import { getCredential, isRevoked } from '@/lib/contractReads';
+import { deriveCredentialHash } from '@/lib/credentialHash';
 
 export const dynamic = 'force-dynamic';
-
-/** Re-derive the credential hash from stored metadata (server-side, Node crypto). */
-function deriveCredentialHash(metadata: unknown): string {
-    return createHash('sha256')
-        .update(JSON.stringify(metadata))
-        .digest('hex');
-}
 
 export async function GET(
     _request: NextRequest,
@@ -38,6 +31,8 @@ export async function GET(
                 revoked,
                 revoked_at,
                 metadata,
+                metadata_schema_version,
+                hash_algorithm,
                 ipfs_hash,
                 student_wallet_address,
                 issuer_wallet_address,
@@ -69,7 +64,13 @@ export async function GET(
         ]);
 
         // ── 3. Cross-check ────────────────────────────────────────────────────
-        const dbHash = data.metadata ? deriveCredentialHash(data.metadata) : null;
+        const dbHash = data.metadata
+            ? await deriveCredentialHash(
+                  data.metadata,
+                  data.metadata_schema_version,
+                  data.hash_algorithm
+              )
+            : null;
         const expectedUri = data.ipfs_hash ? `ipfs://${data.ipfs_hash}` : null;
 
         const onChainMatch = onChain !== null && (() => {

--- a/frontend/src/lib/contracts.ts
+++ b/frontend/src/lib/contracts.ts
@@ -12,6 +12,7 @@ import {
 } from '@stellar/stellar-sdk';
 import { activeNetwork, getContractAddress, sorobanServer } from './stellar';
 import { debugLog, debugWarn } from './debug';
+import { generateCanonicalCredentialHash } from './credentialHash';
 
 export interface CredentialMetadata {
     studentAddress: string;
@@ -320,11 +321,7 @@ export async function revokeCredentialOnStellar(tokenId: string, issuerAddress: 
 }
 
 export async function generateCredentialHash(metadata: any): Promise<string> {
-    const dataString = JSON.stringify(metadata);
-    const msgUint8 = new TextEncoder().encode(dataString);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+    return generateCanonicalCredentialHash(metadata);
 }
 
 export function isValidStellarAddress(address: string): boolean {

--- a/frontend/src/lib/credentialHash.ts
+++ b/frontend/src/lib/credentialHash.ts
@@ -1,0 +1,145 @@
+export const CREDENTIAL_METADATA_SCHEMA_VERSION = 1;
+export const CREDENTIAL_HASH_ALGORITHM = 'sha256:canonical-json:v1';
+export const LEGACY_CREDENTIAL_HASH_ALGORITHM = 'sha256:json-stringify';
+
+export type CredentialMetadataSchemaVersion = typeof CREDENTIAL_METADATA_SCHEMA_VERSION;
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+export interface CanonicalCredentialPayloadV1 {
+    schemaVersion: CredentialMetadataSchemaVersion;
+    name: string;
+    description: string;
+    image: string;
+    credentialData: {
+        studentName: string;
+        studentWallet: string;
+        degree: string;
+        major: string | null;
+        gpa: string | null;
+        issueDate: string;
+        institutionName: string;
+        credentialType: string;
+        subjects: Array<{
+            id: string;
+            name: string;
+            marks: string;
+            maxMarks: string;
+            grade: string | null;
+        }>;
+    };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+}
+
+function requiredString(value: unknown): string {
+    return value == null ? '' : String(value);
+}
+
+function optionalString(value: unknown): string | null {
+    if (value == null || value === '') {
+        return null;
+    }
+
+    return String(value);
+}
+
+export function buildCanonicalCredentialPayloadV1(metadata: unknown): CanonicalCredentialPayloadV1 {
+    const root = asRecord(metadata);
+    const credentialData = asRecord(root.credentialData);
+    const subjects = Array.isArray(credentialData.subjects) ? credentialData.subjects : [];
+
+    return {
+        schemaVersion: CREDENTIAL_METADATA_SCHEMA_VERSION,
+        name: requiredString(root.name),
+        description: requiredString(root.description),
+        image: requiredString(root.image),
+        credentialData: {
+            studentName: requiredString(credentialData.studentName),
+            studentWallet: requiredString(credentialData.studentWallet),
+            degree: requiredString(credentialData.degree),
+            major: optionalString(credentialData.major),
+            gpa: optionalString(credentialData.gpa),
+            issueDate: requiredString(credentialData.issueDate),
+            institutionName: requiredString(credentialData.institutionName),
+            credentialType: requiredString(credentialData.credentialType),
+            subjects: subjects.map((subject) => {
+                const item = asRecord(subject);
+
+                return {
+                    id: requiredString(item.id),
+                    name: requiredString(item.name),
+                    marks: requiredString(item.marks),
+                    maxMarks: requiredString(item.maxMarks),
+                    grade: optionalString(item.grade),
+                };
+            }),
+        },
+    };
+}
+
+export function canonicalJson(value: JsonValue): string {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+
+    if (Array.isArray(value)) {
+        return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+    }
+
+    return `{${Object.keys(value)
+        .sort()
+        .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+        .join(',')}}`;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+    if (!globalThis.crypto?.subtle) {
+        throw new Error('Web Crypto SHA-256 is unavailable in this environment');
+    }
+
+    const encoded = new TextEncoder().encode(value);
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', encoded);
+
+    return Array.from(new Uint8Array(digest))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+export function serializeCredentialMetadataForHash(
+    metadata: unknown,
+    schemaVersion: number | null | undefined = CREDENTIAL_METADATA_SCHEMA_VERSION
+): string {
+    if (schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION) {
+        return canonicalJson(buildCanonicalCredentialPayloadV1(metadata) as unknown as JsonValue);
+    }
+
+    return JSON.stringify(metadata);
+}
+
+export async function generateCanonicalCredentialHash(metadata: unknown): Promise<string> {
+    return sha256Hex(serializeCredentialMetadataForHash(metadata, CREDENTIAL_METADATA_SCHEMA_VERSION));
+}
+
+export async function deriveCredentialHash(
+    metadata: unknown,
+    schemaVersion?: number | null,
+    hashAlgorithm?: string | null
+): Promise<string> {
+    if (
+        schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION &&
+        hashAlgorithm === CREDENTIAL_HASH_ALGORITHM
+    ) {
+        return generateCanonicalCredentialHash(metadata);
+    }
+
+    if (!schemaVersion && (!hashAlgorithm || hashAlgorithm === LEGACY_CREDENTIAL_HASH_ALGORITHM)) {
+        return sha256Hex(JSON.stringify(metadata));
+    }
+
+    throw new Error(`Unsupported credential metadata hash schema: ${schemaVersion ?? 'legacy'} / ${hashAlgorithm ?? 'unknown'}`);
+}

--- a/frontend/src/lib/credentialService.ts
+++ b/frontend/src/lib/credentialService.ts
@@ -5,6 +5,10 @@ import {
     generateCredentialHash,
     revokeCredentialOnStellar,
 } from './contracts';
+import {
+    CREDENTIAL_HASH_ALGORITHM,
+    CREDENTIAL_METADATA_SCHEMA_VERSION,
+} from './credentialHash';
 import { debugLog } from './debug';
 
 export interface Subject {
@@ -177,6 +181,8 @@ export async function issueCredential(
             ipfs_hash: metadataPath, // Store full path (CID/filename)
             blockchain_hash: transactionHash,
             metadata,
+            metadata_schema_version: CREDENTIAL_METADATA_SCHEMA_VERSION,
+            hash_algorithm: CREDENTIAL_HASH_ALGORITHM,
             issued_at: new Date().toISOString(),
             revoked: false,
         });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -25,6 +25,8 @@ export interface Credential {
     ipfs_hash: string;
     blockchain_hash: string;
     metadata: CredentialMetadata;
+    metadata_schema_version: number;
+    hash_algorithm: string;
     issued_at: string;
     revoked: boolean;
 }

--- a/frontend/tests/credentialHash.test.ts
+++ b/frontend/tests/credentialHash.test.ts
@@ -1,0 +1,99 @@
+import { createHash } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  CREDENTIAL_HASH_ALGORITHM,
+  CREDENTIAL_METADATA_SCHEMA_VERSION,
+  buildCanonicalCredentialPayloadV1,
+  canonicalJson,
+  deriveCredentialHash,
+  generateCanonicalCredentialHash,
+  serializeCredentialMetadataForHash,
+} from '../src/lib/credentialHash';
+
+const metadata = {
+  name: 'Degree - Alice Smith',
+  description: 'Academic credential issued by Acredia Academy to Alice Smith',
+  image: 'ipfs://file-cid',
+  attributes: [
+    { trait_type: 'Credential Type', value: 'Degree' },
+  ],
+  credentialData: {
+    studentName: 'Alice Smith',
+    studentWallet: 'GSTUDENTADDRESS',
+    degree: 'BSc Computer Science',
+    major: 'Software Engineering',
+    gpa: undefined,
+    issueDate: '2026-05-31',
+    institutionName: 'Acredia Academy',
+    credentialType: 'Degree',
+    subjects: [
+      {
+        id: 'math-101',
+        name: 'Mathematics',
+        marks: 95,
+        maxMarks: '100',
+      },
+    ],
+  },
+};
+
+const canonicalVector =
+  '{"credentialData":{"credentialType":"Degree","degree":"BSc Computer Science","gpa":null,"institutionName":"Acredia Academy","issueDate":"2026-05-31","major":"Software Engineering","studentName":"Alice Smith","studentWallet":"GSTUDENTADDRESS","subjects":[{"grade":null,"id":"math-101","marks":"95","maxMarks":"100","name":"Mathematics"}]},"description":"Academic credential issued by Acredia Academy to Alice Smith","image":"ipfs://file-cid","name":"Degree - Alice Smith","schemaVersion":1}';
+
+const canonicalHashVector = 'feca52dc50aee21c1942333a13873250b5bda373e09a4e2aff29b80a44a78545';
+
+describe('canonical credential metadata hashing', () => {
+  it('serializes schema v1 payloads to a stable canonical test vector', () => {
+    expect(serializeCredentialMetadataForHash(metadata)).toBe(canonicalVector);
+  });
+
+  it('hashes schema v1 payloads to the shared browser/server test vector', async () => {
+    await expect(generateCanonicalCredentialHash(metadata)).resolves.toBe(canonicalHashVector);
+    await expect(
+      deriveCredentialHash(metadata, CREDENTIAL_METADATA_SCHEMA_VERSION, CREDENTIAL_HASH_ALGORITHM)
+    ).resolves.toBe(canonicalHashVector);
+  });
+
+  it('keeps semantically equivalent metadata stable across key ordering and optional fields', async () => {
+    const reordered = {
+      credentialData: {
+        subjects: [
+          {
+            maxMarks: 100,
+            marks: '95',
+            name: 'Mathematics',
+            id: 'math-101',
+            grade: undefined,
+          },
+        ],
+        credentialType: 'Degree',
+        institutionName: 'Acredia Academy',
+        issueDate: '2026-05-31',
+        major: 'Software Engineering',
+        degree: 'BSc Computer Science',
+        studentWallet: 'GSTUDENTADDRESS',
+        studentName: 'Alice Smith',
+      },
+      image: 'ipfs://file-cid',
+      description: 'Academic credential issued by Acredia Academy to Alice Smith',
+      name: 'Degree - Alice Smith',
+    };
+
+    await expect(generateCanonicalCredentialHash(reordered)).resolves.toBe(canonicalHashVector);
+  });
+
+  it('matches Node SHA-256 over the same canonical payload string', async () => {
+    const payload = buildCanonicalCredentialPayloadV1(metadata);
+    const serialized = canonicalJson(payload as any);
+    const nodeHash = createHash('sha256').update(serialized).digest('hex');
+
+    expect(serialized).toBe(canonicalVector);
+    await expect(generateCanonicalCredentialHash(metadata)).resolves.toBe(nodeHash);
+  });
+
+  it('preserves legacy JSON.stringify hashing for unstamped credentials', async () => {
+    const legacyHash = createHash('sha256').update(JSON.stringify(metadata)).digest('hex');
+
+    await expect(deriveCredentialHash(metadata, null, null)).resolves.toBe(legacyHash);
+  });
+});

--- a/frontend/tests/e2e.lifecycle.test.ts
+++ b/frontend/tests/e2e.lifecycle.test.ts
@@ -67,6 +67,11 @@ vi.mock('../src/lib/supabase', () => ({
 import { issueCredential, type CredentialData } from '../src/lib/credentialService';
 import { GET } from '../src/app/api/verify/[token]/route';
 import { GET as adminStatsGET } from '../src/app/api/admin/stats/route';
+import {
+  CREDENTIAL_HASH_ALGORITHM,
+  CREDENTIAL_METADATA_SCHEMA_VERSION,
+  generateCanonicalCredentialHash,
+} from '../src/lib/credentialHash';
 
 // Helper to derive SHA-256 hash exactly like route.ts does
 function deriveCredentialHash(metadata: unknown): string {
@@ -159,15 +164,20 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
   // ── 3. VERIFICATION SUCCESS ───────────────────────────────────────────────
   it('covers verification success states', async () => {
     const dbMetadata = {
+      name: 'diploma - Alice Smith',
+      description: 'Academic credential issued by Acredia Academy to Alice Smith',
+      image: 'ipfs://mocked-file-cid',
       credentialData: {
         studentName: 'Alice Smith',
+        studentWallet: 'gstudentaddress123456789012345678901234567890123456789',
         credentialType: 'diploma',
         degree: 'Bachelor of Computer Science',
         institutionName: 'Acredia Academy',
+        issueDate: '2026-05-31',
       },
     };
 
-    const expectedHash = deriveCredentialHash(dbMetadata);
+    const expectedHash = await generateCanonicalCredentialHash(dbMetadata);
 
     // Mock Supabase service role client to return database credential record
     const mockMaybeSingle = vi.fn().mockResolvedValue({
@@ -178,6 +188,8 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         revoked: false,
         revoked_at: null,
         metadata: dbMetadata,
+        metadata_schema_version: CREDENTIAL_METADATA_SCHEMA_VERSION,
+        hash_algorithm: CREDENTIAL_HASH_ALGORITHM,
         ipfs_hash: 'mocked-metadata-path',
         student_wallet_address: 'gstudentaddress123456789012345678901234567890123456789',
         issuer_wallet_address: 'ginstitutionaddress12345678901234567890123456789',


### PR DESCRIPTION
Close #66 


This pull request introduces a versioned, canonical credential metadata hashing system to ensure stable, cross-platform credential verification and future extensibility. The changes add explicit schema versioning and hash algorithm tracking to credentials, implement a canonical JSON serialization and hashing strategy, and provide robust test vectors for both browser and server environments. Legacy credentials continue to be supported for backward compatibility.

The most important changes are:

**Database & Schema Updates:**
- Added `metadata_schema_version` (integer) and `hash_algorithm` (text) columns to the `credentials` table, with defaults for new credentials and migration logic for existing ones. These fields are now required and tracked in all credential records. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R970-R971) [[2]](diffhunk://#diff-b6aa9b155aa1c520a769b2385b2e5d4564a758b35d3fc7fc6ce61604eb0720dfR1-R14) [[3]](diffhunk://#diff-673b8f93b73b482ce16bdc70541e6c9ec6a0e339683910b99fefc06000b485a9R139-R140)
- Updated the `Credential` TypeScript type and all relevant data flows to include these new fields. [[1]](diffhunk://#diff-1b4a95b65fea8956418f11410de7b03f8f1474045a4e88eadf7cc7c1ecb6123cR28-R29) [frontend/src/app/api/verify/[token]/route.tsR34-R35](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R34-R35), [[2]](diffhunk://#diff-0fe6bdd773a375ecd5e530d5a1f720e4686067aa3202205a2d2e47385a5e002cR184-R185) [[3]](diffhunk://#diff-865ad4b2a86e24da230dce1943136b5b4f59d943e2899051442119e6d7a63640R191-R192)

**Credential Hashing Implementation:**
- Introduced `frontend/src/lib/credentialHash.ts`, which defines the canonical schema v1 payload, canonical JSON serialization, and versioned hash derivation logic. This ensures hashes are stable across environments and future-proofed for schema evolution.
- Updated all credential issuance and verification logic to use the new canonical hash functions, dispatching based on each credential's stored schema version and algorithm. ([frontend/src/app/api/verify/[token]/route.tsL2-L14](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393L2-L14), [[1]](diffhunk://#diff-acfb6c451293cd09d69c3f6b6157088c3054401f72bc0fae1a0c99a7b8bb91fbR15) [[2]](diffhunk://#diff-acfb6c451293cd09d69c3f6b6157088c3054401f72bc0fae1a0c99a7b8bb91fbL323-R324) [[3]](diffhunk://#diff-0fe6bdd773a375ecd5e530d5a1f720e4686067aa3202205a2d2e47385a5e002cR184-R185)

**Documentation & Testing:**
- Expanded the `README.md` to document the new credential metadata hashing approach, versioning, and migration strategy.
- Added comprehensive test vectors and test coverage to ensure canonical serialization and hashing are stable and cross-compatible, including legacy fallback. [[1]](diffhunk://#diff-8326dda9cc850248de907b0a393428f1a748dedca916ca194d5c43eb91e77b15R1-R99) [[2]](diffhunk://#diff-865ad4b2a86e24da230dce1943136b5b4f59d943e2899051442119e6d7a63640R70-R74) [[3]](diffhunk://#diff-865ad4b2a86e24da230dce1943136b5b4f59d943e2899051442119e6d7a63640R167-R180)

These changes lay the groundwork for robust, versioned credential verification, allowing for future schema evolution without breaking existing on-chain or off-chain verification.- Introduced `metadata_schema_version` and `hash_algorithm` fields in the credentials table.
- Updated credential hashing logic to support canonical JSON serialization.
- Implemented new functions for generating and deriving credential hashes.
- Added tests for canonical credential metadata hashing and verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned credential metadata hashing and canonical JSON serialization for deterministic hashes
  * Credentials now store metadata schema version and hash algorithm for forward-compatible verification

* **Documentation**
  * Updated README with credential metadata hashing spec, canonicalization rules, and version/algorithm handling

* **Tests**
  * Added unit tests for canonical serialization and hashing; updated e2e tests to validate new metadata fields and hashing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->