### PR TITLE
feat : student row auto-adoption by email allows account/credential takeover

### DIFF
--- a/frontend/sql/FULL_SETUP.sql
+++ b/frontend/sql/FULL_SETUP.sql
@@ -162,9 +162,7 @@ BEGIN
       COALESCE(new.raw_user_meta_data->>'name', split_part(new.email, '@', 1)),
       new.email
     )
-    ON CONFLICT (email) DO UPDATE
-      SET auth_user_id = EXCLUDED.auth_user_id
-      WHERE public.institutions.auth_user_id IS NULL;
+    ON CONFLICT (email) DO NOTHING;
   END IF;
   RETURN new;
 END;
@@ -181,9 +179,7 @@ BEGIN
       COALESCE(new.raw_user_meta_data->>'name', split_part(new.email, '@', 1)),
       new.email
     )
-    ON CONFLICT (email) DO UPDATE
-      SET auth_user_id = EXCLUDED.auth_user_id
-      WHERE public.students.auth_user_id IS NULL;
+    ON CONFLICT (email) DO NOTHING;
   END IF;
   RETURN new;
 END;

--- a/frontend/src/app/api/student/credentials/route.ts
+++ b/frontend/src/app/api/student/credentials/route.ts
@@ -79,52 +79,6 @@ export async function GET(request: NextRequest) {
             );
         }
 
-        // ── Auto-create student row if missing ────────────────────────────────
-        if (!studentRow) {
-            console.warn(
-                '[student/credentials] No student row found for userId:',
-                authCheck.userId,
-                '— attempting auto-create',
-            );
-
-            const serviceClient = hasServiceRoleEnv() ? getServiceRoleClient() : null;
-            if (serviceClient) {
-                const { data: authUser } = await serviceClient.auth.admin.getUserById(
-                    authCheck.userId,
-                );
-                const userEmail = authUser?.user?.email ?? '';
-                const userName =
-                    authUser?.user?.user_metadata?.name ?? userEmail.split('@')[0] ?? 'Student';
-
-                if (userEmail) {
-                    const { data: newStudent, error: createError } = await serviceClient
-                        .from('students')
-                        .upsert(
-                            { auth_user_id: authCheck.userId, name: userName, email: userEmail },
-                            { onConflict: 'email', ignoreDuplicates: false },
-                        )
-                        .select('id, wallet_address')
-                        .maybeSingle();
-
-                    if (!createError && newStudent) {
-                        studentRow = newStudent;
-                        // eslint-disable-next-line no-console
-                        console.log(
-                            '[student/credentials] Auto-created student row:',
-                            newStudent.id,
-                        );
-                    } else {
-                        const { data: byEmail } = await serviceClient
-                            .from('students')
-                            .select('id, wallet_address')
-                            .eq('email', userEmail)
-                            .maybeSingle();
-                        if (byEmail) studentRow = byEmail;
-                    }
-                }
-            }
-        }
-
         if (!studentRow?.id) {
             return NextResponse.json({ success: true, credentials: [], total: 0, page, pageSize, totalPages: 0 });
         }

--- a/frontend/src/app/api/student/provision/route.ts
+++ b/frontend/src/app/api/student/provision/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+    getServiceRoleClient,
+    requireAuthenticatedRequest,
+} from '@/lib/serverAuth';
+import { enforceRateLimit } from '@/lib/rateLimit';
+
+export const dynamic = 'force-dynamic';
+
+const STUDENT_PROVISION_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 60,
+    prefix: 'student-provision',
+} as const;
+
+export async function POST(request: NextRequest) {
+    try {
+        const rateLimitResponse = enforceRateLimit(request, STUDENT_PROVISION_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
+        const authCheck = await requireAuthenticatedRequest(request);
+        if (!authCheck.ok) {
+            return NextResponse.json(
+                { success: false, error: authCheck.error },
+                { status: authCheck.status },
+            );
+        }
+
+        const serviceClient = getServiceRoleClient();
+        const { data: authUser, error: authError } = await serviceClient.auth.admin.getUserById(
+            authCheck.userId,
+        );
+
+        if (authError || !authUser?.user) {
+            console.error('[student/provision] Error fetching auth user:', authError);
+            return NextResponse.json(
+                { success: false, error: 'Failed to retrieve auth user details' },
+                { status: 400 },
+            );
+        }
+
+        // Enforce email verification before linking / provisioning
+        const emailConfirmedAt = authUser.user.email_confirmed_at;
+        if (!emailConfirmedAt) {
+            return NextResponse.json(
+                { success: false, error: 'Email verification is required before provisioning/linking your student profile.' },
+                { status: 403 },
+            );
+        }
+
+        const userEmail = authUser.user.email ?? '';
+        if (!userEmail) {
+            return NextResponse.json(
+                { success: false, error: 'User email is missing' },
+                { status: 400 },
+            );
+        }
+
+        // 1. Check if a student profile already exists for this auth_user_id
+        const { data: existingByAuth, error: fetchAuthError } = await serviceClient
+            .from('students')
+            .select('id, email, auth_user_id, wallet_address')
+            .eq('auth_user_id', authCheck.userId)
+            .maybeSingle();
+
+        if (fetchAuthError) {
+            console.error('[student/provision] Error fetching student by auth_user_id:', fetchAuthError);
+            return NextResponse.json(
+                { success: false, error: 'Database error' },
+                { status: 500 },
+            );
+        }
+
+        if (existingByAuth) {
+            return NextResponse.json({ success: true, student: existingByAuth });
+        }
+
+        // 2. Check if a student profile already exists with this email
+        const { data: existingByEmail, error: fetchEmailError } = await serviceClient
+            .from('students')
+            .select('id, email, auth_user_id, wallet_address')
+            .eq('email', userEmail)
+            .maybeSingle();
+
+        if (fetchEmailError) {
+            console.error('[student/provision] Error fetching student by email:', fetchEmailError);
+            return NextResponse.json(
+                { success: false, error: 'Database error' },
+                { status: 500 },
+            );
+        }
+
+        if (existingByEmail) {
+            // NEVER adopt a row belonging to a different auth_user_id
+            if (existingByEmail.auth_user_id && existingByEmail.auth_user_id !== authCheck.userId) {
+                return NextResponse.json(
+                    { success: false, error: 'This email address is already linked to another student account.' },
+                    { status: 409 },
+                );
+            }
+
+            // If the matching student row has a NULL auth_user_id, we can safely link/adopt it
+            const { data: updatedStudent, error: updateError } = await serviceClient
+                .from('students')
+                .update({ auth_user_id: authCheck.userId })
+                .eq('id', existingByEmail.id)
+                .select('id, email, auth_user_id, wallet_address')
+                .maybeSingle();
+
+            if (updateError || !updatedStudent) {
+                console.error('[student/provision] Error linking student profile:', updateError);
+                return NextResponse.json(
+                    { success: false, error: 'Failed to link student profile' },
+                    { status: 500 },
+                );
+            }
+
+            return NextResponse.json({ success: true, student: updatedStudent });
+        }
+
+        // 3. No existing student profile found, create a new one
+        const userName = authUser.user.user_metadata?.name ?? userEmail.split('@')[0] ?? 'Student';
+        const { data: newStudent, error: createError } = await serviceClient
+            .from('students')
+            .insert({
+                auth_user_id: authCheck.userId,
+                name: userName,
+                email: userEmail
+            })
+            .select('id, email, auth_user_id, wallet_address')
+            .maybeSingle();
+
+        if (createError || !newStudent) {
+            console.error('[student/provision] Error creating student profile:', createError);
+            return NextResponse.json(
+                { success: false, error: 'Failed to create student profile' },
+                { status: 500 },
+            );
+        }
+
+        return NextResponse.json({ success: true, student: newStudent });
+
+    } catch (err) {
+        console.error('[student/provision] Unhandled error:', err);
+        return NextResponse.json(
+            { success: false, error: 'Failed to provision student profile' },
+            { status: 500 },
+        );
+    }
+}

--- a/frontend/src/components/student/StudentCredentialsList.tsx
+++ b/frontend/src/components/student/StudentCredentialsList.tsx
@@ -112,6 +112,20 @@ export default function StudentCredentialsList({
                 return;
             }
 
+            // Securely provision/link the student profile first
+            const provisionRes = await fetch('/api/student/provision', {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${accessToken}` },
+            });
+
+            if (!provisionRes.ok) {
+                const provisionData = await provisionRes.json().catch(() => ({}));
+                const errMessage = provisionData?.error || 'Failed to initialize student profile';
+                setError(errMessage);
+                setLoading(false);
+                return;
+            }
+
             const params = new URLSearchParams({
                 page: page.toString(),
                 pageSize: PAGE_SIZE.toString(),

--- a/frontend/tests/studentIdentityCollision.test.ts
+++ b/frontend/tests/studentIdentityCollision.test.ts
@@ -1,0 +1,327 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Hoist mock functions
+const {
+    mockRequireAuthenticatedRequest,
+    mockGetServiceRoleClient,
+} = vi.hoisted(() => ({
+    mockRequireAuthenticatedRequest: vi.fn(),
+    mockGetServiceRoleClient: vi.fn(),
+}));
+
+vi.mock('../src/lib/serverAuth', () => ({
+    requireAuthenticatedRequest: mockRequireAuthenticatedRequest,
+    getServiceRoleClient: mockGetServiceRoleClient,
+    hasServiceRoleEnv: vi.fn().mockReturnValue(true),
+    createUserScopedServerClient: vi.fn(),
+}));
+
+import { POST as provisionPOST } from '../src/app/api/student/provision/route';
+import { GET as credentialsGET } from '../src/app/api/student/credentials/route';
+
+function makeRequest(urlStr: string, method: string = 'POST'): NextRequest {
+    return new NextRequest(urlStr, {
+        method,
+        headers: { Authorization: 'Bearer test-token' },
+    });
+}
+
+describe('Student Identity & Provisioning Security Tests', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns 401 Unauthorized for unauthenticated provisioning requests', async () => {
+        mockRequireAuthenticatedRequest.mockResolvedValue({
+            ok: false,
+            error: 'Unauthorized',
+            status: 401,
+        });
+
+        const req = makeRequest('http://localhost/api/student/provision');
+        const res = await provisionPOST(req);
+        const payload = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(payload.success).toBe(false);
+    });
+
+    it('returns 403 Forbidden when email is not confirmed', async () => {
+        mockRequireAuthenticatedRequest.mockResolvedValue({
+            ok: true,
+            userId: 'unverified-auth-id',
+        });
+
+        const mockGetUserById = vi.fn().mockResolvedValue({
+            data: {
+                user: {
+                    id: 'unverified-auth-id',
+                    email: 'unverified@example.com',
+                    email_confirmed_at: null, // NOT verified
+                    user_metadata: { name: 'Unverified' }
+                }
+            },
+            error: null
+        });
+
+        mockGetServiceRoleClient.mockReturnValue({
+            auth: {
+                admin: {
+                    getUserById: mockGetUserById
+                }
+            }
+        });
+
+        const req = makeRequest('http://localhost/api/student/provision');
+        const res = await provisionPOST(req);
+        const payload = await res.json();
+
+        expect(res.status).toBe(403);
+        expect(payload.success).toBe(false);
+        expect(payload.error).toContain('Email verification is required');
+    });
+
+    it('returns 409 Conflict when the student record is already linked to another auth_user_id', async () => {
+        mockRequireAuthenticatedRequest.mockResolvedValue({
+            ok: true,
+            userId: 'attacker-auth-id',
+        });
+
+        const mockGetUserById = vi.fn().mockResolvedValue({
+            data: {
+                user: {
+                    id: 'attacker-auth-id',
+                    email: 'victim@example.com',
+                    email_confirmed_at: '2026-06-29T12:00:00Z',
+                    user_metadata: { name: 'Attacker' }
+                }
+            },
+            error: null
+        });
+
+        // 1. Check if profile exists by auth_user_id: returns null (doesn't exist)
+        const mockMaybeSingleByAuth = vi.fn().mockResolvedValue({ data: null, error: null });
+        // 2. Check if profile exists by email: returns victim's profile linked to victim's auth_user_id
+        const mockMaybeSingleByEmail = vi.fn().mockResolvedValue({
+            data: {
+                id: 'student-victim-id',
+                email: 'victim@example.com',
+                auth_user_id: 'victim-auth-id',
+                wallet_address: 'GVictimWallet'
+            },
+            error: null
+        });
+
+        const mockFrom = vi.fn((table: string) => {
+            if (table === 'students') {
+                return {
+                    select: vi.fn(() => ({
+                        eq: vi.fn((column: string, value: string) => ({
+                            maybeSingle: column === 'auth_user_id' ? mockMaybeSingleByAuth : mockMaybeSingleByEmail
+                        }))
+                    }))
+                };
+            }
+            throw new Error(`Unexpected table: ${table}`);
+        });
+
+        mockGetServiceRoleClient.mockReturnValue({
+            auth: {
+                admin: {
+                    getUserById: mockGetUserById
+                }
+            },
+            from: mockFrom
+        });
+
+        const req = makeRequest('http://localhost/api/student/provision');
+        const res = await provisionPOST(req);
+        const payload = await res.json();
+
+        expect(res.status).toBe(409);
+        expect(payload.success).toBe(false);
+        expect(payload.error).toContain('already linked to another student account');
+    });
+
+    it('successfully links/adopts an unlinked student record if user email is verified', async () => {
+        mockRequireAuthenticatedRequest.mockResolvedValue({
+            ok: true,
+            userId: 'new-auth-id',
+        });
+
+        const mockGetUserById = vi.fn().mockResolvedValue({
+            data: {
+                user: {
+                    id: 'new-auth-id',
+                    email: 'student@example.com',
+                    email_confirmed_at: '2026-06-29T12:00:00Z',
+                    user_metadata: { name: 'Student Name' }
+                }
+            },
+            error: null
+        });
+
+        const mockMaybeSingleByAuth = vi.fn().mockResolvedValue({ data: null, error: null });
+        const mockMaybeSingleByEmail = vi.fn().mockResolvedValue({
+            data: {
+                id: 'pre-created-student-id',
+                email: 'student@example.com',
+                auth_user_id: null,
+                wallet_address: null
+            },
+            error: null
+        });
+
+        const mockUpdate = vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                    maybeSingle: vi.fn().mockResolvedValue({
+                        data: {
+                            id: 'pre-created-student-id',
+                            email: 'student@example.com',
+                            auth_user_id: 'new-auth-id',
+                            wallet_address: null
+                        },
+                        error: null
+                    })
+                })
+            })
+        });
+
+        const mockFrom = vi.fn((table: string) => {
+            if (table === 'students') {
+                return {
+                    select: vi.fn(() => ({
+                        eq: vi.fn((column: string, value: string) => ({
+                            maybeSingle: column === 'auth_user_id' ? mockMaybeSingleByAuth : mockMaybeSingleByEmail
+                        }))
+                    })),
+                    update: mockUpdate
+                };
+            }
+            throw new Error(`Unexpected table: ${table}`);
+        });
+
+        mockGetServiceRoleClient.mockReturnValue({
+            auth: {
+                admin: {
+                    getUserById: mockGetUserById
+                }
+            },
+            from: mockFrom
+        });
+
+        const req = makeRequest('http://localhost/api/student/provision');
+        const res = await provisionPOST(req);
+        const payload = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(payload.success).toBe(true);
+        expect(payload.student.auth_user_id).toBe('new-auth-id');
+        expect(mockUpdate).toHaveBeenCalledWith({ auth_user_id: 'new-auth-id' });
+    });
+
+    it('creates a new student record if student record does not exist by auth_user_id or email', async () => {
+        mockRequireAuthenticatedRequest.mockResolvedValue({
+            ok: true,
+            userId: 'brand-new-id',
+        });
+
+        const mockGetUserById = vi.fn().mockResolvedValue({
+            data: {
+                user: {
+                    id: 'brand-new-id',
+                    email: 'brandnew@example.com',
+                    email_confirmed_at: '2026-06-29T12:00:00Z',
+                    user_metadata: { name: 'Brand New' }
+                }
+            },
+            error: null
+        });
+
+        const mockMaybeSingleByAuth = vi.fn().mockResolvedValue({ data: null, error: null });
+        const mockMaybeSingleByEmail = vi.fn().mockResolvedValue({ data: null, error: null });
+
+        const mockInsert = vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                    data: {
+                        id: 'new-student-uuid',
+                        email: 'brandnew@example.com',
+                        auth_user_id: 'brand-new-id',
+                        wallet_address: null
+                    },
+                    error: null
+                })
+            })
+        });
+
+        const mockFrom = vi.fn((table: string) => {
+            if (table === 'students') {
+                return {
+                    select: vi.fn(() => ({
+                        eq: vi.fn((column: string, value: string) => ({
+                            maybeSingle: column === 'auth_user_id' ? mockMaybeSingleByAuth : mockMaybeSingleByEmail
+                        }))
+                    })),
+                    insert: mockInsert
+                };
+            }
+            throw new Error(`Unexpected table: ${table}`);
+        });
+
+        mockGetServiceRoleClient.mockReturnValue({
+            auth: {
+                admin: {
+                    getUserById: mockGetUserById
+                }
+            },
+            from: mockFrom
+        });
+
+        const req = makeRequest('http://localhost/api/student/provision');
+        const res = await provisionPOST(req);
+        const payload = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(payload.success).toBe(true);
+        expect(payload.student.auth_user_id).toBe('brand-new-id');
+        expect(mockInsert).toHaveBeenCalledWith({
+            auth_user_id: 'brand-new-id',
+            name: 'Brand New',
+            email: 'brandnew@example.com'
+        });
+    });
+
+    it('returns empty credentials list when student profile is missing', async () => {
+        mockRequireAuthenticatedRequest.mockResolvedValue({
+            ok: true,
+            userId: 'no-student-id',
+        });
+
+        const mockFrom = vi.fn((table: string) => {
+            if (table === 'students') {
+                return {
+                    select: vi.fn().mockReturnThis(),
+                    eq: vi.fn().mockReturnThis(),
+                    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                };
+            }
+            throw new Error(`Unexpected table: ${table}`);
+        });
+
+        mockGetServiceRoleClient.mockReturnValue({
+            from: mockFrom
+        });
+
+        const req = makeRequest('http://localhost/api/student/credentials', 'GET');
+        const res = await credentialsGET(req);
+        const payload = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(payload.success).toBe(true);
+        expect(payload.credentials).toEqual([]);
+        expect(payload.total).toBe(0);
+    });
+});


### PR DESCRIPTION
Closes #94 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added student profile provisioning when credentials are loaded, helping connect accounts automatically when needed.
  * Introduced a student provisioning endpoint that can link an existing profile or create a new one.

* **Bug Fixes**
  * Student credentials now return an empty list instead of trying to create a missing profile.
  * Improved handling for account conflicts, unverified emails, and duplicate student identity matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->