### PR TITLE
Authorized issuers stored in instance() storage — scaling + TTL risk

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -113,6 +113,40 @@ fn extend_total_credentials_ttl(env: &Env) {
     );
 }
 
+/// Checks if an issuer is authorized, handles TTL extension for persistent storage,
+/// and transparently migrates existing instance-based authorizations to persistent storage.
+fn check_and_extend_authorization(env: &Env, issuer: &Address) -> bool {
+    // 1. Check persistent storage (new behavior)
+    if let Some(authorized) = env.storage().persistent().get::<_, bool>(&DataKey::Authorized(issuer.clone())) {
+        if authorized {
+            env.storage().persistent().extend_ttl(
+                &DataKey::Authorized(issuer.clone()),
+                PERSISTENT_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
+        return authorized;
+    }
+
+    // 2. Fallback to instance storage (for existing deployments)
+    if let Some(authorized) = env.storage().instance().get::<_, bool>(&DataKey::Authorized(issuer.clone())) {
+        if authorized {
+            // Migrate to persistent
+            env.storage().persistent().set(&DataKey::Authorized(issuer.clone()), &true);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Authorized(issuer.clone()),
+                PERSISTENT_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+            // Clean up instance storage
+            env.storage().instance().remove(&DataKey::Authorized(issuer.clone()));
+        }
+        return authorized;
+    }
+
+    false
+}
+
 #[contractimpl]
 #[allow(deprecated)]
 impl AcrediaCredential {
@@ -183,8 +217,16 @@ impl AcrediaCredential {
         let owner = read_owner(&env);
         owner.require_auth();
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::Authorized(issuer.clone()), &true);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Authorized(issuer.clone()),
+            PERSISTENT_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage()
+            .instance()
+            .remove(&DataKey::Authorized(issuer.clone())); // Cleanup existing
         extend_instance_ttl(&env);
         env.events().publish((symbol_short!("iss_auth"),), issuer);
     }
@@ -192,6 +234,9 @@ impl AcrediaCredential {
     pub fn revoke_issuer(env: Env, issuer: Address) {
         let owner = read_owner(&env);
         owner.require_auth();
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Authorized(issuer.clone()));
         env.storage()
             .instance()
             .remove(&DataKey::Authorized(issuer.clone()));
@@ -202,10 +247,7 @@ impl AcrediaCredential {
     pub fn is_authorized_issuer(env: Env, issuer: Address) -> bool {
         require_initialized(&env);
         extend_instance_ttl(&env);
-        env.storage()
-            .instance()
-            .get(&DataKey::Authorized(issuer))
-            .unwrap_or(false)
+        check_and_extend_authorization(&env, &issuer)
     }
 
     pub fn issue_credential(
@@ -217,12 +259,7 @@ impl AcrediaCredential {
     ) -> Result<u64, ContractError> {
         issuer.require_auth();
 
-        let is_authorized: bool = env
-            .storage()
-            .instance()
-            .get(&DataKey::Authorized(issuer.clone()))
-            .unwrap_or(false);
-        if !is_authorized {
+        if !check_and_extend_authorization(&env, &issuer) {
             return Err(ContractError::IssuerNotAuthorized);
         }
 
@@ -397,6 +434,14 @@ impl AcrediaCredential {
         extend_total_credentials_ttl(&env);
         extend_instance_ttl(&env);
         Ok(())
+    }
+
+    /// Upgrade the contract to a new WebAssembly code using a WASM hash.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        let owner = read_owner(&env);
+        owner.require_auth();
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        extend_instance_ttl(&env);
     }
 }
 
@@ -783,16 +828,18 @@ mod tests {
         let hash = dummy_hash(&env, 21);
 
         let token_id = env.as_contract(&contract, || {
-            let id = AcrediaCredential::issue_credential(
+            AcrediaCredential::issue_credential(
                 env.clone(),
                 student,
                 issuer.clone(),
                 hash.clone(),
                 String::from_str(&env, "ipfs://revoke-ttl"),
             )
-            .unwrap();
-            AcrediaCredential::revoke_credential(env.clone(), id, issuer).unwrap();
-            id
+            .unwrap()
+        });
+
+        env.as_contract(&contract, || {
+            AcrediaCredential::revoke_credential(env.clone(), token_id, issuer).unwrap();
         });
 
         env.ledger().set_sequence_number(5_000_000);
@@ -851,6 +898,44 @@ mod tests {
                 AcrediaCredential::bump_credential(env.clone(), 9999),
                 Err(ContractError::CredentialNotFound)
             );
+        });
+    }
+    #[test]
+    fn test_authorization_migration() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = AcrediaCredential.register(&env, None, ());
+        let owner = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let student = Address::generate(&env);
+
+        env.as_contract(&contract, || {
+            AcrediaCredential::initialize(env.clone(), owner.clone()).unwrap();
+            
+            // Manually simulate an old deployment by writing to instance storage directly
+            env.storage().instance().set(&DataKey::Authorized(issuer.clone()), &true);
+            
+            // Confirm it's not in persistent storage
+            assert!(!env.storage().persistent().has(&DataKey::Authorized(issuer.clone())));
+            
+            // Call is_authorized_issuer, which should trigger the migration
+            let is_auth = AcrediaCredential::is_authorized_issuer(env.clone(), issuer.clone());
+            assert!(is_auth, "Issuer should be authorized via migration fallback");
+            
+            // Check that it's now in persistent storage and removed from instance
+            assert!(env.storage().persistent().has(&DataKey::Authorized(issuer.clone())));
+            assert!(!env.storage().instance().has(&DataKey::Authorized(issuer.clone())));
+        });
+        
+        env.as_contract(&contract, || {
+            let hash = dummy_hash(&env, 99);
+            AcrediaCredential::issue_credential(
+                env.clone(),
+                student,
+                issuer,
+                hash,
+                String::from_str(&env, "ipfs://test"),
+            ).expect("Should issue credential using migrated authorization");
         });
     }
 }

--- a/frontend/src/app/api/student/credentials/route.ts
+++ b/frontend/src/app/api/student/credentials/route.ts
@@ -63,11 +63,13 @@ export async function GET(request: NextRequest) {
         const offset   = (page - 1) * pageSize;
 
         // ── Resolve student row ───────────────────────────────────────────────
-        let { data: studentRow, error: studentError } = await supabase
+        const { data: initialStudentRow, error: studentError } = await supabase
             .from('students')
             .select('id, wallet_address')
             .eq('auth_user_id', authCheck.userId)
             .maybeSingle();
+
+        let studentRow = initialStudentRow;
 
         if (studentError) {
             console.error('[student/credentials] Error fetching student row:', studentError);

--- a/frontend/src/components/institution/IssuedCredentialsList.tsx
+++ b/frontend/src/components/institution/IssuedCredentialsList.tsx
@@ -60,7 +60,7 @@ interface Credential {
 
 const PAGE_SIZE = 20;
 
-export function IssuedCredentialsList({ institutionId, refreshTrigger }: IssuedCredentialsListProps) {
+export function IssuedCredentialsList({ refreshTrigger }: IssuedCredentialsListProps) {
     const router     = useRouter();
     const pathname   = usePathname();
     const searchParams = useSearchParams();
@@ -124,7 +124,7 @@ const res = await fetch(`/api/institution/credentials?${params}`, {
             setCredentials(json.credentials ?? []);
             setTotal(json.total ?? 0);
             setTotalPages(json.totalPages ?? 0);
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error('Error loading credentials:', err);
             setError((err instanceof Error ? err.message : String(err)) || 'Failed to load credentials');
         } finally {

--- a/frontend/src/components/student/StudentCredentialsList.tsx
+++ b/frontend/src/components/student/StudentCredentialsList.tsx
@@ -121,7 +121,7 @@ export default function StudentCredentialsList({
                 ...(dateTo   && { dateTo }),
             });
 
-            const response = await fetch(`/api/student/credentials?${params}`, {
+            let response = await fetch(`/api/student/credentials?${params}`, {
                 headers: { Authorization: `Bearer ${accessToken}` },
             });
             let payload = await response.json();
@@ -129,13 +129,17 @@ export default function StudentCredentialsList({
             if (response.status === 401 && payload?.error === 'Invalid or expired access token') {
                 const { data: refreshed, error: refreshError } =
                     await supabase.auth.refreshSession();
-                accessToken = refreshed.session?.access_token;
+                const newAccessToken = refreshed.session?.access_token;
 
-                if (refreshError || !accessToken) {
+                if (refreshError || !newAccessToken) {
                     throw new Error('Your session expired. Please sign in again.');
                 }
 
-            const payload = await response.json();
+                response = await fetch(`/api/student/credentials?${params}`, {
+                    headers: { Authorization: `Bearer ${newAccessToken}` },
+                });
+                payload = await response.json();
+            }
 
             if (!response.ok || !payload?.success) {
                 throw new Error(payload?.error || 'Failed to load credentials');
@@ -145,9 +149,9 @@ export default function StudentCredentialsList({
             setCredentials(payload.credentials ?? []);
             setTotal(payload.total ?? 0);
             setTotalPages(payload.totalPages ?? 0);
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error('Error loading credentials:', err);
-            setError(err.message || 'Failed to load credentials');
+            setError((err instanceof Error ? err.message : String(err)) || 'Failed to load credentials');
         } finally {
             setLoading(false);
         }

--- a/frontend/src/lib/credentialService.ts
+++ b/frontend/src/lib/credentialService.ts
@@ -313,7 +313,7 @@ export interface CredentialFilters {
 }
 
 export interface PaginatedResult {
-  data: any[];
+  data: unknown[];
   total: number;
   page: number;
   pageSize: number;

--- a/frontend/tests/pagination.test.ts
+++ b/frontend/tests/pagination.test.ts
@@ -19,7 +19,7 @@ const STUDENT_ID = 'student-xyz-456';
 
 function mockChain(returnValue: object) {
     const resolved = vi.fn().mockResolvedValue(returnValue);
-    const chain: any = {
+    const chain: Record<string, unknown> = {
         select:  vi.fn().mockReturnThis(),
         eq:      vi.fn().mockReturnThis(),
         order:   vi.fn().mockReturnThis(),
@@ -153,7 +153,7 @@ describe('getStudentCredentialsPaginated', () => {
         );
 
         const eqCalls = chain.eq.mock.calls;
-        const revokedCall = eqCalls.find((c: any[]) => c[0] === 'revoked');
+        const revokedCall = eqCalls.find((c: unknown[]) => c[0] === 'revoked');
         expect(revokedCall).toBeUndefined();
     });
 
@@ -258,7 +258,7 @@ describe('student credentials API — permission boundaries', () => {
         // Credentials query must be scoped to the resolved student id,
         // not any id supplied by the caller
         const eqCalls = mockCredChain.eq.mock.calls;
-        const studentIdCall = eqCalls.find((c: any[]) => c[0] === 'student_id');
+        const studentIdCall = eqCalls.find((c: unknown[]) => c[0] === 'student_id');
         expect(studentIdCall).toBeDefined();
         expect(studentIdCall[1]).toBe('student-111');
     });


### PR DESCRIPTION
Move Authorized issuers to persistent storage (close #95)

**Description:**
This PR addresses the scaling and TTL risks associated with storing `Authorized(Address)` entries in `instance()` storage. By moving authorization data to `persistent()` storage, we avoid bloating the shared instance bucket and ensure that each authorization has its own independent TTL.

**Changes Made:**
- **Persistent Storage:** `authorize_issuer` and `revoke_issuer` now read/write `Authorized(Address)` directly to `persistent()` storage.
- **TTL Extensions:** Added logic to extend the TTL on persistent storage whenever an authorization is granted, verified (`is_authorized_issuer`), or utilized (`issue_credential`).
- **Seamless Migration:** Implemented a fallback that checks `instance()` storage for existing deployments and transparently migrates the authorization to `persistent()` storage upon access.
- **Upgradability:** Added an `upgrade` function to the contract to allow for future in-place WASM updates without losing state.
- **Testing:** Added test cases to verify the authorization migration logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorization now persists more reliably across contract updates, helping issuer access remain available after upgrades.

* **Bug Fixes**
  * Improved issuer authorization handling so revoked and authorized states are applied consistently.
  * Student credential loading now retries automatically after an expired session token, reducing sign-in related failures.
  * Credential lists now recover more safely from loading errors and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->