### PR TITLE
Enhance network handling with mainnet checks and testnet status UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,11 +719,14 @@ npm start
 
 Before deploying to production:
 
+- **Switch to Mainnet**: Set `NEXT_PUBLIC_STELLAR_NETWORK=mainnet` in your production environment variables to point the application to the live Stellar network.
+- **Update Contract Addresses**: Ensure `NEXT_PUBLIC_CREDENTIAL_NFT_CONTRACT` and `NEXT_PUBLIC_CREDENTIAL_REGISTRY_CONTRACT` are updated to your verified mainnet deployment IDs. (The app will fail to boot if it detects the known testnet contract on mainnet).
 - Use Stellar Public Network values only after contract review and a verified mainnet deployment.
 - Rotate any secret that was pasted into chat, screenshots, logs, browser code, or an issue.
 - Set server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `PINATA_JWT`, Stellar secret keys) only in the hosting provider's protected environment variables.
 - Confirm Supabase RLS is enabled and production policies come from `frontend/sql/FULL_SETUP.sql`.
 - Verify contract IDs on Stellar Expert before pointing users at a production environment.
+
 
 ---
 

--- a/frontend/src/components/dashboard/DashboardShell.tsx
+++ b/frontend/src/components/dashboard/DashboardShell.tsx
@@ -7,6 +7,7 @@ import { LogOut } from 'lucide-react';
 import { ConnectWallet } from '@/components/ui/ConnectWallet';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { activeNetwork } from '@/lib/stellar';
 
 interface DashboardTopbarProps {
     brandBadge?: string;
@@ -42,9 +43,16 @@ export function DashboardTopbar({
                         height={34}
                         className="h-8 w-8 object-contain"
                     />
-                    <span className="text-lg font-bold tracking-tight text-foreground">
-                        Acredia
-                    </span>
+                    <div className="flex flex-col">
+                        <span className="text-lg font-bold leading-none tracking-tight text-foreground">
+                            Acredia
+                        </span>
+                        {activeNetwork.kind === 'testnet' && (
+                            <span className="mt-1 w-fit rounded-sm bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-amber-600">
+                                Testnet
+                            </span>
+                        )}
+                    </div>
                     {brandBadge && (
                         <span
                             className={cn(

--- a/frontend/src/components/marketing/SiteNavbar.tsx
+++ b/frontend/src/components/marketing/SiteNavbar.tsx
@@ -7,6 +7,7 @@ import { usePathname } from 'next/navigation';
 import { Building2, ChevronDown, GraduationCap, Menu, ShieldCheck, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { activeNetwork } from '@/lib/stellar';
 
 const solutions = [
     {
@@ -74,9 +75,16 @@ export function SiteNavbar() {
                         className="h-9 w-9 object-contain"
                         priority
                     />
-                    <span className="text-lg font-bold tracking-tight text-foreground">
-                        Acredia
-                    </span>
+                    <div className="flex flex-col">
+                        <span className="text-lg font-bold leading-none tracking-tight text-foreground">
+                            Acredia
+                        </span>
+                        {activeNetwork.kind === 'testnet' && (
+                            <span className="mt-1 w-fit rounded-sm bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-amber-600">
+                                Testnet
+                            </span>
+                        )}
+                    </div>
                 </Link>
 
                 {/* Desktop nav */}

--- a/frontend/src/lib/runtimeConfig.ts
+++ b/frontend/src/lib/runtimeConfig.ts
@@ -195,10 +195,16 @@ function buildStellarConfig(isProduction: boolean): StellarNetworkConfig {
     };
 }
 
-function readContractId(name: ContractName, envName: string, isProduction: boolean): string {
+function readContractId(name: ContractName, envName: string, isProduction: boolean, networkKind: StellarNetworkKind): string {
     const value = requireProductionValue(envName, readEnv(envName), isProduction);
     if (value && !StrKey.isValidContract(value)) {
         configError(`${envName} must be a valid Stellar contract ID for ${name}.`);
+    }
+
+    // Fail fast if a known testnet contract is used on mainnet
+    const KNOWN_TESTNET_CONTRACT = 'CARWFW27MJ3OJADAUAHI3TDFHIL62YMLVEKTUTMSNXOMH7JJTNZKC3DK';
+    if (networkKind === 'mainnet' && value === KNOWN_TESTNET_CONTRACT) {
+        configError(`Cannot use the known testnet contract ${value} on mainnet for ${name}. Update your environment variables.`);
     }
 
     return value;
@@ -225,23 +231,27 @@ function buildRuntimeConfig(): RuntimeConfig {
     );
     const debugFlag = debugFlagSchema.safeParse(readEnv('NEXT_PUBLIC_ENABLE_DEBUG_LOGS'));
 
+    const stellar = buildStellarConfig(isProduction);
+    
     return {
         isProduction,
         supabase: {
             url: parseHttpUrl('NEXT_PUBLIC_SUPABASE_URL', supabaseUrl),
             anonKey: supabaseAnonKey,
         },
-        stellar: buildStellarConfig(isProduction),
+        stellar,
         contracts: {
             CREDENTIAL_NFT: readContractId(
                 'CREDENTIAL_NFT',
                 'NEXT_PUBLIC_CREDENTIAL_NFT_CONTRACT',
                 isProduction,
+                stellar.kind
             ),
             CREDENTIAL_REGISTRY: readContractId(
                 'CREDENTIAL_REGISTRY',
                 'NEXT_PUBLIC_CREDENTIAL_REGISTRY_CONTRACT',
                 isProduction,
+                stellar.kind
             ),
         },
         ipfs: {


### PR DESCRIPTION
Closes #90 

This pull request introduces important improvements to environment validation and UI clarity around network selection. It ensures that testnet contract addresses cannot be mistakenly used in mainnet deployments, and adds a clear "Testnet" badge to the UI when running on testnet. These changes reduce the risk of misconfiguration and improve user awareness of the current network context.

**Environment and Configuration Validation:**

* Added a validation step in `readContractId` (in `frontend/src/lib/runtimeConfig.ts`) to prevent deploying with a known testnet contract address (`CARWFW27MJ3OJADAUAHI3TDFHIL62YMLVEKTUTMSNXOMH7JJTNZKC3DK`) on mainnet, causing the app to fail fast if misconfigured.
* Updated `buildRuntimeConfig` to pass the detected network kind to contract ID validation, ensuring environment variables match the intended network.
* Updated the production checklist in `README.md` to explicitly require setting the network and contract addresses for mainnet, and warns that the app will fail to boot if a known testnet contract is detected on mainnet.

**User Interface Improvements:**

* Updated both `DashboardTopbar` and `SiteNavbar` components to display a prominent "Testnet" badge in the header when running on testnet, using the `activeNetwork` context. [[1]](diffhunk://#diff-4fab9376ea3e086d4de71a0bcf45af6af738df3948a686c0617c72e2769174bdR10) [[2]](diffhunk://#diff-4fab9376ea3e086d4de71a0bcf45af6af738df3948a686c0617c72e2769174bdL45-R55) [[3]](diffhunk://#diff-97c6099ccc6c2809ccc7cdcf847761abcfd95c89013d7cb59e138ec3d953048dR10) [[4]](diffhunk://#diff-97c6099ccc6c2809ccc7cdcf847761abcfd95c89013d7cb59e138ec3d953048dL77-R87)

These changes collectively enhance deployment safety and user awareness of the current Stellar network.