### PR TITLE
feat: institution analytics dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
                 "react-dom": "^19.2.6",
                 "react-hook-form": "^7.77.0",
                 "react-hot-toast": "^2.6.0",
+                "recharts": "^3.10.1",
                 "sonner": "^2.0.7",
                 "tailwind-merge": "^3.6.0",
                 "zod": "^4.4.3"
@@ -2385,6 +2386,32 @@
             "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
             "license": "MIT"
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+            "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
@@ -2660,7 +2687,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@standard-schema/utils": {
@@ -3193,6 +3219,69 @@
                 "assertion-error": "^2.0.1"
             }
         },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "license": "MIT"
+        },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3267,6 +3356,12 @@
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.62.0",
@@ -4701,6 +4796,127 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4797,6 +5013,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -5148,6 +5370,17 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/es-toolkit": {
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks",
+                "tests/types"
+            ]
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -5796,6 +6029,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
         },
         "node_modules/eventsource": {
             "version": "2.0.2",
@@ -6469,6 +6708,16 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "11.1.15",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+            "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6515,6 +6764,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/is-array-buffer": {
@@ -8378,6 +8636,29 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/react-redux": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+            "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-remove-scroll": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
@@ -8447,6 +8728,51 @@
                 }
             }
         },
+        "node_modules/recharts": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+            "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+            "license": "MIT",
+            "workspaces": [
+                "www"
+            ],
+            "dependencies": {
+                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^11.1.8",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.2.0",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
+            }
+        },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8505,6 +8831,12 @@
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "license": "ISC"
+        },
+        "node_modules/reselect": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+            "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "2.0.0-next.7",
@@ -9280,6 +9612,12 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
+        },
         "node_modules/tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9722,6 +10060,28 @@
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "license": "MIT AND ISC",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
         "react-dom": "^19.2.6",
         "react-hook-form": "^7.77.0",
         "react-hot-toast": "^2.6.0",
+        "recharts": "^3.10.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.4.3"

--- a/frontend/src/app/api/institution/analytics/route.ts
+++ b/frontend/src/app/api/institution/analytics/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+    getServiceRoleClient,
+    hasServiceRoleEnv,
+    requireAuthenticatedRequest,
+} from '@/lib/serverAuth';
+import { last12Months, groupByMonth, fillMonths, topVerified } from '@/lib/analyticsAggregation';
+import { captureException, structuredLog } from '@/lib/debug';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+    const requestId = request.headers.get('x-request-id') ?? 'unknown';
+    try {
+        const authCheck = await requireAuthenticatedRequest(request);
+        if (!authCheck.ok) {
+            return NextResponse.json(
+                { success: false, error: authCheck.error },
+                { status: authCheck.status },
+            );
+        }
+
+        const supabase = hasServiceRoleEnv()
+            ? getServiceRoleClient()
+            : (() => {
+                  throw new Error('Service role key required');
+              })();
+
+        const { data: inst, error: instErr } = await supabase
+            .from('institutions')
+            .select('id')
+            .eq('auth_user_id', authCheck.userId)
+            .maybeSingle();
+
+        if (instErr) {
+            structuredLog('ERROR', 'Error fetching institution for analytics', requestId, {
+                error: instErr,
+            });
+            return NextResponse.json(
+                { success: false, error: 'Failed to load institution profile' },
+                { status: 500 },
+            );
+        }
+        if (!inst?.id) {
+            return NextResponse.json(
+                { success: false, error: 'Institution not found' },
+                { status: 404 },
+            );
+        }
+
+        // Fetch credentials — lightweight select, no pagination (analytics needs full set)
+        // TODO: swap this query to the indexer once issue #11 is implemented
+        const { data: credentials, error: credErr } = await supabase
+            .from('credentials')
+            .select('id, token_id, issued_at, revoked, metadata')
+            .eq('institution_id', inst.id);
+
+        if (credErr) throw credErr;
+
+        const creds = credentials ?? [];
+        const months = last12Months();
+
+        const issuedOverTime = fillMonths(groupByMonth(creds.map((c) => c.issued_at)), months);
+        const active = creds.filter((c) => !c.revoked).length;
+        const statusBreakdown = { active, revoked: creds.length - active, total: creds.length };
+
+        let verificationsOverTime: { month: string; count: number }[] = months.map((m) => ({
+            month: m,
+            count: 0,
+        }));
+        let topVerifiedCredentials: {
+            tokenId: string;
+            credentialType: string;
+            studentName: string;
+            count: number;
+        }[] = [];
+
+        if (creds.length > 0) {
+            const credIds = creds.map((c) => c.id);
+            const { data: logs, error: logsErr } = await supabase
+                .from('verification_logs')
+                .select('credential_id, created_at')
+                .in('credential_id', credIds);
+
+            if (logsErr) throw logsErr;
+
+            const logRows = logs ?? [];
+            verificationsOverTime = fillMonths(
+                groupByMonth(logRows.map((l) => l.created_at ?? '')),
+                months,
+            );
+
+            const credMap = new Map(
+                creds.map((c) => [
+                    c.id,
+                    {
+                        tokenId: c.token_id,
+                        credentialType:
+                            (c.metadata as { credentialData?: { credentialType?: string } } | null)
+                                ?.credentialData?.credentialType ?? 'Unknown',
+                        studentName:
+                            (c.metadata as { credentialData?: { studentName?: string } } | null)
+                                ?.credentialData?.studentName ?? 'Unknown',
+                    },
+                ]),
+            );
+            topVerifiedCredentials = topVerified(logRows, credMap);
+        }
+
+        return NextResponse.json({
+            success: true,
+            issuedOverTime,
+            statusBreakdown,
+            verificationsOverTime,
+            topVerifiedCredentials,
+        });
+    } catch (err) {
+        captureException(err, { requestId, context: 'GET /api/institution/analytics' });
+        return NextResponse.json(
+            { success: false, error: 'Failed to fetch analytics' },
+            { status: 500 },
+        );
+    }
+}

--- a/frontend/src/app/api/institution/analytics/route.ts
+++ b/frontend/src/app/api/institution/analytics/route.ts
@@ -50,6 +50,7 @@ export async function GET(request: NextRequest) {
 
         // Fetch credentials — lightweight select, no pagination (analytics needs full set)
         // TODO: swap this query to the indexer once issue #11 is implemented
+        // Note: the subsequent .in('credential_id', credIds) is unbounded; safe up to ~500 credentials
         const { data: credentials, error: credErr } = await supabase
             .from('credentials')
             .select('id, token_id, issued_at, revoked, metadata')

--- a/frontend/src/app/api/institution/export/route.ts
+++ b/frontend/src/app/api/institution/export/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+    getServiceRoleClient,
+    hasServiceRoleEnv,
+    requireAuthenticatedRequest,
+} from '@/lib/serverAuth';
+import { toCsv } from '@/lib/analyticsAggregation';
+import { captureException, structuredLog } from '@/lib/debug';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+    const requestId = request.headers.get('x-request-id') ?? 'unknown';
+    try {
+        const authCheck = await requireAuthenticatedRequest(request);
+        if (!authCheck.ok) {
+            return NextResponse.json(
+                { success: false, error: authCheck.error },
+                { status: authCheck.status },
+            );
+        }
+
+        const supabase = hasServiceRoleEnv()
+            ? getServiceRoleClient()
+            : (() => {
+                  throw new Error('Service role key required');
+              })();
+
+        const { data: inst, error: instErr } = await supabase
+            .from('institutions')
+            .select('id')
+            .eq('auth_user_id', authCheck.userId)
+            .maybeSingle();
+
+        if (instErr) {
+            structuredLog('ERROR', 'Error fetching institution for export', requestId, {
+                error: instErr,
+            });
+            return NextResponse.json(
+                { success: false, error: 'Failed to load institution profile' },
+                { status: 500 },
+            );
+        }
+        if (!inst?.id) {
+            return NextResponse.json(
+                { success: false, error: 'Institution not found' },
+                { status: 404 },
+            );
+        }
+
+        const { data: credentials, error: credErr } = await supabase
+            .from('credentials')
+            .select('token_id, issued_at, revoked, metadata')
+            .eq('institution_id', inst.id)
+            .order('issued_at', { ascending: false });
+
+        if (credErr) throw credErr;
+
+        const csv = toCsv(credentials ?? []);
+        return new NextResponse(csv, {
+            status: 200,
+            headers: {
+                'Content-Type': 'text/csv',
+                'Content-Disposition': 'attachment; filename="credentials.csv"',
+            },
+        });
+    } catch (err) {
+        captureException(err, { requestId, context: 'GET /api/institution/export' });
+        return NextResponse.json(
+            { success: false, error: 'Failed to export credentials' },
+            { status: 500 },
+        );
+    }
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, List, Shield, Upload, User, Wallet } from 'lucide-react';
+import { ArrowRight, BarChart2, List, Shield, Upload, User, Wallet } from 'lucide-react';
 import { toast } from 'sonner';
 import { DashboardShell } from '@/components/dashboard/DashboardShell';
 import { CredentialUploadForm } from '@/components/institution/CredentialUploadForm';
+import { InstitutionAnalytics } from '@/components/institution/InstitutionAnalytics';
 import { IssuedCredentialsList } from '@/components/institution/IssuedCredentialsList';
 import StudentCredentialsList from '@/components/student/StudentCredentialsList';
 import { Card } from '@/components/ui/card';
@@ -261,7 +262,7 @@ function DashboardContent() {
 
                     {institutionId && (
                         <Tabs defaultValue="issue" className="w-full">
-                            <TabsList className="grid w-full max-w-md grid-cols-2">
+                            <TabsList className="grid w-full max-w-lg grid-cols-3">
                                 <TabsTrigger value="issue" className="gap-2">
                                     <Upload className="h-4 w-4" />
                                     Issue credential
@@ -269,6 +270,10 @@ function DashboardContent() {
                                 <TabsTrigger value="view" className="gap-2">
                                     <List className="h-4 w-4" />
                                     View issued
+                                </TabsTrigger>
+                                <TabsTrigger value="analytics" className="gap-2">
+                                    <BarChart2 className="h-4 w-4" />
+                                    Analytics
                                 </TabsTrigger>
                             </TabsList>
 
@@ -287,6 +292,10 @@ function DashboardContent() {
                                     institutionId={institutionId}
                                     refreshTrigger={refreshTrigger}
                                 />
+                            </TabsContent>
+
+                            <TabsContent value="analytics" className="mt-6">
+                                <InstitutionAnalytics />
                             </TabsContent>
                         </Tabs>
                     )}

--- a/frontend/src/components/institution/InstitutionAnalytics.tsx
+++ b/frontend/src/components/institution/InstitutionAnalytics.tsx
@@ -114,7 +114,9 @@ export function InstitutionAnalytics() {
             const a = document.createElement('a');
             a.href = url;
             a.download = 'credentials.csv';
+            document.body.appendChild(a);
             a.click();
+            document.body.removeChild(a);
             setTimeout(() => URL.revokeObjectURL(url), 100);
             toast.success('Export downloaded');
         } catch (err) {

--- a/frontend/src/components/institution/InstitutionAnalytics.tsx
+++ b/frontend/src/components/institution/InstitutionAnalytics.tsx
@@ -115,7 +115,7 @@ export function InstitutionAnalytics() {
             a.href = url;
             a.download = 'credentials.csv';
             a.click();
-            URL.revokeObjectURL(url);
+            setTimeout(() => URL.revokeObjectURL(url), 100);
             toast.success('Export downloaded');
         } catch (err) {
             captureException(err, { context: 'InstitutionAnalytics.export' });

--- a/frontend/src/components/institution/InstitutionAnalytics.tsx
+++ b/frontend/src/components/institution/InstitutionAnalytics.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    Tooltip,
+    ResponsiveContainer,
+    CartesianGrid,
+} from 'recharts';
+import { CheckCircle, Download, Eye, TrendingUp, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { captureException } from '@/lib/debug';
+import { safeGetSession } from '@/lib/supabase';
+import { toast } from 'sonner';
+
+interface AnalyticsData {
+    issuedOverTime: { month: string; count: number }[];
+    statusBreakdown: { active: number; revoked: number; total: number };
+    verificationsOverTime: { month: string; count: number }[];
+    topVerifiedCredentials: {
+        tokenId: string;
+        credentialType: string;
+        studentName: string;
+        count: number;
+    }[];
+}
+
+function StatCard({
+    label,
+    value,
+    icon,
+}: {
+    label: string;
+    value: number;
+    icon: React.ReactNode;
+}) {
+    return (
+        <div className="rounded-xl border border-border bg-secondary/40 p-4">
+            <div className="mb-1 flex items-center gap-2">
+                <span className="text-muted-foreground">{icon}</span>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {label}
+                </p>
+            </div>
+            <p className="text-2xl font-bold text-foreground">{value}</p>
+        </div>
+    );
+}
+
+export function InstitutionAnalytics() {
+    const [data, setData] = useState<AnalyticsData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [mounted, setMounted] = useState(false);
+    const [exporting, setExporting] = useState(false);
+
+    // Guard recharts from SSR — only render charts after client mount
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    useEffect(() => {
+        async function load() {
+            try {
+                const {
+                    data: { session },
+                } = await safeGetSession();
+                if (!session?.access_token) {
+                    setLoading(false);
+                    return;
+                }
+                const res = await fetch('/api/institution/analytics', {
+                    headers: { Authorization: `Bearer ${session.access_token}` },
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) {
+                    throw new Error(json.error ?? 'Failed to load analytics');
+                }
+                setData(json);
+            } catch (err) {
+                captureException(err, { context: 'InstitutionAnalytics.load' });
+                setError(err instanceof Error ? err.message : 'Failed to load analytics');
+            } finally {
+                setLoading(false);
+            }
+        }
+        load();
+    }, []);
+
+    const handleExport = async () => {
+        setExporting(true);
+        try {
+            const {
+                data: { session },
+            } = await safeGetSession();
+            if (!session?.access_token) {
+                toast.error('Not authenticated');
+                return;
+            }
+            const res = await fetch('/api/institution/export', {
+                headers: { Authorization: `Bearer ${session.access_token}` },
+            });
+            if (!res.ok) {
+                toast.error('Export failed');
+                return;
+            }
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'credentials.csv';
+            a.click();
+            URL.revokeObjectURL(url);
+            toast.success('Export downloaded');
+        } catch (err) {
+            captureException(err, { context: 'InstitutionAnalytics.export' });
+            toast.error('Export failed');
+        } finally {
+            setExporting(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="space-y-6">
+                <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                    {[0, 1, 2, 3].map((i) => (
+                        <Skeleton key={i} className="h-20 rounded-xl" />
+                    ))}
+                </div>
+                <Skeleton className="h-64 rounded-xl" />
+                <Skeleton className="h-64 rounded-xl" />
+                <Skeleton className="h-48 rounded-xl" />
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <Card className="p-8 text-center">
+                <p className="text-destructive">{error}</p>
+            </Card>
+        );
+    }
+
+    if (!data) return null;
+
+    const { statusBreakdown, issuedOverTime, verificationsOverTime, topVerifiedCredentials } = data;
+    const totalVerifications = verificationsOverTime.reduce((s, r) => s + r.count, 0);
+
+    return (
+        <div className="space-y-6">
+            {/* Summary stats */}
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                <StatCard
+                    label="Total issued"
+                    value={statusBreakdown.total}
+                    icon={<TrendingUp className="h-4 w-4" />}
+                />
+                <StatCard
+                    label="Active"
+                    value={statusBreakdown.active}
+                    icon={<CheckCircle className="h-4 w-4 text-success" />}
+                />
+                <StatCard
+                    label="Revoked"
+                    value={statusBreakdown.revoked}
+                    icon={<XCircle className="h-4 w-4 text-destructive" />}
+                />
+                <StatCard
+                    label="Verifications"
+                    value={totalVerifications}
+                    icon={<Eye className="h-4 w-4" />}
+                />
+            </div>
+
+            {/* Issued over time */}
+            <Card className="p-6">
+                <h3 className="mb-4 text-base font-semibold text-foreground">
+                    Credentials issued (last 12 months)
+                </h3>
+                {mounted && (
+                    <ResponsiveContainer width="100%" height={220}>
+                        <BarChart data={issuedOverTime}>
+                            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                            <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+                            <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                            <Tooltip />
+                            <Bar dataKey="count" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+                        </BarChart>
+                    </ResponsiveContainer>
+                )}
+            </Card>
+
+            {/* Verifications over time */}
+            <Card className="p-6">
+                <h3 className="mb-4 text-base font-semibold text-foreground">
+                    Verifications (last 12 months)
+                </h3>
+                {mounted && (
+                    <ResponsiveContainer width="100%" height={220}>
+                        <BarChart data={verificationsOverTime}>
+                            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                            <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+                            <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                            <Tooltip />
+                            <Bar dataKey="count" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+                        </BarChart>
+                    </ResponsiveContainer>
+                )}
+            </Card>
+
+            {/* Top verified credentials + CSV export */}
+            <Card className="p-6">
+                <div className="mb-4 flex items-center justify-between">
+                    <h3 className="text-base font-semibold text-foreground">
+                        Most verified credentials
+                    </h3>
+                    <Button variant="outline" size="sm" onClick={handleExport} disabled={exporting}>
+                        <Download className="mr-2 h-4 w-4" />
+                        {exporting ? 'Exporting...' : 'Export CSV'}
+                    </Button>
+                </div>
+                {topVerifiedCredentials.length === 0 ? (
+                    <p className="py-4 text-sm text-muted-foreground">
+                        No verifications recorded yet.
+                    </p>
+                ) : (
+                    <div className="space-y-3">
+                        {topVerifiedCredentials.map((cred, i) => (
+                            <div
+                                key={cred.tokenId}
+                                className="flex items-center justify-between rounded-lg border border-border p-3"
+                            >
+                                <div className="flex items-center gap-3">
+                                    <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
+                                        {i + 1}
+                                    </span>
+                                    <div>
+                                        <p className="text-sm font-medium text-foreground">
+                                            {cred.studentName}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                            {cred.credentialType}
+                                        </p>
+                                    </div>
+                                </div>
+                                <span className="text-sm font-semibold text-foreground">
+                                    {cred.count} verif.
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </Card>
+        </div>
+    );
+}

--- a/frontend/src/lib/analyticsAggregation.ts
+++ b/frontend/src/lib/analyticsAggregation.ts
@@ -1,0 +1,93 @@
+export function last12Months(): string[] {
+    const months: string[] = [];
+    const now = new Date();
+    for (let i = 11; i >= 0; i--) {
+        const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`);
+    }
+    return months;
+}
+
+export function groupByMonth(dates: string[]): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const d of dates) {
+        const m = d.slice(0, 7);
+        counts[m] = (counts[m] ?? 0) + 1;
+    }
+    return counts;
+}
+
+export function fillMonths(
+    counts: Record<string, number>,
+    months: string[],
+): { month: string; count: number }[] {
+    return months.map((m) => ({ month: m, count: counts[m] ?? 0 }));
+}
+
+export interface TopCredential {
+    tokenId: string;
+    credentialType: string;
+    studentName: string;
+    count: number;
+}
+
+export function topVerified(
+    logs: { credential_id: string }[],
+    credMap: Map<string, { tokenId: string; credentialType: string; studentName: string }>,
+    limit = 5,
+): TopCredential[] {
+    const counts: Record<string, number> = {};
+    for (const log of logs) {
+        counts[log.credential_id] = (counts[log.credential_id] ?? 0) + 1;
+    }
+    return Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, limit)
+        .map(([credId, count]) => {
+            const c = credMap.get(credId);
+            return {
+                tokenId: c?.tokenId ?? credId,
+                credentialType: c?.credentialType ?? 'Unknown',
+                studentName: c?.studentName ?? 'Unknown',
+                count,
+            };
+        });
+}
+
+interface CsvCredential {
+    token_id: string;
+    issued_at: string;
+    revoked: boolean;
+    metadata: {
+        credentialData?: {
+            studentName?: string;
+            credentialType?: string;
+            degree?: string;
+            major?: string;
+            gpa?: string;
+            issueDate?: string;
+        };
+    } | null;
+}
+
+export function toCsv(credentials: CsvCredential[]): string {
+    const headers = ['token_id', 'student_name', 'credential_type', 'degree', 'major', 'gpa', 'issue_date', 'issued_at', 'status'];
+    const escape = (v: unknown) => `"${String(v ?? '').replace(/"/g, '""')}"`;
+    const rows = credentials.map((c) => {
+        const d = c.metadata?.credentialData ?? {};
+        return [
+            c.token_id,
+            d.studentName ?? '',
+            d.credentialType ?? '',
+            d.degree ?? '',
+            d.major ?? '',
+            d.gpa ?? '',
+            d.issueDate ?? '',
+            c.issued_at,
+            c.revoked ? 'revoked' : 'active',
+        ]
+            .map(escape)
+            .join(',');
+    });
+    return [headers.join(','), ...rows].join('\n');
+}

--- a/frontend/src/lib/analyticsAggregation.ts
+++ b/frontend/src/lib/analyticsAggregation.ts
@@ -11,6 +11,7 @@ export function last12Months(): string[] {
 export function groupByMonth(dates: string[]): Record<string, number> {
     const counts: Record<string, number> = {};
     for (const d of dates) {
+        if (d.length < 7) continue;
         const m = d.slice(0, 7);
         counts[m] = (counts[m] ?? 0) + 1;
     }

--- a/frontend/tests/analyticsAggregation.test.ts
+++ b/frontend/tests/analyticsAggregation.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import {
+    last12Months,
+    groupByMonth,
+    fillMonths,
+    topVerified,
+    toCsv,
+} from '../src/lib/analyticsAggregation';
+
+describe('last12Months', () => {
+    it('returns exactly 12 entries', () => {
+        expect(last12Months()).toHaveLength(12);
+    });
+
+    it('entries are in YYYY-MM format', () => {
+        for (const m of last12Months()) {
+            expect(m).toMatch(/^\d{4}-\d{2}$/);
+        }
+    });
+
+    it('last entry is the current month', () => {
+        const now = new Date();
+        const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+        const months = last12Months();
+        expect(months[months.length - 1]).toBe(expected);
+    });
+
+    it('entries are ascending', () => {
+        const months = last12Months();
+        for (let i = 1; i < months.length; i++) {
+            expect(months[i] > months[i - 1]).toBe(true);
+        }
+    });
+});
+
+describe('groupByMonth', () => {
+    it('counts ISO timestamps by YYYY-MM prefix', () => {
+        const dates = ['2025-01-15T10:00:00Z', '2025-01-20T10:00:00Z', '2025-02-05T10:00:00Z'];
+        expect(groupByMonth(dates)).toEqual({ '2025-01': 2, '2025-02': 1 });
+    });
+
+    it('returns empty object for empty input', () => {
+        expect(groupByMonth([])).toEqual({});
+    });
+});
+
+describe('fillMonths', () => {
+    it('fills missing months with 0', () => {
+        const counts = { '2025-01': 3 };
+        const months = ['2025-01', '2025-02', '2025-03'];
+        expect(fillMonths(counts, months)).toEqual([
+            { month: '2025-01', count: 3 },
+            { month: '2025-02', count: 0 },
+            { month: '2025-03', count: 0 },
+        ]);
+    });
+
+    it('returns empty array for empty months', () => {
+        expect(fillMonths({}, [])).toEqual([]);
+    });
+});
+
+describe('topVerified', () => {
+    const credMap = new Map([
+        ['cred-1', { tokenId: 'tok-1', credentialType: 'Degree', studentName: 'Alice' }],
+        ['cred-2', { tokenId: 'tok-2', credentialType: 'Certificate', studentName: 'Bob' }],
+    ]);
+
+    it('returns credentials sorted by verification count descending', () => {
+        const logs = [
+            { credential_id: 'cred-2' },
+            { credential_id: 'cred-2' },
+            { credential_id: 'cred-1' },
+        ];
+        const result = topVerified(logs, credMap);
+        expect(result[0].tokenId).toBe('tok-2');
+        expect(result[0].count).toBe(2);
+        expect(result[1].tokenId).toBe('tok-1');
+        expect(result[1].count).toBe(1);
+    });
+
+    it('respects the limit parameter', () => {
+        const logs = [
+            { credential_id: 'cred-1' },
+            { credential_id: 'cred-2' },
+        ];
+        expect(topVerified(logs, credMap, 1)).toHaveLength(1);
+    });
+
+    it('uses fallback values for unknown credential IDs', () => {
+        const logs = [{ credential_id: 'unknown-id' }];
+        const result = topVerified(logs, new Map());
+        expect(result[0].tokenId).toBe('unknown-id');
+        expect(result[0].studentName).toBe('Unknown');
+    });
+
+    it('returns empty array for no logs', () => {
+        expect(topVerified([], credMap)).toEqual([]);
+    });
+});
+
+describe('toCsv', () => {
+    it('produces a header row followed by data rows', () => {
+        const credentials = [
+            {
+                token_id: 'tok-1',
+                issued_at: '2025-01-15T10:00:00Z',
+                revoked: false,
+                metadata: {
+                    credentialData: {
+                        studentName: 'Alice',
+                        credentialType: 'Bachelor',
+                        degree: 'BSc',
+                        major: 'CS',
+                        gpa: '3.8',
+                        issueDate: '2025-01-15',
+                    },
+                },
+            },
+        ];
+        const csv = toCsv(credentials);
+        const lines = csv.split('\n');
+        expect(lines[0]).toBe('token_id,student_name,credential_type,degree,major,gpa,issue_date,issued_at,status');
+        expect(lines[1]).toContain('"tok-1"');
+        expect(lines[1]).toContain('"Alice"');
+        expect(lines[1]).toContain('"active"');
+    });
+
+    it('marks revoked credentials with status "revoked"', () => {
+        const credentials = [
+            {
+                token_id: 'tok-2',
+                issued_at: '2025-02-10T10:00:00Z',
+                revoked: true,
+                metadata: null,
+            },
+        ];
+        const csv = toCsv(credentials);
+        expect(csv).toContain('"revoked"');
+    });
+
+    it('escapes double-quotes in field values', () => {
+        const credentials = [
+            {
+                token_id: 'tok-3',
+                issued_at: '2025-03-01T10:00:00Z',
+                revoked: false,
+                metadata: { credentialData: { studentName: 'O"Brien' } },
+            },
+        ];
+        const csv = toCsv(credentials);
+        expect(csv).toContain('O""Brien');
+    });
+
+    it('returns only the header for empty input', () => {
+        const csv = toCsv([]);
+        expect(csv.trim()).toBe('token_id,student_name,credential_type,degree,major,gpa,issue_date,issued_at,status');
+    });
+});

--- a/frontend/tests/institutionAnalytics.test.ts
+++ b/frontend/tests/institutionAnalytics.test.ts
@@ -130,6 +130,7 @@ describe('GET /api/institution/analytics', () => {
         const body = await res.json();
         const mar = body.verificationsOverTime.find((r: { month: string; count: number }) => r.month === '2026-03');
         expect(mar?.count).toBe(2);
+        expect(mockLogsIn).toHaveBeenCalledWith('credential_id', ['c1']);
     });
 
     it('returns 500 when credential query throws', async () => {

--- a/frontend/tests/institutionAnalytics.test.ts
+++ b/frontend/tests/institutionAnalytics.test.ts
@@ -1,0 +1,146 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+    mockRequireAuthenticatedRequest,
+    mockHasServiceRoleEnv,
+    mockGetServiceRoleClient,
+    mockInstMaybeSingle,
+    mockCredEq,
+    mockLogsIn,
+} = vi.hoisted(() => ({
+    mockRequireAuthenticatedRequest: vi.fn(),
+    mockHasServiceRoleEnv: vi.fn(),
+    mockGetServiceRoleClient: vi.fn(),
+    mockInstMaybeSingle: vi.fn(),
+    mockCredEq: vi.fn(),
+    mockLogsIn: vi.fn(),
+}));
+
+vi.mock('../src/lib/serverAuth', () => ({
+    requireAuthenticatedRequest: mockRequireAuthenticatedRequest,
+    hasServiceRoleEnv: mockHasServiceRoleEnv,
+    getServiceRoleClient: mockGetServiceRoleClient,
+}));
+
+import { GET } from '../src/app/api/institution/analytics/route';
+
+function makeRequest(): NextRequest {
+    return new NextRequest('http://localhost/api/institution/analytics', {
+        headers: { Authorization: 'Bearer test-token' },
+    });
+}
+
+function makeSupabase() {
+    return {
+        from: vi.fn((table: string) => {
+            if (table === 'institutions') {
+                return {
+                    select: () => ({
+                        eq: () => ({ maybeSingle: mockInstMaybeSingle }),
+                    }),
+                };
+            }
+            if (table === 'credentials') {
+                return {
+                    select: () => ({ eq: mockCredEq }),
+                };
+            }
+            if (table === 'verification_logs') {
+                return {
+                    select: () => ({ in: mockLogsIn }),
+                };
+            }
+            return {};
+        }),
+    };
+}
+
+describe('GET /api/institution/analytics', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuthenticatedRequest.mockResolvedValue({ ok: true, userId: 'user-1' });
+        mockHasServiceRoleEnv.mockReturnValue(true);
+        mockInstMaybeSingle.mockResolvedValue({ data: { id: 'inst-1' }, error: null });
+        mockCredEq.mockResolvedValue({ data: [], error: null });
+        mockLogsIn.mockResolvedValue({ data: [], error: null });
+        mockGetServiceRoleClient.mockReturnValue(makeSupabase());
+    });
+
+    it('returns 401 when auth check fails', async () => {
+        mockRequireAuthenticatedRequest.mockResolvedValue({ ok: false, error: 'Unauthorized', status: 401 });
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.success).toBe(false);
+    });
+
+    it('returns 404 when institution is not found', async () => {
+        mockInstMaybeSingle.mockResolvedValue({ data: null, error: null });
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.success).toBe(false);
+        expect(body.error).toBe('Institution not found');
+    });
+
+    it('returns 500 when institution query errors', async () => {
+        mockInstMaybeSingle.mockResolvedValue({ data: null, error: new Error('db error') });
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(500);
+    });
+
+    it('returns success with empty data when institution has no credentials', async () => {
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(body.issuedOverTime).toHaveLength(12);
+        expect(body.statusBreakdown).toEqual({ active: 0, revoked: 0, total: 0 });
+        expect(body.verificationsOverTime).toHaveLength(12);
+        expect(body.topVerifiedCredentials).toEqual([]);
+    });
+
+    it('returns correct status breakdown for mixed credentials', async () => {
+        mockCredEq.mockResolvedValue({
+            data: [
+                { id: 'c1', token_id: 't1', issued_at: '2025-06-01T00:00:00Z', revoked: false, metadata: null },
+                { id: 'c2', token_id: 't2', issued_at: '2025-07-01T00:00:00Z', revoked: true, metadata: null },
+            ],
+            error: null,
+        });
+        const res = await GET(makeRequest());
+        const body = await res.json();
+        expect(body.statusBreakdown).toEqual({ active: 1, revoked: 1, total: 2 });
+    });
+
+    it('aggregates verifications over time from verification_logs', async () => {
+        mockCredEq.mockResolvedValue({
+            data: [{ id: 'c1', token_id: 't1', issued_at: '2026-01-01T00:00:00Z', revoked: false, metadata: null }],
+            error: null,
+        });
+        mockLogsIn.mockResolvedValue({
+            data: [
+                { credential_id: 'c1', created_at: '2026-03-10T00:00:00Z' },
+                { credential_id: 'c1', created_at: '2026-03-20T00:00:00Z' },
+            ],
+            error: null,
+        });
+        const res = await GET(makeRequest());
+        const body = await res.json();
+        const mar = body.verificationsOverTime.find((r: { month: string; count: number }) => r.month === '2026-03');
+        expect(mar?.count).toBe(2);
+    });
+
+    it('returns 500 when credential query throws', async () => {
+        mockCredEq.mockRejectedValue(new Error('network error'));
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(500);
+    });
+
+    it('skips verification_logs query when institution has no credentials', async () => {
+        mockCredEq.mockResolvedValue({ data: [], error: null });
+        await GET(makeRequest());
+        expect(mockLogsIn).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/tests/institutionExport.test.ts
+++ b/frontend/tests/institutionExport.test.ts
@@ -1,0 +1,118 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+    mockRequireAuthenticatedRequest,
+    mockHasServiceRoleEnv,
+    mockGetServiceRoleClient,
+    mockInstMaybeSingle,
+    mockCredOrder,
+} = vi.hoisted(() => ({
+    mockRequireAuthenticatedRequest: vi.fn(),
+    mockHasServiceRoleEnv: vi.fn(),
+    mockGetServiceRoleClient: vi.fn(),
+    mockInstMaybeSingle: vi.fn(),
+    mockCredOrder: vi.fn(),
+}));
+
+vi.mock('../src/lib/serverAuth', () => ({
+    requireAuthenticatedRequest: mockRequireAuthenticatedRequest,
+    hasServiceRoleEnv: mockHasServiceRoleEnv,
+    getServiceRoleClient: mockGetServiceRoleClient,
+}));
+
+import { GET } from '../src/app/api/institution/export/route';
+
+function makeRequest(): NextRequest {
+    return new NextRequest('http://localhost/api/institution/export', {
+        headers: { Authorization: 'Bearer test-token' },
+    });
+}
+
+function makeSupabase() {
+    return {
+        from: vi.fn((table: string) => {
+            if (table === 'institutions') {
+                return {
+                    select: () => ({
+                        eq: () => ({ maybeSingle: mockInstMaybeSingle }),
+                    }),
+                };
+            }
+            if (table === 'credentials') {
+                return {
+                    select: () => ({
+                        eq: () => ({ order: mockCredOrder }),
+                    }),
+                };
+            }
+            return {};
+        }),
+    };
+}
+
+describe('GET /api/institution/export', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuthenticatedRequest.mockResolvedValue({ ok: true, userId: 'user-1' });
+        mockHasServiceRoleEnv.mockReturnValue(true);
+        mockInstMaybeSingle.mockResolvedValue({ data: { id: 'inst-1' }, error: null });
+        mockCredOrder.mockResolvedValue({ data: [], error: null });
+        mockGetServiceRoleClient.mockReturnValue(makeSupabase());
+    });
+
+    it('returns 401 when auth check fails', async () => {
+        mockRequireAuthenticatedRequest.mockResolvedValue({ ok: false, error: 'Unauthorized', status: 401 });
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 404 when institution is not found', async () => {
+        mockInstMaybeSingle.mockResolvedValue({ data: null, error: null });
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 200 with text/csv content-type', async () => {
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toBe('text/csv');
+    });
+
+    it('sets content-disposition to attachment with filename', async () => {
+        const res = await GET(makeRequest());
+        expect(res.headers.get('content-disposition')).toContain('attachment');
+        expect(res.headers.get('content-disposition')).toContain('credentials.csv');
+    });
+
+    it('CSV body starts with the header row', async () => {
+        const res = await GET(makeRequest());
+        const text = await res.text();
+        expect(text.startsWith('token_id,student_name')).toBe(true);
+    });
+
+    it('includes credential data rows in the CSV', async () => {
+        mockCredOrder.mockResolvedValue({
+            data: [
+                {
+                    token_id: 'tok-99',
+                    issued_at: '2025-05-01T00:00:00Z',
+                    revoked: false,
+                    metadata: { credentialData: { studentName: 'Carol', credentialType: 'Master' } },
+                },
+            ],
+            error: null,
+        });
+        const res = await GET(makeRequest());
+        const text = await res.text();
+        expect(text).toContain('tok-99');
+        expect(text).toContain('Carol');
+        expect(text).toContain('active');
+    });
+
+    it('returns 500 when credential query throws', async () => {
+        mockCredOrder.mockRejectedValue(new Error('db failure'));
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(500);
+    });
+});


### PR DESCRIPTION
Closes #175

Adds an Analytics tab to the institution dashboard with charts and CSV export.

**Changes:**
- `/api/institution/analytics` — aggregates credential and verification_log data
- `/api/institution/export` — returns all credentials as a CSV download
- `InstitutionAnalytics` component with recharts bar charts, stat cards, ranked verification list, and Export CSV button
- Pure aggregation helpers in `src/lib/analyticsAggregation.ts`

Data sourced from Supabase (indexer from #11 not yet built; TODO comment marks the swap point).

**Tests:** 31 new — aggregation helpers and both API routes. Full suite: 196/196 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an institution Analytics tab with credential issuance and verification charts.
  - Added summary metrics and a list of the most verified credentials.
  - Added CSV export for institution credentials, including status and credential details.

- **Bug Fixes**
  - Added handling for loading, empty, authentication, and data retrieval states.

- **Tests**
  - Added coverage for analytics calculations, CSV formatting, analytics responses, and exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->