### PR TITLE
I improved the fix by moving wallet linking out of direct browser-side Supabase updates and into an authenticated API route.

### DIFF
--- a/frontend/src/app/api/institution/link-wallet/route.ts
+++ b/frontend/src/app/api/institution/link-wallet/route.ts
@@ -1,0 +1,122 @@
+import { StrKey } from '@stellar/stellar-sdk';
+import { NextRequest, NextResponse } from 'next/server';
+import {
+    createUserScopedServerClient,
+    getServiceRoleClient,
+    hasServiceRoleEnv,
+    requireAuthenticatedRequest,
+} from '@/lib/serverAuth';
+import { enforceRateLimit } from '@/lib/rateLimit';
+
+export const dynamic = 'force-dynamic';
+
+const INSTITUTION_LINK_WALLET_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 30,
+    prefix: 'institution-link-wallet',
+} as const;
+
+function getAccessToken(request: NextRequest): string {
+    const authHeader = request.headers.get('authorization') || '';
+    return authHeader.toLowerCase().startsWith('bearer ') ? authHeader.slice(7) : '';
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        const rateLimitResponse = enforceRateLimit(request, INSTITUTION_LINK_WALLET_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
+        const authCheck = await requireAuthenticatedRequest(request);
+        if (!authCheck.ok) {
+            return NextResponse.json(
+                { success: false, error: authCheck.error },
+                { status: authCheck.status },
+            );
+        }
+
+        const { walletAddress } = await request.json();
+        const normalizedWallet =
+            typeof walletAddress === 'string' ? walletAddress.trim() : '';
+
+        if (!normalizedWallet) {
+            return NextResponse.json(
+                { success: false, error: 'Wallet address is required' },
+                { status: 400 },
+            );
+        }
+
+        if (!StrKey.isValidEd25519PublicKey(normalizedWallet)) {
+            return NextResponse.json(
+                { success: false, error: 'Wallet address must be a valid Stellar public key' },
+                { status: 400 },
+            );
+        }
+
+        const supabase = hasServiceRoleEnv()
+            ? getServiceRoleClient()
+            : createUserScopedServerClient(getAccessToken(request));
+
+        const { data: institution, error: findError } = await supabase
+            .from('institutions')
+            .select('id, wallet_address')
+            .eq('auth_user_id', authCheck.userId)
+            .maybeSingle();
+
+        if (findError) {
+            console.error('[institution/link-wallet] Error fetching institution:', findError);
+            return NextResponse.json(
+                { success: false, error: 'Failed to load institution profile' },
+                { status: 500 },
+            );
+        }
+
+        if (!institution) {
+            return NextResponse.json(
+                { success: false, error: 'Institution profile not found' },
+                { status: 404 },
+            );
+        }
+
+        if (institution.wallet_address?.toLowerCase() === normalizedWallet.toLowerCase()) {
+            return NextResponse.json({
+                success: true,
+                walletAddress: institution.wallet_address,
+                changed: false,
+            });
+        }
+
+        const { data: updatedInstitution, error: updateError } = await supabase
+            .from('institutions')
+            .update({
+                wallet_address: normalizedWallet,
+                verified: false,
+                authorization_tx_hash: null,
+            })
+            .eq('id', institution.id)
+            .eq('auth_user_id', authCheck.userId)
+            .select('id, wallet_address')
+            .single();
+
+        if (updateError) {
+            console.error('[institution/link-wallet] Error updating institution:', updateError);
+            return NextResponse.json(
+                { success: false, error: 'Failed to link institution wallet' },
+                { status: 500 },
+            );
+        }
+
+        return NextResponse.json({
+            success: true,
+            walletAddress: updatedInstitution.wallet_address,
+            changed: true,
+        });
+    } catch (error) {
+        console.error('[institution/link-wallet] Unhandled error:', error);
+        return NextResponse.json(
+            { success: false, error: 'Failed to link institution wallet' },
+            { status: 500 },
+        );
+    }
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -13,7 +13,7 @@ import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { debugLog, debugWarn } from '@/lib/debug';
-import { supabase } from '@/lib/supabase';
+import { safeGetSession, supabase } from '@/lib/supabase';
 import { useStellarAccount } from '@/contexts/StellarContext';
 import { ProtectedRoute, useAuth } from '@/contexts/AuthContext';
 
@@ -112,23 +112,34 @@ function DashboardContent() {
             setLinkingInstitutionWallet(true);
 
             try {
-                const { error } = await supabase
-                    .from('institutions')
-                    .update({
-                        wallet_address: address,
-                        verified: false,
-                        authorization_tx_hash: null,
-                    })
-                    .eq('id', institutionId)
-                    .eq('auth_user_id', user.id);
+                const {
+                    data: { session },
+                    error: sessionError,
+                } = await safeGetSession();
 
-                if (error) {
-                    throw error;
+                if (sessionError || !session?.access_token) {
+                    throw new Error('Your session expired. Please sign in again.');
                 }
 
-                setInstitutionWalletAddress(address);
+                const response = await fetch('/api/institution/link-wallet', {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${session.access_token}`,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ walletAddress: address }),
+                });
+                const payload = await response.json();
+
+                if (!response.ok || !payload?.success) {
+                    throw new Error(payload?.error || 'Failed to link institution wallet');
+                }
+
+                setInstitutionWalletAddress(payload.walletAddress || address);
                 debugLog('Connected wallet linked to institution profile.');
-                toast.success('Institution wallet linked');
+                if (payload.changed) {
+                    toast.success('Institution wallet linked');
+                }
             } catch (error) {
                 console.error('Error linking institution wallet:', error);
                 toast.error('Failed to link connected wallet to your institution');

--- a/frontend/tests/institutionLinkWalletRoute.test.ts
+++ b/frontend/tests/institutionLinkWalletRoute.test.ts
@@ -1,0 +1,148 @@
+import { NextRequest } from 'next/server';
+import { Keypair } from '@stellar/stellar-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+    mockCreateUserScopedServerClient,
+    mockGetServiceRoleClient,
+    mockHasServiceRoleEnv,
+    mockRequireAuthenticatedRequest,
+    mockEqAfterFind,
+    mockMaybeSingle,
+    mockUpdate,
+    mockFirstEqAfterUpdate,
+    mockSecondEqAfterUpdate,
+    mockSelectAfterUpdate,
+    mockSingleAfterUpdate,
+} = vi.hoisted(() => ({
+    mockCreateUserScopedServerClient: vi.fn(),
+    mockGetServiceRoleClient: vi.fn(),
+    mockHasServiceRoleEnv: vi.fn(),
+    mockRequireAuthenticatedRequest: vi.fn(),
+    mockEqAfterFind: vi.fn(),
+    mockMaybeSingle: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockFirstEqAfterUpdate: vi.fn(),
+    mockSecondEqAfterUpdate: vi.fn(),
+    mockSelectAfterUpdate: vi.fn(),
+    mockSingleAfterUpdate: vi.fn(),
+}));
+
+vi.mock('../src/lib/serverAuth', () => ({
+    createUserScopedServerClient: mockCreateUserScopedServerClient,
+    getServiceRoleClient: mockGetServiceRoleClient,
+    hasServiceRoleEnv: mockHasServiceRoleEnv,
+    requireAuthenticatedRequest: mockRequireAuthenticatedRequest,
+}));
+
+import { POST } from '../src/app/api/institution/link-wallet/route';
+
+function request(body: unknown): NextRequest {
+    return new NextRequest('http://localhost:3000/api/institution/link-wallet', {
+        method: 'POST',
+        headers: {
+            Authorization: 'Bearer valid-token',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+    });
+}
+
+describe('institution link wallet route', () => {
+    const walletAddress = Keypair.random().publicKey();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuthenticatedRequest.mockResolvedValue({ ok: true, userId: 'institution-user' });
+        mockHasServiceRoleEnv.mockReturnValue(true);
+        mockEqAfterFind.mockReturnValue({ maybeSingle: mockMaybeSingle });
+        mockMaybeSingle.mockResolvedValue({
+            data: { id: 'institution-1', wallet_address: null },
+            error: null,
+        });
+        mockUpdate.mockReturnValue({ eq: mockFirstEqAfterUpdate });
+        mockFirstEqAfterUpdate.mockReturnValue({ eq: mockSecondEqAfterUpdate });
+        mockSecondEqAfterUpdate.mockReturnValue({ select: mockSelectAfterUpdate });
+        mockSelectAfterUpdate.mockReturnValue({ single: mockSingleAfterUpdate });
+        mockSingleAfterUpdate.mockResolvedValue({
+            data: { id: 'institution-1', wallet_address: walletAddress },
+            error: null,
+        });
+        mockGetServiceRoleClient.mockReturnValue({
+            from: vi.fn(() => ({
+                select: vi.fn(() => ({
+                    eq: mockEqAfterFind,
+                })),
+                update: mockUpdate,
+            })),
+        });
+    });
+
+    it('links the authenticated institution wallet and clears stale authorization', async () => {
+        const response = await POST(request({ walletAddress }));
+        const payload = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(payload).toEqual({
+            success: true,
+            walletAddress,
+            changed: true,
+        });
+        expect(mockEqAfterFind).toHaveBeenCalledWith('auth_user_id', 'institution-user');
+        expect(mockUpdate).toHaveBeenCalledWith({
+            wallet_address: walletAddress,
+            verified: false,
+            authorization_tx_hash: null,
+        });
+        expect(mockFirstEqAfterUpdate).toHaveBeenCalledWith('id', 'institution-1');
+        expect(mockSecondEqAfterUpdate).toHaveBeenCalledWith(
+            'auth_user_id',
+            'institution-user',
+        );
+    });
+
+    it('does not reset authorization when the same wallet is already linked', async () => {
+        mockMaybeSingle.mockResolvedValue({
+            data: { id: 'institution-1', wallet_address: walletAddress },
+            error: null,
+        });
+
+        const response = await POST(request({ walletAddress }));
+        const payload = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(payload).toEqual({
+            success: true,
+            walletAddress,
+            changed: false,
+        });
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid Stellar wallet addresses', async () => {
+        const response = await POST(request({ walletAddress: 'not-a-stellar-key' }));
+        const payload = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(payload).toEqual({
+            success: false,
+            error: 'Wallet address must be a valid Stellar public key',
+        });
+        expect(mockGetServiceRoleClient).not.toHaveBeenCalled();
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('requires an institution profile for the authenticated user', async () => {
+        mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+
+        const response = await POST(request({ walletAddress }));
+        const payload = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(payload).toEqual({
+            success: false,
+            error: 'Institution profile not found',
+        });
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
close #9 


I improved the fix by moving wallet linking out of direct browser-side Supabase updates and into an authenticated API route.


## Description

Fixes the institution wallet authorization linkage issue by ensuring the connected institution wallet is persisted to the institution record from the dashboard.

Previously, the admin authorization sync API searched institutions by `wallet_address`, but the institution dashboard only used the connected wallet in client state. If the wallet was never saved to the institution row, authorization sync could not reliably match the authorized wallet to the correct institution.

## Changes

- Store the connected wallet address on the signed-in institution’s database row.
- Track the institution’s existing stored wallet in the dashboard.
- When the connected wallet changes, update `institutions.wallet_address`.
- Reset `verified` and `authorization_tx_hash` when a different wallet is linked, preventing stale verification from carrying over.
- Show a temporary `Linking` wallet status while the update is in progress.

## Verification

- Ran TypeScript check: `npm exec tsc -- --noEmit`
- Ran lint: `npm.cmd run lint`

## Scope

Only the institution dashboard wallet-linking behavior was changed.