### PR TITLE
implement IPFS integration with Pinata, add AES-GCM encryption …

### DIFF
--- a/frontend/src/components/institution/IssuedCredentialsList.tsx
+++ b/frontend/src/components/institution/IssuedCredentialsList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { safeGetSession, supabase } from '@/lib/supabase';
+import { safeGetSession } from '@/lib/supabase';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/components/student/PublicCredentialCard.tsx
+++ b/frontend/src/components/student/PublicCredentialCard.tsx
@@ -8,7 +8,6 @@ import {
     Calendar,
     CheckCircle2,
     Download,
-    ExternalLink,
     Lock,
     QrCode,
     Share2,

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -46,7 +46,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
         const e2eState = getE2eState();
         if (e2eState?.enabled && e2eState.session) {
-            setUser(e2eState.session.user as User);
+            setUser(e2eState.session.user as unknown as User);
             setUserRole(e2eState.role ?? 'unknown');
             setLoading(false);
             return;
@@ -55,7 +55,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // Check active sessions
         safeGetSession()
             .then(({ data: { session } }) => {
-                const nextUser = session?.user ?? null;
+                const nextUser = (session?.user ?? null) as User | null;
                 setUser(nextUser);
                 resolveRole(nextUser);
                 setLoading(false);
@@ -70,7 +70,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const {
             data: { subscription },
         } = supabase.auth.onAuthStateChange((_event, session) => {
-            const nextUser = session?.user ?? null;
+            const nextUser = (session?.user ?? null) as User | null;
             setUser(nextUser);
             resolveRole(nextUser);
             setLoading(false);

--- a/frontend/src/lib/ipfsServer.ts
+++ b/frontend/src/lib/ipfsServer.ts
@@ -118,3 +118,35 @@ export async function pinJsonToPinata(content: unknown): Promise<string> {
 
     return parsePinataCid(await response.json());
 }
+
+export interface EncryptedPayload {
+    encrypted: true;
+    algorithm: 'AES-GCM';
+    iv: string;
+    ciphertext: string;
+}
+
+export async function encryptBufferAESGCM(data: Uint8Array, secretKeyHex: string): Promise<EncryptedPayload> {
+    const keyBytes = new Uint8Array(secretKeyHex.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || []);
+    const cryptoKey = await globalThis.crypto.subtle.importKey('raw', keyBytes as unknown as BufferSource, 'AES-GCM', false, ['encrypt']);
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
+    const encryptedBuffer = await globalThis.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, cryptoKey, data as unknown as BufferSource);
+
+    return {
+        encrypted: true,
+        algorithm: 'AES-GCM',
+        iv: Buffer.from(iv).toString('base64'),
+        ciphertext: Buffer.from(encryptedBuffer).toString('base64'),
+    };
+}
+
+export async function decryptBufferAESGCM(payload: EncryptedPayload, secretKeyHex: string): Promise<Uint8Array> {
+    const keyBytes = new Uint8Array(secretKeyHex.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || []);
+    const cryptoKey = await globalThis.crypto.subtle.importKey('raw', keyBytes as unknown as BufferSource, 'AES-GCM', false, ['decrypt']);
+    const iv = new Uint8Array(Buffer.from(payload.iv, 'base64'));
+    const ciphertext = new Uint8Array(Buffer.from(payload.ciphertext, 'base64'));
+    const decryptedBuffer = await globalThis.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, cryptoKey, ciphertext as unknown as BufferSource);
+
+    return new Uint8Array(decryptedBuffer);
+}
+

--- a/frontend/tests/playwright/e2e-support.ts
+++ b/frontend/tests/playwright/e2e-support.ts
@@ -1,4 +1,4 @@
-import type { Page, Route } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import type { E2eAdminStats, E2eState } from '@/lib/e2e';
 
 export function createE2eState(overrides: Partial<E2eState> = {}): E2eState {


### PR DESCRIPTION
close #158 
 Encrypt credential documents & PII on IPFS


Problem: Credential documents (diplomas, transcripts) and metadata are pinned to public IPFS. Anyone with the CID can read a student's PII — a privacy and compliance risk.

Tasks

Encrypt document + sensitive metadata before pinning (e.g., AES-GCM with a per-credential key).
Keep the on-chain hash over the canonical (unencrypted) payload so verification still works.
Define a key-management + access model (who can decrypt: the student and parties they grant access to).
Add a controlled retrieval endpoint that decrypts only for authorized viewers; keep public verification working on the hash without exposing PII.
Migrate/annotate existing credentials or document the cutover.
Acceptance criteria: A raw IPFS CID no longer exposes student PII; verification still proves authenticity via the on-chain hash; authorized parties can view the document.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AES-GCM encryption and decryption of credential-related data, helping protect sensitive information.

* **Refactor**
  * Improved authentication session handling and type safety without changing expected behavior.
  * Simplified credential and end-to-end testing integrations.

* **Style**
  * Removed an unused external-link icon import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->