### PR TITLE
Add production security headers (CSP, HSTS, frame protection, permissions policy)

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,12 @@
 import type { NextConfig } from 'next';
+import { buildSecurityHeaders } from './src/lib/securityHeaders';
 
 const nextConfig: NextConfig = {
+    // ── Security headers ────────────────────────────────────────────────────
+    async headers() {
+        return buildSecurityHeaders(process.env.NODE_ENV === 'production');
+    },
+
     turbopack: {},
     webpack: (config, { isServer }) => {
         // Ignore test files and development dependencies from thread-stream
@@ -51,6 +57,8 @@ const nextConfig: NextConfig = {
             { protocol: 'https', hostname: 'www.scholarshipregion.com' },
             { protocol: 'https', hostname: 'gateway.pinata.cloud' },
             { protocol: 'https', hostname: '**.ipfs.dweb.link' },
+            { protocol: 'https', hostname: 'ipfs.io' },
+            { protocol: 'https', hostname: 'res.cloudinary.com' },
         ],
     },
 

--- a/frontend/scripts/check-security-headers.sh
+++ b/frontend/scripts/check-security-headers.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────────
+# check-security-headers.sh
+# ──────────────────────────────────────────────────────────────────────────────
+# Usage:
+#   ./scripts/check-security-headers.sh <base-url>
+#
+# Example:
+#   ./scripts/check-security-headers.sh https://acredia-stellar-tau.vercel.app
+#
+# This script checks that the expected security headers are present in the
+# response from a production (or preview) deployment. It exits with code 0
+# if all headers are present, or 1 with details about what is missing.
+# ──────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <base-url>"
+    echo "Example: $0 https://acredia-stellar-tau.vercel.app"
+    exit 1
+fi
+
+BASE_URL="${1%/}"
+FAILED=0
+
+check_header() {
+    local header_name="$1"
+    local expected_pattern="$2"
+    local location="$3"
+
+    local value
+    value=$(curl -sI "$location" | grep -i "^${header_name}:" | sed 's/^[^:]*:\s*//i' | tr -d '\r')
+
+    if [ -z "$value" ]; then
+        echo "  MISSING: $header_name"
+        FAILED=1
+        return
+    fi
+
+    if echo "$value" | grep -qE "$expected_pattern"; then
+        echo "  OK: $header_name"
+    else
+        echo "⚠  $header_name present but pattern mismatch"
+        echo "   Expected pattern: $expected_pattern"
+        echo "   Got: $value"
+        FAILED=1
+    fi
+}
+
+echo "── Checking security headers at ${BASE_URL} ──"
+echo ""
+
+check_header "Content-Security-Policy" "default-src" "$BASE_URL"
+check_header "X-Frame-Options" "DENY" "$BASE_URL"
+check_header "X-Content-Type-Options" "nosniff" "$BASE_URL"
+check_header "Referrer-Policy" "strict-origin-when-cross-origin" "$BASE_URL"
+check_header "Permissions-Policy" "camera=\(self\)" "$BASE_URL"
+check_header "Strict-Transport-Security" "max-age=" "$BASE_URL"
+
+echo ""
+if [ $FAILED -eq 0 ]; then
+    echo "✓ All security headers are present."
+else
+    echo "✗ Some security headers are missing or have unexpected values."
+    echo "  Update the CSP in src/lib/securityHeaders.ts if a new integration"
+    echo "  intentionally requires additional domains."
+fi
+exit $FAILED

--- a/frontend/src/lib/securityHeaders.ts
+++ b/frontend/src/lib/securityHeaders.ts
@@ -1,0 +1,92 @@
+export interface SecurityHeader {
+    key: string;
+    value: string;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Content Security Policy directives
+// ──────────────────────────────────────────────────────────────────────────────
+//
+// When adding a new external integration (image CDN, API endpoint, IPFS gateway,
+// wallet provider, etc.):
+//
+// 1. Add the domain to the relevant directive below:
+//    - img-src      → images loaded via <img>, <picture>, or Next.js <Image>
+//    - media-src    → <video>, <audio>, <source>
+//    - connect-src  → fetch(), XMLHttpRequest, WebSocket, Supabase, Stellar RPC
+//    - script-src   → external scripts (avoid if possible; prefer bundled code)
+//    - style-src    → external stylesheets (avoid if possible)
+//    - font-src     → web fonts
+//    - frame-src    → iframes, embeds
+// 2. Also update `images.remotePatterns` in next.config.ts if Next.js <Image>
+//    uses the new domain.
+// 3. Run `npm test` to confirm the header definitions are valid.
+// 4. Rebuild and verify with: curl -sI https://your-deployment.url | grep -i 'content-security-policy'
+//
+// To harden script-src with nonces in the future:
+//   - Remove 'unsafe-inline' from script-src
+//   - Generate a per-request nonce in middleware (src/middleware.ts)
+//   - Pass the nonce to the layout via request headers or React context
+//   - The nonce will appear in CSP as: script-src 'nonce-{random}' 'strict-dynamic'
+// ──────────────────────────────────────────────────────────────────────────────
+
+export const CSP_DIRECTIVES: Record<string, string> = {
+    'default-src': "'self'",
+    'script-src': "'self' 'unsafe-eval' 'unsafe-inline'",
+    'style-src': "'self' 'unsafe-inline'",
+    'img-src':
+        "'self' data: blob: "
+        + 'tse1.mm.bing.net tse3.mm.bing.net tse4.mm.bing.net '
+        + 'www.scholarshipregion.com '
+        + 'gateway.pinata.cloud ipfs.io *.ipfs.dweb.link res.cloudinary.com',
+    'media-src': "'self' gateway.pinata.cloud ipfs.io *.ipfs.dweb.link res.cloudinary.com",
+    'connect-src':
+        "'self' "
+        + '*.supabase.co '
+        + 'https://horizon-testnet.stellar.org https://soroban-testnet.stellar.org '
+        + 'https://horizon.stellar.org https://soroban-mainnet.stellar.org '
+        + 'https://gateway.pinata.cloud https://ipfs.io https://api.pinata.cloud',
+    'frame-ancestors': "'none'",
+    'form-action': "'self'",
+    'base-uri': "'self'",
+};
+
+export function buildCspString(): string {
+    return Object.entries(CSP_DIRECTIVES)
+        .map(([directive, value]) => `${directive} ${value}`)
+        .join('; ');
+}
+
+export function buildPermissionsPolicy(): string {
+    return [
+        'camera=(self)',
+        'clipboard-write=(self)',
+        'display-capture=(self)',
+        'microphone=()',
+        'geolocation=()',
+    ].join(', ');
+}
+
+export interface HeaderGroup {
+    source: string;
+    headers: SecurityHeader[];
+}
+
+export function buildSecurityHeaders(isProduction: boolean): HeaderGroup[] {
+    const headers: SecurityHeader[] = [
+        { key: 'Content-Security-Policy', value: buildCspString() },
+        { key: 'X-Frame-Options', value: 'DENY' },
+        { key: 'X-Content-Type-Options', value: 'nosniff' },
+        { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        { key: 'Permissions-Policy', value: buildPermissionsPolicy() },
+    ];
+
+    if (isProduction) {
+        headers.push({
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+        });
+    }
+
+    return [{ source: '/(.*)', headers }];
+}

--- a/frontend/tests/security-headers.test.ts
+++ b/frontend/tests/security-headers.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from 'vitest';
+import {
+    CSP_DIRECTIVES,
+    buildCspString,
+    buildPermissionsPolicy,
+    buildSecurityHeaders,
+} from '../src/lib/securityHeaders';
+
+const REQUIRED_DIRECTIVES = [
+    'default-src',
+    'script-src',
+    'style-src',
+    'img-src',
+    'media-src',
+    'connect-src',
+    'frame-ancestors',
+    'form-action',
+    'base-uri',
+] as const;
+
+const STELLAR_ENDPOINTS = [
+    'horizon-testnet.stellar.org',
+    'soroban-testnet.stellar.org',
+    'horizon.stellar.org',
+    'soroban-mainnet.stellar.org',
+];
+
+const IMAGE_DOMAINS = [
+    'tse1.mm.bing.net',
+    'tse3.mm.bing.net',
+    'tse4.mm.bing.net',
+    'www.scholarshipregion.com',
+    'gateway.pinata.cloud',
+    'ipfs.io',
+    'res.cloudinary.com',
+];
+
+const IPFS_DOMAINS = [
+    'gateway.pinata.cloud',
+    'ipfs.io',
+    '*.ipfs.dweb.link',
+];
+
+describe('CSP directives', () => {
+    it('includes all required directives', () => {
+        for (const directive of REQUIRED_DIRECTIVES) {
+            expect(CSP_DIRECTIVES).toHaveProperty(directive);
+        }
+    });
+
+    it('has no unknown directives (typo guard)', () => {
+        const known = new Set(REQUIRED_DIRECTIVES);
+        for (const key of Object.keys(CSP_DIRECTIVES)) {
+            expect(known.has(key as typeof REQUIRED_DIRECTIVES[number])).toBe(true);
+        }
+    });
+
+    it('uses single-quoted keywords correctly', () => {
+        for (const value of Object.values(CSP_DIRECTIVES)) {
+            for (const keyword of ['self', 'none', 'unsafe-inline', 'unsafe-eval']) {
+                if (value.includes(keyword)) {
+                    expect(value).toContain(`'${keyword}'`);
+                }
+            }
+        }
+    });
+});
+
+describe('script-src', () => {
+    it('allows self, unsafe-eval, and unsafe-inline (practical baseline)', () => {
+        const value = CSP_DIRECTIVES['script-src'];
+        expect(value).toContain("'self'");
+        expect(value).toContain("'unsafe-eval'");
+        expect(value).toContain("'unsafe-inline'");
+    });
+});
+
+describe('img-src', () => {
+    it('allows self, data:, and blob:', () => {
+        const value = CSP_DIRECTIVES['img-src'];
+        expect(value).toContain("'self'");
+        expect(value).toContain('data:');
+        expect(value).toContain('blob:');
+    });
+
+    it('allows all known image CDNs', () => {
+        const value = CSP_DIRECTIVES['img-src'];
+        for (const domain of IMAGE_DOMAINS) {
+            expect(value).toContain(domain);
+        }
+    });
+
+    it('allows IPFS gateways', () => {
+        const value = CSP_DIRECTIVES['img-src'];
+        for (const domain of IPFS_DOMAINS) {
+            expect(value).toContain(domain);
+        }
+    });
+});
+
+describe('media-src', () => {
+    it('allows self and IPFS gateways', () => {
+        const value = CSP_DIRECTIVES['media-src'];
+        expect(value).toContain("'self'");
+        for (const domain of IPFS_DOMAINS) {
+            expect(value).toContain(domain);
+        }
+    });
+
+    it('allows res.cloudinary.com for hero video', () => {
+        expect(CSP_DIRECTIVES['media-src']).toContain('res.cloudinary.com');
+    });
+});
+
+describe('connect-src', () => {
+    it('allows self and Supabase', () => {
+        const value = CSP_DIRECTIVES['connect-src'];
+        expect(value).toContain("'self'");
+        expect(value).toContain('*.supabase.co');
+    });
+
+    it('allows all Stellar endpoints', () => {
+        const value = CSP_DIRECTIVES['connect-src'];
+        for (const endpoint of STELLAR_ENDPOINTS) {
+            expect(value).toContain(endpoint);
+        }
+    });
+
+    it('allows IPFS gateways and Pinata API', () => {
+        const value = CSP_DIRECTIVES['connect-src'];
+        // *.ipfs.dweb.link is for media/img, not connect; only explicit gateway domains go here.
+        for (const domain of ['gateway.pinata.cloud', 'ipfs.io', 'api.pinata.cloud']) {
+            expect(value).toContain(domain);
+        }
+    });
+});
+
+describe('frame-ancestors', () => {
+    it('blocks all framing', () => {
+        expect(CSP_DIRECTIVES['frame-ancestors']).toBe("'none'");
+    });
+});
+
+describe('form-action', () => {
+    it('restricts to self', () => {
+        expect(CSP_DIRECTIVES['form-action']).toBe("'self'");
+    });
+});
+
+describe('base-uri', () => {
+    it('restricts to self', () => {
+        expect(CSP_DIRECTIVES['base-uri']).toBe("'self'");
+    });
+});
+
+describe('buildCspString', () => {
+    it('produces a valid CSP header string', () => {
+        const csp = buildCspString();
+        expect(csp).toBeTruthy();
+
+        // Each directive should be separated by "; "
+        const parts = csp.split('; ');
+        expect(parts.length).toBe(Object.keys(CSP_DIRECTIVES).length);
+
+        // Each part should be "directive value"
+        for (const part of parts) {
+            expect(part).toMatch(/^[a-z-]+ .+/);
+        }
+    });
+
+    it('round-trips directives correctly', () => {
+        const csp = buildCspString();
+        const parts = csp.split('; ');
+        for (const part of parts) {
+            const [directive] = part.split(' ');
+            expect(CSP_DIRECTIVES[directive]).toBe(part.slice(directive.length + 1));
+        }
+    });
+});
+
+describe('buildPermissionsPolicy', () => {
+    it('allows camera and clipboard-write for self', () => {
+        const policy = buildPermissionsPolicy();
+        expect(policy).toContain('camera=(self)');
+        expect(policy).toContain('clipboard-write=(self)');
+    });
+
+    it('disables microphone and geolocation', () => {
+        const policy = buildPermissionsPolicy();
+        expect(policy).toContain('microphone=()');
+        expect(policy).toContain('geolocation=()');
+    });
+
+    it('is a comma-separated list', () => {
+        const policy = buildPermissionsPolicy();
+        expect(policy).toMatch(/^[a-z-]+=\([^)]*\)(, [a-z-]+=\([^)]*\))*$/);
+    });
+});
+
+describe('buildSecurityHeaders', () => {
+    it('includes all required headers in development', () => {
+        const groups = buildSecurityHeaders(false);
+        const headers = groups[0].headers;
+        const keys = headers.map((h) => h.key);
+
+        expect(keys).toContain('Content-Security-Policy');
+        expect(keys).toContain('X-Frame-Options');
+        expect(keys).toContain('X-Content-Type-Options');
+        expect(keys).toContain('Referrer-Policy');
+        expect(keys).toContain('Permissions-Policy');
+    });
+
+    it('excludes HSTS in development', () => {
+        const groups = buildSecurityHeaders(false);
+        const keys = groups[0].headers.map((h) => h.key);
+        expect(keys).not.toContain('Strict-Transport-Security');
+    });
+
+    it('includes HSTS in production', () => {
+        const groups = buildSecurityHeaders(true);
+        const keys = groups[0].headers.map((h) => h.key);
+        expect(keys).toContain('Strict-Transport-Security');
+    });
+
+    it('sets HSTS with secure values in production', () => {
+        const groups = buildSecurityHeaders(true);
+        const hsts = groups[0].headers.find(
+            (h) => h.key === 'Strict-Transport-Security',
+        );
+        expect(hsts).toBeDefined();
+        expect(hsts!.value).toMatch(/max-age=\d+/);
+        expect(hsts!.value).toContain('includeSubDomains');
+    });
+
+    it('has X-Frame-Options set to DENY', () => {
+        const groups = buildSecurityHeaders(false);
+        const header = groups[0].headers.find((h) => h.key === 'X-Frame-Options');
+        expect(header?.value).toBe('DENY');
+    });
+
+    it('has X-Content-Type-Options set to nosniff', () => {
+        const groups = buildSecurityHeaders(false);
+        const header = groups[0].headers.find(
+            (h) => h.key === 'X-Content-Type-Options',
+        );
+        expect(header?.value).toBe('nosniff');
+    });
+
+    it('has Referrer-Policy set to strict-origin-when-cross-origin', () => {
+        const groups = buildSecurityHeaders(false);
+        const header = groups[0].headers.find((h) => h.key === 'Referrer-Policy');
+        expect(header?.value).toBe('strict-origin-when-cross-origin');
+    });
+
+    it('has a single header group targeting all routes', () => {
+        const groups = buildSecurityHeaders(false);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].source).toBe('/(.*)');
+    });
+});


### PR DESCRIPTION
Closes #80

Adds browser-level security hardening via Next.js `headers()` with a Content Security Policy (9 directives), X-Frame-Options: DENY, X-Content-Type-Options: nosniff, Referrer-Policy, Permissions-Policy, and HSTS. Includes 28-unit test suite and a manual check script.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger browser security protections for the app, including stricter page, framing, and referrer handling.
  * Expanded support for loading images and media from additional remote sources.

* **Bug Fixes**
  * Improved consistency of security settings between development and production environments.
  * Added validation to help ensure security headers are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->