### PR TITLE
Add API rate limiting to protect public verification endpoints.

### DIFF
--- a/frontend/src/app/api/admin/stats/route.ts
+++ b/frontend/src/app/api/admin/stats/route.ts
@@ -1,10 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceRoleClient, requireAdminRequest } from '@/lib/serverAuth';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 export const dynamic = 'force-dynamic';
 
+const ADMIN_STATS_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 60,
+    prefix: 'admin-stats',
+} as const;
+
 export async function GET(request: NextRequest) {
     try {
+        const rateLimitResponse = enforceRateLimit(request, ADMIN_STATS_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
         const adminCheck = await requireAdminRequest(request);
         if (!adminCheck.ok) {
             return NextResponse.json(

--- a/frontend/src/app/api/admin/update-authorization/route.ts
+++ b/frontend/src/app/api/admin/update-authorization/route.ts
@@ -1,11 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceRoleClient, requireAdminRequest } from '@/lib/serverAuth';
 import { verifyAdminAuthorizationTransaction } from '@/lib/adminAuthorizationVerification';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 export const dynamic = 'force-dynamic';
 
+const ADMIN_UPDATE_AUTHORIZATION_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 60,
+    prefix: 'admin-update-authorization',
+} as const;
+
 export async function POST(request: NextRequest) {
     try {
+        const rateLimitResponse = enforceRateLimit(request, ADMIN_UPDATE_AUTHORIZATION_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
         const adminCheck = await requireAdminRequest(request);
         if (!adminCheck.ok) {
             return NextResponse.json(

--- a/frontend/src/app/api/ipfs/file/route.ts
+++ b/frontend/src/app/api/ipfs/file/route.ts
@@ -1,10 +1,22 @@
 import { NextResponse } from 'next/server';
 import { pinFileToPinata, validatePinataFile } from '@/lib/ipfsServer';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 export const dynamic = 'force-dynamic';
 
+const IPFS_FILE_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 20,
+    prefix: 'ipfs-file',
+} as const;
+
 export async function POST(request: Request) {
     try {
+        const rateLimitResponse = enforceRateLimit(request, IPFS_FILE_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
         const formData = await request.formData();
         const file = formData.get('file');
 

--- a/frontend/src/app/api/ipfs/json/route.ts
+++ b/frontend/src/app/api/ipfs/json/route.ts
@@ -1,10 +1,22 @@
 import { NextResponse } from 'next/server';
 import { pinJsonToPinata, validatePinataJson } from '@/lib/ipfsServer';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 export const dynamic = 'force-dynamic';
 
+const IPFS_JSON_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 20,
+    prefix: 'ipfs-json',
+} as const;
+
 export async function POST(request: Request) {
     try {
+        const rateLimitResponse = enforceRateLimit(request, IPFS_JSON_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
         const payload = await request.json();
         const content = payload?.content;
         const validationError = validatePinataJson(content);

--- a/frontend/src/app/api/student/credentials/route.ts
+++ b/frontend/src/app/api/student/credentials/route.ts
@@ -5,8 +5,15 @@ import {
     hasServiceRoleEnv,
     requireAuthenticatedRequest,
 } from '@/lib/serverAuth';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 export const dynamic = 'force-dynamic';
+
+const STUDENT_CREDENTIALS_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 60,
+    prefix: 'student-credentials',
+} as const;
 
 type CredentialRow = {
     id: string;
@@ -21,6 +28,11 @@ type CredentialRow = {
 
 export async function GET(request: NextRequest) {
     try {
+        const rateLimitResponse = enforceRateLimit(request, STUDENT_CREDENTIALS_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
         const authCheck = await requireAuthenticatedRequest(request);
         if (!authCheck.ok) {
             return NextResponse.json(

--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -2,14 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceRoleClient } from '@/lib/serverAuth';
 import { getCredential, isRevoked } from '@/lib/contractReads';
 import { deriveCredentialHash } from '@/lib/credentialHash';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 export const dynamic = 'force-dynamic';
 
+const VERIFY_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 10,
+    prefix: 'verify',
+} as const;
+
 export async function GET(
-    _request: NextRequest,
+    request: NextRequest,
     { params }: { params: Promise<{ token: string }> }
 ) {
     try {
+        const rateLimitResponse = enforceRateLimit(request, VERIFY_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
         const { token: rawToken } = await params;
         const token = rawToken?.trim();
 

--- a/frontend/src/lib/rateLimit.ts
+++ b/frontend/src/lib/rateLimit.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from 'next/server';
+
+type RateLimitOptions = {
+    windowSeconds: number;
+    maxRequests: number;
+    prefix?: string;
+};
+
+type RateLimitResult = {
+    success: boolean;
+    remaining: number;
+    retryAfter: number;
+};
+
+const buckets = new Map<string, number[]>();
+
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // every 5 minutes
+let lastCleanup = Date.now();
+
+const getClientIp = (request: Request): string => {
+    const forwardedFor = request.headers.get('x-forwarded-for');
+    if (forwardedFor) {
+        const [firstIp] = forwardedFor.split(',');
+        if (firstIp?.trim()) {
+            return firstIp.trim();
+        }
+    }
+
+    const realIp = request.headers.get('x-real-ip');
+    if (realIp?.trim()) {
+        return realIp.trim();
+    }
+
+    const requestWithIp = request as Request & { ip?: string | null };
+    if (requestWithIp.ip?.trim()) {
+        return requestWithIp.ip.trim();
+    }
+
+    return 'unknown';
+};
+
+function cleanupStaleBuckets(now: number) {
+    for (const [key, timestamps] of buckets.entries()) {
+        // Remove entries with no activity in the last 10 minutes
+        const active = timestamps.filter(ts => now - ts < 10 * 60 * 1000);
+        if (active.length === 0) {
+            buckets.delete(key);
+        } else {
+            buckets.set(key, active);
+        }
+    }
+    lastCleanup = now;
+}
+
+export const checkRateLimit = (
+    request: Request,
+    { windowSeconds, maxRequests, prefix = 'api' }: RateLimitOptions
+): RateLimitResult => {
+    const now = Date.now();
+    const windowMs = windowSeconds * 1000;
+    const ip = getClientIp(request);
+    const key = `${prefix}:${ip}`;
+
+    // Run cleanup periodically to prevent memory leak
+    if (now - lastCleanup > CLEANUP_INTERVAL_MS) {
+        cleanupStaleBuckets(now);
+    }
+
+    const timestamps = buckets.get(key) ?? [];
+    const activeTimestamps = timestamps.filter((timestamp) => now - timestamp < windowMs);
+
+    if (activeTimestamps.length >= maxRequests) {
+        const oldestTimestamp = activeTimestamps[0] ?? now;
+        const retryAfter = Math.max(
+            1,
+            Math.ceil((oldestTimestamp + windowMs - now) / 1000)
+        );
+
+        buckets.set(key, activeTimestamps);
+
+        return {
+            success: false,
+            remaining: 0,
+            retryAfter,
+        };
+    }
+
+    activeTimestamps.push(now);
+    buckets.set(key, activeTimestamps);
+
+    return {
+        success: true,
+        remaining: Math.max(0, maxRequests - activeTimestamps.length),
+        retryAfter: 0,
+    };
+};
+
+export const enforceRateLimit = (
+    request: Request,
+    options: RateLimitOptions
+): NextResponse | null => {
+    const result = checkRateLimit(request, options);
+
+    if (result.success) {
+        return null;
+    }
+
+    return NextResponse.json(
+        { success: false, error: 'Too many requests' },
+        {
+            status: 429,
+            headers: {
+                'Retry-After': String(result.retryAfter),
+            },
+        }
+    );
+};
+
+export const resetRateLimitStore = () => {
+    buckets.clear();
+    lastCleanup = Date.now();
+};

--- a/frontend/tests/verify-route-rate-limit.test.ts
+++ b/frontend/tests/verify-route-rate-limit.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '@/app/api/verify/[token]/route';
+import { resetRateLimitStore } from '@/lib/rateLimit';
+
+vi.mock('@/lib/serverAuth', () => ({
+    getServiceRoleClient: () => ({
+        from: () => ({
+            select: () => ({
+                eq: () => ({
+                    maybeSingle: async () => ({
+                        data: {
+                            token_id: 'token-123',
+                            issued_at: '2026-01-01T00:00:00.000Z',
+                            revoked: false,
+                            revoked_at: null,
+                            metadata: {
+                                credentialData: {
+                                    institutionName: 'ACREDIA',
+                                    credentialType: 'Degree',
+                                },
+                            },
+                            metadata_schema_version: 1,
+                            hash_algorithm: 'sha256',
+                            ipfs_hash: 'cid-123',
+                            student_wallet_address: 'GStudent',
+                            issuer_wallet_address: 'GIssuer',
+                            institution: { name: 'ACREDIA' },
+                        },
+                        error: null,
+                    }),
+                }),
+            }),
+        }),
+    }),
+}));
+
+vi.mock('@/lib/contractReads', () => ({
+    getCredential: async () => ({
+        issuer: 'gissuer',
+        student: 'gstudent',
+        hash: 'derived-hash',
+        uri: 'ipfs://cid-123',
+    }),
+    isRevoked: async () => false,
+}));
+
+vi.mock('@/lib/credentialHash', () => ({
+    deriveCredentialHash: async () => 'derived-hash',
+}));
+
+describe('verify route rate limiting', () => {
+    beforeEach(() => {
+        resetRateLimitStore();
+    });
+
+    it('returns 429 with Retry-After after the verify limit is exceeded', async () => {
+        const makeRequest = () =>
+            new Request('http://localhost/api/verify/token-123', {
+                headers: {
+                    'x-forwarded-for': '203.0.113.10',
+                },
+            });
+
+        for (let index = 0; index < 10; index += 1) {
+            const response = await GET(makeRequest() as any, {
+                params: Promise.resolve({ token: 'token-123' }),
+            });
+
+            expect(response.status).toBe(200);
+        }
+
+        const blockedResponse = await GET(makeRequest() as any, {
+            params: Promise.resolve({ token: 'token-123' }),
+        });
+
+        expect(blockedResponse.status).toBe(429);
+        expect(blockedResponse.headers.get('Retry-After')).toBeTruthy();
+        await expect(blockedResponse.json()).resolves.toEqual({
+            success: false,
+            error: 'Too many requests',
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add a reusable in-memory IP-based rate limiter for App Router API handlers
- protect all API routes, with stricter limits on public `verify` and `ipfs` endpoints
- return `429 Too Many Requests` with a `Retry-After` header and add a focused verify-route test

## Test plan
- [x] Run `npm test -- --run tests/verify-route-rate-limit.test.ts`
- [x] Confirm rate-limited responses return `{ "success": false, "error": "Too many requests" }`
- [x] Confirm public routes are stricter than authenticated/admin routes

## Notes
- this limiter is intentionally in-memory for now, so counters are per-process and reset on restart
- no external rate-limiting service or middleware was introduced in this PR

Closes #93 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request rate limiting to several API endpoints, including verification, student credentials, admin stats, admin authorization updates, and IPFS uploads.
  * Users now receive a clear “Too many requests” response with retry timing when limits are exceeded.

* **Bug Fixes**
  * Improved protection against excessive requests to help keep these services more reliable and responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->