### PR TITLE
Implement canonical credential metadata hashing and schema versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ This single contract replaces two separate EVM contracts (CredentialNFT + Creden
 **Storage Architecture**:
 - `DataKey::Authorized(Address)` → `instance` storage (low-cost, ephemeral)
 - `DataKey::Credential(u64)` → `persistent` storage (permanent, survives ledger closings)
-- `DataKey::HashIndex(String)` → `persistent` storage (hash → token_id index)
+- `DataKey::HashIndex(BytesN<32>)` → `persistent` storage (SHA-256 hash bytes → token_id index)
 
 ### Stellar Testnet Deployment (Active)
 
@@ -625,18 +625,17 @@ STELLAR_CONTRACT_ID=
 
 5. **Set Up Supabase Database**
 
-Run the canonical SQL setup listed in `frontend/sql/README.md`. For a fresh
-Supabase project, run only these scripts in your Supabase SQL Editor:
+Run the canonical SQL setup in your Supabase SQL Editor. For a fresh Supabase
+project, run the single idempotent setup file:
 
 ```sql
--- Run these in order:
-1. frontend/sql/database_schema.sql
-2. frontend/sql/secure_rls_migration.sql
+frontend/sql/FULL_SETUP.sql
 ```
 
-`database_schema.sql` creates tables, indexes, triggers, and enables RLS without
-opening broad public policies. `secure_rls_migration.sql` is the canonical
-production policy set and can be safely re-run after older deployments.
+`FULL_SETUP.sql` creates tables, indexes, triggers, canonical credential hash
+metadata columns, and production RLS policies. It can be safely re-run after
+older deployments. `frontend/sql/database_schema.sql` is kept as a focused base
+schema reference, but clean deployments should use `FULL_SETUP.sql`.
 
 The older one-off SQL repair scripts are retained only as compatibility notices:
 they point back to the canonical setup flow and should not be run for new
@@ -722,7 +721,7 @@ Before deploying to production:
 - Use Stellar Public Network values only after contract review and a verified mainnet deployment.
 - Rotate any secret that was pasted into chat, screenshots, logs, browser code, or an issue.
 - Set server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `PINATA_JWT`, Stellar secret keys) only in the hosting provider's protected environment variables.
-- Confirm Supabase RLS is enabled and production policies come from `frontend/sql/secure_rls_migration.sql`.
+- Confirm Supabase RLS is enabled and production policies come from `frontend/sql/FULL_SETUP.sql`.
 - Verify contract IDs on Stellar Expert before pointing users at a production environment.
 
 ---
@@ -746,11 +745,9 @@ Before deploying to production:
 1. Create account at [Supabase](https://supabase.com)
 2. Create a new project
 3. Get your project URL and anon key from Settings > API
-4. Run the canonical SQL scripts in SQL Editor (see `frontend/sql/README.md`):
-   - `frontend/sql/database_schema.sql`
-   - `frontend/sql/secure_rls_migration.sql`
+4. Run `frontend/sql/FULL_SETUP.sql` in the Supabase SQL Editor.
 
-The older repair scripts are kept for legacy deployments only. For a clean clone, use the two scripts above.
+The base `frontend/sql/database_schema.sql` file is retained as a schema reference. For a clean clone, use `FULL_SETUP.sql`.
 
 #### Stellar Account Setup
 
@@ -1010,10 +1007,12 @@ Credential hashes are derived from a versioned canonical payload, not directly f
 
 - Current schema: `metadata_schema_version = 1`
 - Current algorithm: `hash_algorithm = sha256:canonical-json:v1`
+- Legacy schema: `metadata_schema_version = 0`, `hash_algorithm = sha256:json-stringify`
 - Shared implementation: `frontend/src/lib/credentialHash.ts`
+- Stellar byte encoding: `frontend/src/lib/credentialHashEncoding.ts`
 - Test vectors: `frontend/tests/credentialHash.test.ts`
 
-Schema v1 hashes only the credential meaning needed for verification: name, description, image, student wallet/name, credential type, degree, major, GPA, issue date, institution name, and normalized subjects. Optional fields are represented as `null` or empty arrays, numeric-like values are converted to strings where the UI treats them as text, and object keys are serialized in sorted canonical order.
+Schema v1 hashes only the credential meaning needed for verification: name, description, image, student wallet/name, credential type, degree, major, GPA, issue date, institution name, and normalized subjects. Optional fields are represented as `null` or empty arrays, numeric-like values are converted to strings where the UI treats them as text, ISO date-times are normalized to `YYYY-MM-DD`, and object keys are serialized in sorted canonical order.
 
 Future metadata fields can be added to stored `metadata` or IPFS display metadata without changing old hashes. To make a new field part of the on-chain digest, add a new schema version and algorithm identifier, keep the v1 builder intact, add new fixed test vectors, store the new version on newly issued credentials, and keep verification dispatching by each row's stored `metadata_schema_version` and `hash_algorithm`.
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -223,7 +223,7 @@ soroban contract invoke \
   issue_credential \
   --student <STUDENT_ADDRESS> \
   --issuer <INSTITUTION_ADDRESS> \
-  --credential_hash "credential_hash_value" \
+  --credential_hash "<64_CHAR_SHA256_HEX_DIGEST>" \
   --ipfs_uri "ipfs_hash_value"
 ```
 
@@ -236,7 +236,7 @@ soroban contract invoke \
   --network testnet \
   -- \
   verify_credential \
-  --credential_hash "credential_hash_value"
+  --credential_hash "<64_CHAR_SHA256_HEX_DIGEST>"
 ```
 
 ### Check Revocation Status

--- a/frontend/sql/FULL_SETUP.sql
+++ b/frontend/sql/FULL_SETUP.sql
@@ -93,14 +93,26 @@ ALTER TABLE public.credentials
     ADD COLUMN IF NOT EXISTS hash_algorithm TEXT;
 
 -- Stamp legacy rows that predate canonical hashing, then set defaults.
+-- v0 means "legacy JSON.stringify(metadata)"; v1 means canonical JSON.
 UPDATE public.credentials
-SET hash_algorithm = 'sha256:json-stringify'
-WHERE metadata_schema_version IS NULL
-  AND hash_algorithm IS NULL;
+SET metadata_schema_version = CASE
+    WHEN hash_algorithm = 'sha256:canonical-json:v1' THEN 1
+    ELSE 0
+END
+WHERE metadata_schema_version IS NULL;
+
+UPDATE public.credentials
+SET hash_algorithm = CASE
+    WHEN metadata_schema_version = 0 THEN 'sha256:json-stringify'
+    ELSE 'sha256:canonical-json:v1'
+END
+WHERE hash_algorithm IS NULL;
 
 ALTER TABLE public.credentials
     ALTER COLUMN metadata_schema_version SET DEFAULT 1,
-    ALTER COLUMN hash_algorithm SET DEFAULT 'sha256:canonical-json:v1';
+    ALTER COLUMN hash_algorithm SET DEFAULT 'sha256:canonical-json:v1',
+    ALTER COLUMN metadata_schema_version SET NOT NULL,
+    ALTER COLUMN hash_algorithm SET NOT NULL;
 
 -- ---------------------------------------------------------------------
 -- Functions

--- a/frontend/sql/database_schema.sql
+++ b/frontend/sql/database_schema.sql
@@ -1,0 +1,78 @@
+-- =====================================================================
+-- ACREDIA-STELLAR base database schema
+-- =====================================================================
+-- Prefer FULL_SETUP.sql for a new Supabase project; it includes this base
+-- schema plus production RLS policies and compatibility migrations.
+-- This file is kept as the focused table/index schema reference.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS public.profiles (
+    id         UUID PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+    email      TEXT UNIQUE NOT NULL,
+    role       TEXT NOT NULL,
+    full_name  TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.institutions (
+    id                    UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
+    auth_user_id          UUID REFERENCES auth.users (id) ON DELETE CASCADE,
+    name                  TEXT NOT NULL,
+    email                 TEXT UNIQUE NOT NULL,
+    wallet_address        TEXT UNIQUE,
+    verified              BOOLEAN DEFAULT false,
+    authorization_tx_hash TEXT,
+    created_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.students (
+    id             UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
+    auth_user_id   UUID REFERENCES auth.users (id) ON DELETE CASCADE,
+    name           TEXT NOT NULL,
+    email          TEXT UNIQUE NOT NULL,
+    wallet_address TEXT UNIQUE,
+    created_at     TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.credentials (
+    id                      UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
+    student_id              UUID REFERENCES public.students (id) ON DELETE CASCADE,
+    student_wallet_address  TEXT,
+    institution_id          UUID REFERENCES public.institutions (id) ON DELETE CASCADE,
+    issuer_wallet_address   TEXT,
+    token_id                TEXT UNIQUE NOT NULL,
+    ipfs_hash               TEXT NOT NULL,
+    blockchain_hash         TEXT NOT NULL,
+    metadata                JSONB NOT NULL,
+    metadata_schema_version INTEGER NOT NULL DEFAULT 1,
+    hash_algorithm          TEXT NOT NULL DEFAULT 'sha256:canonical-json:v1',
+    issued_at               TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    revoked                 BOOLEAN DEFAULT false,
+    revoked_at              TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE IF NOT EXISTS public.verification_logs (
+    id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
+    credential_id       UUID REFERENCES public.credentials (id) ON DELETE SET NULL,
+    verifier_email      TEXT,
+    verifier_org        TEXT,
+    verification_result JSONB NOT NULL,
+    created_at          TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_institutions_auth_user       ON public.institutions (auth_user_id);
+CREATE INDEX IF NOT EXISTS idx_institutions_wallet          ON public.institutions (wallet_address);
+CREATE INDEX IF NOT EXISTS idx_students_auth_user           ON public.students (auth_user_id);
+CREATE INDEX IF NOT EXISTS idx_students_wallet              ON public.students (wallet_address);
+CREATE INDEX IF NOT EXISTS idx_credentials_student          ON public.credentials (student_id);
+CREATE INDEX IF NOT EXISTS idx_credentials_institution      ON public.credentials (institution_id);
+CREATE INDEX IF NOT EXISTS idx_credentials_token            ON public.credentials (token_id);
+CREATE INDEX IF NOT EXISTS idx_verification_logs_credential ON public.verification_logs (credential_id);
+
+ALTER TABLE IF EXISTS public.profiles          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.institutions      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.students          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.credentials       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.verification_logs ENABLE ROW LEVEL SECURITY;

--- a/frontend/src/lib/contractReads.ts
+++ b/frontend/src/lib/contractReads.ts
@@ -14,6 +14,10 @@ import {
     scValToNative,
     xdr,
 } from "@stellar/stellar-sdk";
+import {
+    credentialHashBytesToHex,
+    credentialHashHexToScVal,
+} from "./credentialHashEncoding";
 
 const RPC_URL =
     process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
@@ -29,11 +33,13 @@ const DUMMY_SOURCE = CONTRACT_ID;
 const server = new rpc.Server(RPC_URL);
 
 export interface OnChainCredential {
+    token_id?: bigint | number;
     student: string;
     issuer: string;
     hash: string;
     uri: string;
     issued_at: bigint | number;
+    revoked?: boolean;
 }
 
 async function simulate(method: string, args: xdr.ScVal[]): Promise<unknown> {
@@ -67,6 +73,54 @@ async function simulate(method: string, args: xdr.ScVal[]): Promise<unknown> {
     return scValToNative(retval);
 }
 
+function nativeStructToRecord(value: unknown): Record<string, unknown> | null {
+    if (!value || typeof value !== "object") {
+        return null;
+    }
+
+    if (value instanceof Map) {
+        return Object.fromEntries(
+            Array.from(value.entries()).map(([key, item]) => [String(key), item])
+        );
+    }
+
+    return value as Record<string, unknown>;
+}
+
+function firstPresent(record: Record<string, unknown>, keys: string[]): unknown {
+    for (const key of keys) {
+        if (record[key] !== undefined && record[key] !== null) {
+            return record[key];
+        }
+    }
+
+    return undefined;
+}
+
+export function normalizeOnChainCredential(result: unknown): OnChainCredential | null {
+    const record = nativeStructToRecord(result);
+    if (!record) {
+        return null;
+    }
+
+    const credentialHash = firstPresent(record, ["credential_hash", "credentialHash", "hash"]);
+    const ipfsHash = firstPresent(record, ["ipfs_hash", "ipfsHash", "uri"]);
+
+    if (!credentialHash || !ipfsHash) {
+        return null;
+    }
+
+    return {
+        token_id: firstPresent(record, ["token_id", "tokenId"]) as bigint | number | undefined,
+        student: String(firstPresent(record, ["student"]) ?? ""),
+        issuer: String(firstPresent(record, ["issuer"]) ?? ""),
+        hash: credentialHashBytesToHex(credentialHash),
+        uri: String(ipfsHash),
+        issued_at: (firstPresent(record, ["issued_at", "issuedAt"]) as bigint | number) ?? 0,
+        revoked: firstPresent(record, ["revoked"]) as boolean | undefined,
+    };
+}
+
 /**
  * Fetch full credential struct by token_id (u64).
  * Returns null if the token does not exist on-chain.
@@ -76,15 +130,7 @@ export async function getCredential(tokenId: string | number): Promise<OnChainCr
         const result = await simulate("get_credential", [
             nativeToScVal(Number(tokenId), { type: "u64" }),
         ]);
-        if (!result || typeof result !== "object") return null;
-        const r = result as Record<string, unknown>;
-        return {
-            student: String(r.student ?? ""),
-            issuer: String(r.issuer ?? ""),
-            hash: String(r.hash ?? ""),
-            uri: String(r.uri ?? ""),
-            issued_at: (r.issued_at as bigint | number) ?? 0,
-        };
+        return normalizeOnChainCredential(result);
     } catch {
         return null;
     }
@@ -92,15 +138,12 @@ export async function getCredential(tokenId: string | number): Promise<OnChainCr
 
 /**
  * Look up a credential by its SHA-256 hash.
- * Returns the token_id (number) or null if not found.
+ * Returns the full credential struct or null if not found.
  */
-export async function verifyCredentialByHash(hash: string): Promise<number | null> {
+export async function verifyCredentialByHash(hash: string): Promise<OnChainCredential | null> {
     try {
-        const result = await simulate("verify_credential", [
-            nativeToScVal(hash, { type: "string" }),
-        ]);
-        if (result === null || result === undefined) return null;
-        return Number(result);
+        const result = await simulate("verify_credential", [credentialHashHexToScVal(hash)]);
+        return normalizeOnChainCredential(result);
     } catch {
         return null;
     }

--- a/frontend/src/lib/contracts.ts
+++ b/frontend/src/lib/contracts.ts
@@ -13,6 +13,7 @@ import {
 import { activeNetwork, getContractAddress, sorobanServer } from './stellar';
 import { debugLog, debugWarn } from './debug';
 import { generateCanonicalCredentialHash } from './credentialHash';
+import { credentialHashHexToScVal } from './credentialHashEncoding';
 
 export interface CredentialMetadata {
     studentAddress: string;
@@ -306,7 +307,7 @@ export async function issueCredentialOnStellar(
     const args = [
         new Address(studentAddress).toScVal(),
         new Address(issuerAddress).toScVal(),
-        nativeToScVal(credentialHash, { type: 'string' }),
+        credentialHashHexToScVal(credentialHash),
         nativeToScVal(ipfsUri, { type: 'string' }),
     ];
 

--- a/frontend/src/lib/credentialHash.ts
+++ b/frontend/src/lib/credentialHash.ts
@@ -1,13 +1,16 @@
+export const LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION = 0;
 export const CREDENTIAL_METADATA_SCHEMA_VERSION = 1;
 export const CREDENTIAL_HASH_ALGORITHM = 'sha256:canonical-json:v1';
 export const LEGACY_CREDENTIAL_HASH_ALGORITHM = 'sha256:json-stringify';
 
-export type CredentialMetadataSchemaVersion = typeof CREDENTIAL_METADATA_SCHEMA_VERSION;
+export type CredentialMetadataSchemaVersion =
+    | typeof LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION
+    | typeof CREDENTIAL_METADATA_SCHEMA_VERSION;
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 
 export interface CanonicalCredentialPayloadV1 {
-    schemaVersion: CredentialMetadataSchemaVersion;
+    schemaVersion: typeof CREDENTIAL_METADATA_SCHEMA_VERSION;
     name: string;
     description: string;
     image: string;
@@ -48,6 +51,17 @@ function optionalString(value: unknown): string | null {
     return String(value);
 }
 
+function requiredDateString(value: unknown): string {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+        return value.toISOString().slice(0, 10);
+    }
+
+    const text = requiredString(value);
+    const isoDate = /^(\d{4}-\d{2}-\d{2})(?:T.*)?$/.exec(text);
+
+    return isoDate ? isoDate[1] : text;
+}
+
 export function buildCanonicalCredentialPayloadV1(metadata: unknown): CanonicalCredentialPayloadV1 {
     const root = asRecord(metadata);
     const credentialData = asRecord(root.credentialData);
@@ -64,7 +78,7 @@ export function buildCanonicalCredentialPayloadV1(metadata: unknown): CanonicalC
             degree: requiredString(credentialData.degree),
             major: optionalString(credentialData.major),
             gpa: optionalString(credentialData.gpa),
-            issueDate: requiredString(credentialData.issueDate),
+            issueDate: requiredDateString(credentialData.issueDate),
             institutionName: requiredString(credentialData.institutionName),
             credentialType: requiredString(credentialData.credentialType),
             subjects: subjects.map((subject) => {
@@ -118,7 +132,15 @@ export function serializeCredentialMetadataForHash(
         return canonicalJson(buildCanonicalCredentialPayloadV1(metadata) as unknown as JsonValue);
     }
 
-    return JSON.stringify(metadata);
+    if (
+        schemaVersion === LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION ||
+        schemaVersion === null ||
+        schemaVersion === undefined
+    ) {
+        return JSON.stringify(metadata);
+    }
+
+    throw new Error(`Unsupported credential metadata schema version: ${schemaVersion}`);
 }
 
 export async function generateCanonicalCredentialHash(metadata: unknown): Promise<string> {
@@ -137,7 +159,12 @@ export async function deriveCredentialHash(
         return generateCanonicalCredentialHash(metadata);
     }
 
-    if (!schemaVersion && (!hashAlgorithm || hashAlgorithm === LEGACY_CREDENTIAL_HASH_ALGORITHM)) {
+    if (
+        (schemaVersion === LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION ||
+            schemaVersion === null ||
+            schemaVersion === undefined) &&
+        (!hashAlgorithm || hashAlgorithm === LEGACY_CREDENTIAL_HASH_ALGORITHM)
+    ) {
         return sha256Hex(JSON.stringify(metadata));
     }
 

--- a/frontend/src/lib/credentialHashEncoding.ts
+++ b/frontend/src/lib/credentialHashEncoding.ts
@@ -1,0 +1,67 @@
+import { xdr } from '@stellar/stellar-sdk';
+
+const SHA256_HEX_LENGTH = 64;
+
+export function normalizeCredentialHashHex(hash: string): string {
+    const normalized = hash.trim().toLowerCase();
+
+    if (!/^[0-9a-f]+$/.test(normalized) || normalized.length !== SHA256_HEX_LENGTH) {
+        throw new Error('Credential hash must be a 64-character SHA-256 hex digest');
+    }
+
+    return normalized;
+}
+
+export function credentialHashHexToBytes(hash: string): Uint8Array {
+    const normalized = normalizeCredentialHashHex(hash);
+    const bytes = new Uint8Array(32);
+
+    for (let index = 0; index < bytes.length; index += 1) {
+        bytes[index] = Number.parseInt(normalized.slice(index * 2, index * 2 + 2), 16);
+    }
+
+    return bytes;
+}
+
+export function credentialHashHexToScVal(hash: string): xdr.ScVal {
+    return xdr.ScVal.scvBytes(credentialHashHexToBytes(hash) as any);
+}
+
+function bytesToHex(bytes: Uint8Array | number[]): string {
+    if (bytes.length !== 32) {
+        throw new Error('Credential hash bytes must be exactly 32 bytes');
+    }
+
+    return Array.from(bytes)
+        .map((byte) => {
+            if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
+                throw new Error('Credential hash contains an invalid byte');
+            }
+
+            return byte.toString(16).padStart(2, '0');
+        })
+        .join('');
+}
+
+export function credentialHashBytesToHex(value: unknown): string {
+    if (typeof value === 'string') {
+        return normalizeCredentialHashHex(value);
+    }
+
+    if (value instanceof Uint8Array) {
+        return bytesToHex(value);
+    }
+
+    if (Array.isArray(value)) {
+        return bytesToHex(value);
+    }
+
+    if (value && typeof value === 'object') {
+        const maybeBuffer = value as { data?: unknown };
+        if (Array.isArray(maybeBuffer.data)) {
+            return bytesToHex(maybeBuffer.data);
+        }
+    }
+
+    throw new Error('Unsupported on-chain credential hash encoding');
+}

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -242,6 +242,8 @@ export const dbHelpers = {
         ipfs_hash: string;
         blockchain_hash: string;
         metadata: any;
+        metadata_schema_version?: number;
+        hash_algorithm?: string;
     }) {
         const { data, error } = await supabase
             .from('credentials')

--- a/frontend/tests/TEST_STRATEGY.md
+++ b/frontend/tests/TEST_STRATEGY.md
@@ -30,7 +30,7 @@ Located in [e2e.lifecycle.test.ts](./e2e.lifecycle.test.ts):
 * **Strategy**: Configure Freighter signature simulators to throw rejected/canceled errors, verifying that the service fails gracefully, bubbles up transaction sign failures, and does **not** insert stray records into Supabase.
 
 ### 3. Verification Success States
-* **Strategy**: Query the `/api/verify/[token]` handler with a mock request. Verify that the system dynamically calculates the SHA-256 metadata hash, checks it against the simulated on-chain registry, and returns `verification.verified: true`.
+* **Strategy**: Query the `/api/verify/[token]` handler with a mock request. Verify that the system dynamically calculates the stored schema version's credential metadata hash, checks it against the simulated on-chain registry, and returns `verification.verified: true`.
 
 ### 4. Verification Revoked States
 * **Strategy**: Request validation of an issued credential where the on-chain Soroban query yields `isRevoked: true`. Verify that the route responds with `revoked: true` and `verification.verified: false` instantly.

--- a/frontend/tests/contractReads.test.ts
+++ b/frontend/tests/contractReads.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeOnChainCredential } from '../src/lib/contractReads';
+import { credentialHashHexToBytes } from '../src/lib/credentialHashEncoding';
+
+const hash = 'feca52dc50aee21c1942333a13873250b5bda373e09a4e2aff29b80a44a78545';
+
+describe('contract read normalization', () => {
+  it('maps the Rust credential struct field names into verification fields', () => {
+    expect(
+      normalizeOnChainCredential({
+        token_id: BigInt(7),
+        student: 'GSTUDENT',
+        issuer: 'GISSUER',
+        credential_hash: credentialHashHexToBytes(hash),
+        ipfs_hash: 'ipfs://metadata-cid',
+        issued_at: BigInt(1770000000),
+        revoked: false,
+      })
+    ).toEqual({
+      token_id: BigInt(7),
+      student: 'GSTUDENT',
+      issuer: 'GISSUER',
+      hash,
+      uri: 'ipfs://metadata-cid',
+      issued_at: BigInt(1770000000),
+      revoked: false,
+    });
+  });
+
+  it('keeps compatibility with existing mocked hash and uri aliases', () => {
+    expect(
+      normalizeOnChainCredential({
+        student: 'GSTUDENT',
+        issuer: 'GISSUER',
+        hash,
+        uri: 'ipfs://metadata-cid',
+        issued_at: 1770000000,
+      })
+    ).toMatchObject({
+      hash,
+      uri: 'ipfs://metadata-cid',
+    });
+  });
+});

--- a/frontend/tests/credentialHash.test.ts
+++ b/frontend/tests/credentialHash.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   CREDENTIAL_HASH_ALGORITHM,
   CREDENTIAL_METADATA_SCHEMA_VERSION,
+  LEGACY_CREDENTIAL_HASH_ALGORITHM,
+  LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION,
   buildCanonicalCredentialPayloadV1,
   canonicalJson,
   deriveCredentialHash,
@@ -82,6 +84,27 @@ describe('canonical credential metadata hashing', () => {
     await expect(generateCanonicalCredentialHash(reordered)).resolves.toBe(canonicalHashVector);
   });
 
+  it('normalizes equivalent issue date representations in schema v1', async () => {
+    const withIsoTimestamp = {
+      ...metadata,
+      credentialData: {
+        ...metadata.credentialData,
+        issueDate: '2026-05-31T00:00:00.000Z',
+      },
+    };
+
+    const withDateObject = {
+      ...metadata,
+      credentialData: {
+        ...metadata.credentialData,
+        issueDate: new Date('2026-05-31T00:00:00.000Z'),
+      },
+    };
+
+    await expect(generateCanonicalCredentialHash(withIsoTimestamp)).resolves.toBe(canonicalHashVector);
+    await expect(generateCanonicalCredentialHash(withDateObject)).resolves.toBe(canonicalHashVector);
+  });
+
   it('matches Node SHA-256 over the same canonical payload string', async () => {
     const payload = buildCanonicalCredentialPayloadV1(metadata);
     const serialized = canonicalJson(payload as any);
@@ -95,5 +118,18 @@ describe('canonical credential metadata hashing', () => {
     const legacyHash = createHash('sha256').update(JSON.stringify(metadata)).digest('hex');
 
     await expect(deriveCredentialHash(metadata, null, null)).resolves.toBe(legacyHash);
+    await expect(
+      deriveCredentialHash(
+        metadata,
+        LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION,
+        LEGACY_CREDENTIAL_HASH_ALGORITHM
+      )
+    ).resolves.toBe(legacyHash);
+  });
+
+  it('rejects unsupported stamped hash schemas instead of guessing', async () => {
+    await expect(
+      deriveCredentialHash(metadata, 99, CREDENTIAL_HASH_ALGORITHM)
+    ).rejects.toThrow(/Unsupported credential metadata hash schema/);
   });
 });

--- a/frontend/tests/credentialHashEncoding.test.ts
+++ b/frontend/tests/credentialHashEncoding.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  credentialHashBytesToHex,
+  credentialHashHexToBytes,
+  credentialHashHexToScVal,
+  normalizeCredentialHashHex,
+} from '../src/lib/credentialHashEncoding';
+
+const hash = 'FECA52DC50AEE21C1942333A13873250B5BDA373E09A4E2AFF29B80A44A78545';
+const normalized = hash.toLowerCase();
+
+describe('credential hash Stellar encoding', () => {
+  it('normalizes SHA-256 hex digests for contract calls', () => {
+    expect(normalizeCredentialHashHex(` ${hash} `)).toBe(normalized);
+  });
+
+  it('round-trips between hex and the 32-byte contract representation', () => {
+    const bytes = credentialHashHexToBytes(hash);
+
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes).toHaveLength(32);
+    expect(credentialHashBytesToHex(bytes)).toBe(normalized);
+  });
+
+  it('builds a 32-byte ScVal for the Soroban ABI', () => {
+    const scVal = credentialHashHexToScVal(hash);
+
+    expect(scVal.switch().name).toBe('scvBytes');
+    expect(scVal.bytes()).toHaveLength(32);
+  });
+
+  it('rejects non-SHA-256 hash values', () => {
+    expect(() => normalizeCredentialHashHex('abc')).toThrow(/64-character/);
+    expect(() => normalizeCredentialHashHex(`${normalized.slice(0, 63)}z`)).toThrow(/64-character/);
+  });
+});

--- a/frontend/tests/e2e.lifecycle.test.ts
+++ b/frontend/tests/e2e.lifecycle.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
-import { createHash } from 'crypto';
 
 // ── HOISTED MOCK VARIABLES ───────────────────────────────────────────────────
 // Vitest hoists vi.mock calls, so any variables used inside must be created with vi.hoisted
@@ -73,13 +72,6 @@ import {
   generateCanonicalCredentialHash,
 } from '../src/lib/credentialHash';
 
-// Helper to derive SHA-256 hash exactly like route.ts does
-function deriveCredentialHash(metadata: unknown): string {
-  return createHash('sha256')
-    .update(JSON.stringify(metadata))
-    .digest('hex');
-}
-
 // ── CORE LIFECYCLE TESTS ──────────────────────────────────────────────────────
 
 describe('Academic Credential E2E Integration / Lifecycle', () => {
@@ -137,6 +129,8 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         token_id: '123',
         ipfs_hash: 'mocked-metadata-path',
         blockchain_hash: 'mocked-transaction-hash',
+        metadata_schema_version: CREDENTIAL_METADATA_SCHEMA_VERSION,
+        hash_algorithm: CREDENTIAL_HASH_ALGORITHM,
         revoked: false,
       })
     );
@@ -241,7 +235,7 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
       },
     };
 
-    const expectedHash = deriveCredentialHash(dbMetadata);
+    const expectedHash = await generateCanonicalCredentialHash(dbMetadata);
 
     // Mock Supabase service role client to return active record but marked revoked on-chain
     const mockMaybeSingle = vi.fn().mockResolvedValue({
@@ -252,6 +246,8 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         revoked: false, // active in DB
         revoked_at: null,
         metadata: dbMetadata,
+        metadata_schema_version: CREDENTIAL_METADATA_SCHEMA_VERSION,
+        hash_algorithm: CREDENTIAL_HASH_ALGORITHM,
         ipfs_hash: 'mocked-metadata-path',
         student_wallet_address: 'gstudentaddress123456789012345678901234567890123456789',
         issuer_wallet_address: 'ginstitutionaddress12345678901234567890123456789',
@@ -336,6 +332,8 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         revoked: false,
         revoked_at: null,
         metadata: dbMetadata,
+        metadata_schema_version: CREDENTIAL_METADATA_SCHEMA_VERSION,
+        hash_algorithm: CREDENTIAL_HASH_ALGORITHM,
         ipfs_hash: 'mocked-metadata-path',
         student_wallet_address: 'gstudentaddress123456789012345678901234567890123456789',
         issuer_wallet_address: 'ginstitutionaddress12345678901234567890123456789',

--- a/frontend/tests/sqlMigrations.test.ts
+++ b/frontend/tests/sqlMigrations.test.ts
@@ -10,6 +10,7 @@ function readSql(name: string) {
 
 // The schema is now consolidated into a single idempotent setup file.
 const setup = readSql('FULL_SETUP.sql');
+const baseSchema = readSql('database_schema.sql');
 
 describe('database migration policy model', () => {
   it('keeps the consolidated schema free of permissive public policies', () => {
@@ -48,5 +49,20 @@ describe('database migration policy model', () => {
     expect(setup).toContain('CREATE TABLE IF NOT EXISTS public.credentials');
     expect(setup).toMatch(/DROP TRIGGER IF EXISTS on_auth_user_created\b/);
     expect(setup).toContain('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+  });
+
+  it('stores credential hash schema metadata in base and full schemas', () => {
+    for (const sql of [baseSchema, setup]) {
+      expect(sql).toContain('metadata_schema_version INTEGER NOT NULL DEFAULT 1');
+      expect(sql).toContain("hash_algorithm          TEXT NOT NULL DEFAULT 'sha256:canonical-json:v1'");
+    }
+  });
+
+  it('stamps legacy credential rows before enforcing hash metadata requirements', () => {
+    expect(setup).toContain("WHEN hash_algorithm = 'sha256:canonical-json:v1' THEN 1");
+    expect(setup).toContain("ELSE 0");
+    expect(setup).toContain("WHEN metadata_schema_version = 0 THEN 'sha256:json-stringify'");
+    expect(setup).toContain('ALTER COLUMN metadata_schema_version SET NOT NULL');
+    expect(setup).toContain('ALTER COLUMN hash_algorithm SET NOT NULL');
   });
 });


### PR DESCRIPTION
## Summary

- Implemented versioned credential metadata hashing with canonical schema v1
- Added legacy schema v0 support for old `JSON.stringify(metadata)` credentials
- Stored and migrated `metadata_schema_version` and `hash_algorithm` in the database setup SQL
- Fixed Soroban hash encoding to use 32-byte SHA-256 digest values instead of plain strings
- Updated verification contract reads to normalize `credential_hash` / `ipfs_hash`
- Added shared test vectors and tests for key ordering, optional fields, date normalization, browser/server hashing, SQL schema guarantees, and contract read normalization
- Documented how future metadata fields should be added without breaking old credentials

## Testing

- `npm.cmd test`
- `npm.cmd run build`
- `git diff --check`

Note: `cargo test` was attempted but the local machine is missing MSVC linker `link.exe`.

Closes #66 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for credential hash normalization and encoding across the app.
  * Expanded credential metadata handling to support both current and legacy hashing formats.
  * Improved database setup with a unified, idempotent setup flow and stronger data constraints.

* **Bug Fixes**
  * Made on-chain credential reads more consistent by normalizing varied result shapes.
  * Updated verification and issuance flows to use the correct credential hash format.

* **Documentation**
  * Clarified setup steps, hash metadata behavior, and CLI examples.
  * Updated testing guidance to reflect schema-aware verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->