### PR TITLE
oute-level  and loading UI

### DIFF
--- a/frontend/src/app/admin/error.tsx
+++ b/frontend/src/app/admin/error.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function AdminError({ reset }: { reset: () => void }) {
+    return (
+        <RouteStateScreen
+            title="Admin panel unavailable"
+            description="We could not load the admin workspace right now. Please try again in a moment."
+            actionLabel="Try again"
+            secondaryActionLabel="Back to home"
+            onAction={reset}
+            variant="error"
+        />
+    );
+}

--- a/frontend/src/app/admin/loading.tsx
+++ b/frontend/src/app/admin/loading.tsx
@@ -1,0 +1,11 @@
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function AdminLoading() {
+    return (
+        <RouteStateScreen
+            title="Loading admin"
+            description="Preparing the administration workspace..."
+            variant="loading"
+        />
+    );
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -9,6 +9,7 @@ import { AuthorizeIssuer } from '@/components/institution/AuthorizeIssuer';
 import { ConnectWallet } from '@/components/ui/ConnectWallet';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
 import { getContractOwner } from '@/lib/contracts';
 import { debugLog, debugWarn } from '@/lib/debug';
 import { runtimeConfig } from '@/lib/runtimeConfig';
@@ -152,33 +153,11 @@ function AdminDashboardContent() {
 
     if (isChecking) {
         return (
-            <div className="flex min-h-screen flex-col bg-linear-to-br from-gray-50 via-teal-50 to-cyan-50">
-                <div className="p-6 md:p-10 mx-auto w-full max-w-7xl">
-                    <div className="flex items-center space-x-4 mb-8">
-                        <Skeleton className="h-11 w-11 rounded-xl" />
-                        <div className="space-y-2">
-                            <Skeleton className="h-8 w-48" />
-                            <Skeleton className="h-4 w-64" />
-                        </div>
-                    </div>
-                    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-8">
-                        {[1, 2, 3, 4].map((i) => (
-                            <Card key={i} className="p-6">
-                                <Skeleton className="h-4 w-24 mb-4" />
-                                <Skeleton className="h-8 w-16" />
-                            </Card>
-                        ))}
-                    </div>
-                    <Card className="p-6">
-                        <Skeleton className="h-6 w-32 mb-6" />
-                        <div className="space-y-4">
-                            {[1, 2, 3].map((i) => (
-                                <Skeleton key={i} className="h-16 w-full" />
-                            ))}
-                        </div>
-                    </Card>
-                </div>
-            </div>
+            <RouteStateScreen
+                title="Loading admin"
+                description="Preparing the administration workspace..."
+                variant="loading"
+            />
         );
     }
 

--- a/frontend/src/app/dashboard/error.tsx
+++ b/frontend/src/app/dashboard/error.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function DashboardError({ reset }: { reset: () => void }) {
+    return (
+        <RouteStateScreen
+            title="Dashboard could not load"
+            description="We hit a problem loading your dashboard. Please try again or return home."
+            actionLabel="Try again"
+            secondaryActionLabel="Back to home"
+            onAction={reset}
+            variant="error"
+        />
+    );
+}

--- a/frontend/src/app/dashboard/loading.tsx
+++ b/frontend/src/app/dashboard/loading.tsx
@@ -1,0 +1,11 @@
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function DashboardLoading() {
+    return (
+        <RouteStateScreen
+            title="Loading dashboard"
+            description="Preparing your workspace and credentials..."
+            variant="loading"
+        />
+    );
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { IssuedCredentialsList } from '@/components/institution/IssuedCredential
 import StudentCredentialsList from '@/components/student/StudentCredentialsList';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { debugLog, debugWarn } from '@/lib/debug';
 import { safeGetSession, supabase } from '@/lib/supabase';

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+    useEffect(() => {
+        console.error('Route error:', error);
+        if (typeof window !== 'undefined' && 'gtag' in window) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (window as Window & { gtag?: (...args: unknown[]) => void }).gtag?.('event', 'exception', {
+                description: error.message,
+                fatal: false,
+            });
+        }
+    }, [error]);
+
+    return (
+        <RouteStateScreen
+            title="Something went wrong"
+            description="We could not complete that request. Please try again, or return home and continue from there."
+            actionLabel="Try again"
+            secondaryActionLabel="Back to home"
+            onAction={reset}
+            variant="error"
+        />
+    );
+}

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+    return (
+        <html lang="en">
+            <body>
+                <RouteStateScreen
+                    title="Acredia hit an unexpected issue"
+                    description="The app encountered a problem. Please refresh the page or try again in a moment."
+                    actionLabel="Try again"
+                    secondaryActionLabel="Back to home"
+                    onAction={reset}
+                    variant="error"
+                />
+            </body>
+        </html>
+    );
+}

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,0 +1,11 @@
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function Loading() {
+    return (
+        <RouteStateScreen
+            title="Loading Acredia"
+            description="Preparing the next experience for you. This should only take a moment."
+            variant="loading"
+        />
+    );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,12 @@
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function NotFound() {
+    return (
+        <RouteStateScreen
+            title="Page not found"
+            description="The page you are looking for does not exist or may have moved. Please return home and continue exploring Acredia."
+            secondaryActionLabel="Back to home"
+            variant="not-found"
+        />
+    );
+}

--- a/frontend/src/app/verify/error.tsx
+++ b/frontend/src/app/verify/error.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function VerifyError({ reset }: { reset: () => void }) {
+    return (
+        <RouteStateScreen
+            title="Verification unavailable"
+            description="We could not load the verification experience. Please try again or return home."
+            actionLabel="Try again"
+            secondaryActionLabel="Back to home"
+            onAction={reset}
+            variant="error"
+        />
+    );
+}

--- a/frontend/src/app/verify/loading.tsx
+++ b/frontend/src/app/verify/loading.tsx
@@ -1,0 +1,11 @@
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
+
+export default function VerifyLoading() {
+    return (
+        <RouteStateScreen
+            title="Loading verification"
+            description="Preparing the credential verification experience..."
+            variant="loading"
+        />
+    );
+}

--- a/frontend/src/app/verify/page.tsx
+++ b/frontend/src/app/verify/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
+import { RouteStateScreen } from '@/components/route-state/RouteStateScreen';
 import { useSearchParams } from 'next/navigation';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -1064,15 +1065,11 @@ export default function VerifyPage() {
     return (
         <Suspense
             fallback={
-                <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-                    <div className="w-full max-w-md space-y-8">
-                        <div className="flex flex-col items-center justify-center space-y-4">
-                            <div className="h-16 w-16 animate-pulse rounded-2xl bg-gray-200"></div>
-                            <div className="h-8 w-48 animate-pulse rounded-lg bg-gray-200"></div>
-                            <div className="h-4 w-64 animate-pulse rounded bg-gray-200"></div>
-                        </div>
-                    </div>
-                </div>
+                <RouteStateScreen
+                    title="Loading verification"
+                    description="Preparing the credential verification experience..."
+                    variant="loading"
+                />
             }
         >
             <VerifyContent />

--- a/frontend/src/components/route-state/RouteStateScreen.tsx
+++ b/frontend/src/components/route-state/RouteStateScreen.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { AlertCircle, Loader2, ShieldCheck } from 'lucide-react';
+
+interface RouteStateScreenProps {
+    title: string;
+    description: string;
+    actionLabel?: string;
+    secondaryActionLabel?: string;
+    onAction?: () => void;
+    onSecondaryAction?: () => void;
+    variant?: 'error' | 'loading' | 'not-found';
+}
+
+export function RouteStateScreen({
+    title,
+    description,
+    actionLabel,
+    secondaryActionLabel,
+    onAction,
+    onSecondaryAction,
+    variant = 'error',
+}: RouteStateScreenProps) {
+    const isLoading = variant === 'loading';
+
+    return (
+        <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 via-cyan-50 to-teal-50 px-4 py-12">
+            <Card className="w-full max-w-2xl border border-slate-200 bg-white/90 p-8 shadow-xl backdrop-blur">
+                <div className="flex flex-col items-center text-center">
+                    <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-teal-600 to-cyan-600 text-white shadow-lg">
+                        {isLoading ? (
+                            <Loader2 className="h-8 w-8 animate-spin" />
+                        ) : variant === 'not-found' ? (
+                            <ShieldCheck className="h-8 w-8" />
+                        ) : (
+                            <AlertCircle className="h-8 w-8" />
+                        )}
+                    </div>
+                    <p className="mb-3 text-sm font-semibold uppercase tracking-[0.3em] text-teal-600">
+                        ACREDIA
+                    </p>
+                    <h1 className="text-3xl font-semibold tracking-tight text-slate-900">{title}</h1>
+                    <p className="mt-4 max-w-xl text-lg leading-8 text-slate-600">{description}</p>
+                    <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                        {actionLabel ? (
+                            <Button onClick={onAction} className="bg-gradient-to-r from-teal-600 to-cyan-600 text-white">
+                                {actionLabel}
+                            </Button>
+                        ) : null}
+                        {secondaryActionLabel ? (
+                            <Button variant="outline" asChild onClick={onSecondaryAction}>
+                                <Link href="/">{secondaryActionLabel}</Link>
+                            </Button>
+                        ) : null}
+                    </div>
+                </div>
+            </Card>
+        </div>
+    );
+}

--- a/frontend/tests/routeState.test.tsx
+++ b/frontend/tests/routeState.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RouteStateScreen } from '../src/components/route-state/RouteStateScreen';
+
+describe('route state screens', () => {
+    it('renders branded recovery screens with actionable copy', () => {
+        const html = renderToStaticMarkup(
+            <RouteStateScreen
+                title="Something went wrong"
+                description="We could not complete that request. Please try again."
+                actionLabel="Try again"
+                secondaryActionLabel="Back to home"
+            />,
+        );
+
+        expect(html).toContain('Something went wrong');
+        expect(html).toContain('Try again');
+        expect(html).toContain('Back to home');
+        expect(html).toContain('ACREDIA');
+    });
+
+    it('renders a loading state for route-level transitions', () => {
+        const html = renderToStaticMarkup(
+            <RouteStateScreen
+                title="Loading dashboard"
+                description="Preparing your workspace..."
+                variant="loading"
+            />,
+        );
+
+        expect(html).toContain('Loading dashboard');
+        expect(html).toContain('Preparing your workspace...');
+        expect(html).toContain('ACREDIA');
+    });
+});


### PR DESCRIPTION
close #98 Missing route-level error, not-found, and loading UI
Repo Avatar
[soumen0818/ACREDIA-STELLAR](https://github.com/soumen0818/ACREDIA-STELLAR)
Labels: bug, frontend · Priority: High
Affected paths: frontend/src/app/ (no error.tsx, global-error.tsx, not-found.tsx, loading.tsx)

Problem
The App Router has no error boundaries, no custom 404, and no route-level loading files. An unhandled error in any client page (e.g. a failed Supabase/RPC call) shows the default Next error overlay in dev and a blank/ugly screen in prod, and unknown URLs get the default 404. This directly contributes to the "bad UX" the maintainer flagged.

Tasks

 Add app/error.tsx and app/global-error.tsx with branded recovery UI + "try again".
 Add app/not-found.tsx.
 Add loading.tsx (or Suspense skeletons) for /dashboard, /admin, /verify.
 Ensure errors are reported to monitoring (#18).
Acceptance criteria: Thrown errors and unknown routes render branded, actionable screens.