### PR TITLE
 implement verified issuers directory with API route and UI components

### DIFF
--- a/frontend/src/app/api/issuers/route.ts
+++ b/frontend/src/app/api/issuers/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { runtimeConfig } from '@/lib/runtimeConfig';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/issuers
+ *
+ * Public issuer trust registry — Issue #171.
+ * Returns verified institutions with public, non-PII fields only.
+ * No authentication required; rate-limited by IP.
+ *
+ * Response shape:
+ * {
+ *   success: true,
+ *   issuers: Array<{
+ *     id: string;
+ *     name: string;
+ *     wallet_address: string | null;
+ *     authorization_tx_hash: string | null;
+ *     verified_at: string;          // ISO timestamp (created_at of institution row)
+ *   }>
+ * }
+ */
+export async function GET(request: NextRequest) {
+    const rateLimitResponse = enforceRateLimit(request, {
+        windowSeconds: 60,
+        maxRequests: 60,
+        prefix: 'issuers-public',
+    });
+    if (rateLimitResponse) return rateLimitResponse;
+
+    const { url: supabaseUrl, anonKey } = runtimeConfig.supabase;
+
+    if (!supabaseUrl || !anonKey) {
+        return NextResponse.json(
+            { success: false, error: 'Service temporarily unavailable.' },
+            { status: 503 },
+        );
+    }
+
+    const client = createClient(supabaseUrl, anonKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    // Only expose public, non-PII columns of verified institutions.
+    // email is excluded (PII); name and wallet are public business identifiers.
+    const { data, error } = await client
+        .from('institutions')
+        .select('id, name, wallet_address, authorization_tx_hash, created_at')
+        .eq('verified', true)
+        .order('created_at', { ascending: false });
+
+    if (error) {
+        return NextResponse.json(
+            { success: false, error: 'Failed to fetch issuer registry.' },
+            { status: 500 },
+        );
+    }
+
+    const issuers = (data ?? []).map(
+        (row: {
+            id: string;
+            name: string;
+            wallet_address: string | null;
+            authorization_tx_hash: string | null;
+            created_at: string;
+        }) => ({
+            id: row.id,
+            name: row.name,
+            wallet_address: row.wallet_address,
+            authorization_tx_hash: row.authorization_tx_hash,
+            verified_at: row.created_at,
+        }),
+    );
+
+    return NextResponse.json(
+        { success: true, issuers },
+        {
+            headers: {
+                // Allow CDN / browser caching for up to 5 minutes — the list
+                // changes infrequently (only when admin verifies an institution).
+                'Cache-Control': 'public, max-age=300, stale-while-revalidate=60',
+            },
+        },
+    );
+}

--- a/frontend/src/app/issuers/layout.tsx
+++ b/frontend/src/app/issuers/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: 'Verified Issuer Registry — Acredia',
+    description:
+        'Public directory of institutions verified and authorised on the Stellar blockchain to issue tamper-proof academic credentials via Acredia.',
+};
+
+export { default } from './page';

--- a/frontend/src/app/issuers/page.tsx
+++ b/frontend/src/app/issuers/page.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Building2, ExternalLink, Search, ShieldCheck, AlertCircle } from 'lucide-react';
+import { SiteNavbar } from '@/components/marketing/SiteNavbar';
+import { SiteFooter } from '@/components/marketing/SiteFooter';
+
+type Issuer = {
+    id: string;
+    name: string;
+    wallet_address: string | null;
+    authorization_tx_hash: string | null;
+    verified_at: string;
+};
+
+function IssuerCard({ issuer }: { issuer: Issuer }) {
+    const explorerBase = 'https://stellar.expert/explorer/testnet/account';
+    const txExplorerBase = 'https://stellar.expert/explorer/testnet/tx';
+    const shortAddr = issuer.wallet_address
+        ? `${issuer.wallet_address.slice(0, 8)}…${issuer.wallet_address.slice(-6)}`
+        : null;
+    const shortTx = issuer.authorization_tx_hash
+        ? `${issuer.authorization_tx_hash.slice(0, 10)}…`
+        : null;
+    const verifiedDate = new Date(issuer.verified_at).toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+    });
+
+    return (
+        <div className="group rounded-xl border border-border bg-card p-5 transition-shadow hover:shadow-md">
+            <div className="flex items-start gap-3">
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                    <Building2 className="h-5 w-5" />
+                </span>
+                <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="truncate font-semibold text-foreground">{issuer.name}</h3>
+                        <span className="inline-flex items-center gap-1 rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
+                            <ShieldCheck className="h-3 w-3" />
+                            Verified
+                        </span>
+                    </div>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                        Verified on {verifiedDate}
+                    </p>
+                </div>
+            </div>
+
+            <dl className="mt-4 space-y-2 text-sm">
+                {issuer.wallet_address && (
+                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
+                        <dt className="text-muted-foreground">Wallet address</dt>
+                        <dd>
+                            <a
+                                href={`${explorerBase}/${issuer.wallet_address}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 font-mono text-xs text-primary hover:underline"
+                                title={issuer.wallet_address}
+                            >
+                                {shortAddr}
+                                <ExternalLink className="h-3 w-3" />
+                            </a>
+                        </dd>
+                    </div>
+                )}
+                {issuer.authorization_tx_hash && (
+                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
+                        <dt className="text-muted-foreground">On-chain authorization</dt>
+                        <dd>
+                            <a
+                                href={`${txExplorerBase}/${issuer.authorization_tx_hash}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 font-mono text-xs text-primary hover:underline"
+                                title={issuer.authorization_tx_hash}
+                            >
+                                {shortTx}
+                                <ExternalLink className="h-3 w-3" />
+                            </a>
+                        </dd>
+                    </div>
+                )}
+                {!issuer.wallet_address && !issuer.authorization_tx_hash && (
+                    <p className="text-xs text-muted-foreground italic">
+                        On-chain details not yet available for this issuer.
+                    </p>
+                )}
+            </dl>
+        </div>
+    );
+}
+
+export default function IssuersPage() {
+    const [issuers, setIssuers] = useState<Issuer[]>([]);
+    const [query, setQuery] = useState('');
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchIssuers = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await fetch('/api/issuers');
+            const body = await res.json();
+            if (body.success) {
+                setIssuers(body.issuers);
+            } else {
+                setError(body.error ?? 'Failed to load issuer registry.');
+            }
+        } catch {
+            setError('Network error. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchIssuers();
+    }, [fetchIssuers]);
+
+    const filtered = issuers.filter((i) =>
+        i.name.toLowerCase().includes(query.toLowerCase()) ||
+        (i.wallet_address ?? '').toLowerCase().includes(query.toLowerCase()),
+    );
+
+    return (
+        <div className="flex min-h-screen flex-col">
+            <SiteNavbar />
+
+            <main className="flex-1">
+                {/* Hero */}
+                <section className="border-b border-border bg-secondary/30 py-14 sm:py-20">
+                    <div className="container-shell">
+                        <div className="mx-auto max-w-2xl text-center">
+                            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                                <ShieldCheck className="h-7 w-7" />
+                            </div>
+                            <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+                                Verified Issuer Registry
+                            </h1>
+                            <p className="mt-4 text-lg text-muted-foreground">
+                                Every institution listed here has been vetted by Acredia and
+                                authorised on the Stellar blockchain. Cross-check any issuer's
+                                wallet address against their on-chain authorization record.
+                            </p>
+                        </div>
+                    </div>
+                </section>
+
+                {/* Search + list */}
+                <section className="container-shell py-10">
+                    {/* Search bar */}
+                    <div className="mx-auto mb-8 max-w-lg">
+                        <label htmlFor="issuer-search" className="sr-only">
+                            Search verified issuers
+                        </label>
+                        <div className="relative">
+                            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                            <input
+                                id="issuer-search"
+                                type="search"
+                                value={query}
+                                onChange={(e) => setQuery(e.target.value)}
+                                placeholder="Search by name or wallet address…"
+                                className="w-full rounded-lg border border-border bg-card py-2.5 pl-9 pr-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                            />
+                        </div>
+                    </div>
+
+                    {/* States */}
+                    {loading && (
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {[...Array(3)].map((_, i) => (
+                                <div
+                                    key={i}
+                                    className="h-36 animate-pulse rounded-xl border border-border bg-card"
+                                />
+                            ))}
+                        </div>
+                    )}
+
+                    {!loading && error && (
+                        <div className="mx-auto flex max-w-md flex-col items-center gap-3 rounded-xl border border-destructive/30 bg-destructive/5 p-8 text-center">
+                            <AlertCircle className="h-8 w-8 text-destructive" />
+                            <p className="text-sm text-muted-foreground">{error}</p>
+                            <button
+                                onClick={fetchIssuers}
+                                className="text-sm font-medium text-primary underline"
+                            >
+                                Retry
+                            </button>
+                        </div>
+                    )}
+
+                    {!loading && !error && filtered.length === 0 && (
+                        <p className="py-16 text-center text-muted-foreground">
+                            {query ? `No verified issuers matching "${query}".` : 'No verified issuers yet.'}
+                        </p>
+                    )}
+
+                    {!loading && !error && filtered.length > 0 && (
+                        <>
+                            <p className="mb-4 text-sm text-muted-foreground">
+                                {filtered.length} verified issuer{filtered.length !== 1 ? 's' : ''}
+                                {query && ` matching "${query}"`}
+                            </p>
+                            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                                {filtered.map((issuer) => (
+                                    <IssuerCard key={issuer.id} issuer={issuer} />
+                                ))}
+                            </div>
+                        </>
+                    )}
+
+                    {/* How to verify note */}
+                    <div className="mx-auto mt-12 max-w-2xl rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground">
+                        <p className="font-semibold text-foreground">How to cross-check on-chain</p>
+                        <ol className="mt-2 list-decimal space-y-1 pl-5 leading-6">
+                            <li>Click the wallet address link to open the issuer's account on Stellar Expert.</li>
+                            <li>Click the on-chain authorization link to view the exact transaction that granted this institution credential-issuance rights.</li>
+                            <li>Compare the wallet address shown here with the <code className="rounded bg-secondary px-1">issuer_wallet_address</code> on any credential's verification page.</li>
+                        </ol>
+                        <p className="mt-3">
+                            To verify a specific credential, visit the{' '}
+                            <Link href="/verify" className="text-primary underline">
+                                verification page
+                            </Link>
+                            .
+                        </p>
+                    </div>
+                </section>
+            </main>
+
+            <SiteFooter />
+        </div>
+    );
+}

--- a/frontend/src/components/marketing/SiteFooter.tsx
+++ b/frontend/src/components/marketing/SiteFooter.tsx
@@ -14,6 +14,7 @@ const footerNav: { heading: string; links: { label: string; href: string; extern
     {
         heading: 'Product',
         links: [
+            { label: 'Verified Issuers', href: '/issuers' },
             { label: 'Verify a credential', href: '/verify' },
             { label: 'For institutions', href: '/solutions/institutions' },
             { label: 'For students', href: '/solutions/students' },

--- a/frontend/src/components/marketing/SiteNavbar.tsx
+++ b/frontend/src/components/marketing/SiteNavbar.tsx
@@ -26,6 +26,7 @@ const solutions = [
 
 const navLinks = [
     { href: '/verify', label: 'Verify' },
+    { href: '/issuers', label: 'Issuers' },
     { href: '/about', label: 'About' },
 ];
 

--- a/frontend/tests/issuersRoute.test.ts
+++ b/frontend/tests/issuersRoute.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for Issue #171 — Public Issuer Trust Registry
+ * Covers the GET /api/issuers route handler.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module-level mocks (hoisted by Vitest before imports)
+// ---------------------------------------------------------------------------
+vi.mock('@/lib/runtimeConfig', () => ({
+    runtimeConfig: {
+        supabase: { url: 'https://test.supabase.co', anonKey: 'test-anon-key' },
+        isProduction: false,
+        stellar: {},
+        contracts: {},
+        ipfs: { gatewayUrl: '' },
+        debug: { enableLogs: false },
+    },
+    serverRuntimeConfig: {
+        admin: { emailAllowlist: [] },
+        auth: { serviceRoleKey: '' },
+        ipfs: { jwt: '' },
+        verification: { hashSecret: '' },
+        debug: { enableLogs: false },
+    },
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+    enforceRateLimit: vi.fn().mockReturnValue(null), // no rate-limit block
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+    createClient: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('GET /api/issuers — route handler', async () => {
+    const { createClient } = await import('@supabase/supabase-js');
+    const { GET } = await import('@/app/api/issuers/route');
+
+    const mockVerifiedIssuers = [
+        {
+            id: 'inst-1',
+            name: 'State University',
+            wallet_address: 'GABCDE',
+            authorization_tx_hash: 'txhash1',
+            created_at: '2025-01-15T10:00:00Z',
+        },
+        {
+            id: 'inst-2',
+            name: 'Tech College',
+            wallet_address: null,
+            authorization_tx_hash: null,
+            created_at: '2025-03-20T08:00:00Z',
+        },
+    ];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns 200 with issuer list when Supabase succeeds', async () => {
+        vi.mocked(createClient).mockReturnValue({
+            from: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({ data: mockVerifiedIssuers, error: null }),
+            }),
+        } as never);
+
+        const req = new Request('http://localhost/api/issuers');
+        // @ts-expect-error NextRequest vs Request
+        const res = await GET(req);
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(body.issuers).toHaveLength(2);
+        expect(body.issuers[0].name).toBe('State University');
+        expect(body.issuers[0].verified_at).toBe('2025-01-15T10:00:00Z');
+    });
+
+    it('maps created_at to verified_at and omits email', async () => {
+        vi.mocked(createClient).mockReturnValue({
+            from: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({ data: [mockVerifiedIssuers[0]], error: null }),
+            }),
+        } as never);
+
+        const req = new Request('http://localhost/api/issuers');
+        // @ts-expect-error NextRequest vs Request
+        const res = await GET(req);
+        const body = await res.json();
+
+        const issuer = body.issuers[0];
+        expect(issuer).toHaveProperty('verified_at');
+        expect(issuer).not.toHaveProperty('email');          // PII must not be exposed
+        expect(issuer).not.toHaveProperty('created_at');     // remapped to verified_at
+    });
+
+    it('returns 503 when Supabase config is missing', async () => {
+        // Temporarily override to simulate missing config
+        const { runtimeConfig } = await import('@/lib/runtimeConfig');
+        const original = { ...runtimeConfig.supabase };
+        runtimeConfig.supabase.url = '';
+
+        const req = new Request('http://localhost/api/issuers');
+        // @ts-expect-error NextRequest vs Request
+        const res = await GET(req);
+        expect(res.status).toBe(503);
+
+        runtimeConfig.supabase.url = original.url;
+    });
+
+    it('returns 500 when Supabase query errors', async () => {
+        vi.mocked(createClient).mockReturnValue({
+            from: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+            }),
+        } as never);
+
+        const req = new Request('http://localhost/api/issuers');
+        // @ts-expect-error NextRequest vs Request
+        const res = await GET(req);
+        expect(res.status).toBe(500);
+        const body = await res.json();
+        expect(body.success).toBe(false);
+    });
+
+    it('sets Cache-Control header on successful response', async () => {
+        vi.mocked(createClient).mockReturnValue({
+            from: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({ data: mockVerifiedIssuers, error: null }),
+            }),
+        } as never);
+
+        const req = new Request('http://localhost/api/issuers');
+        // @ts-expect-error NextRequest vs Request
+        const res = await GET(req);
+        expect(res.headers.get('Cache-Control')).toContain('max-age=300');
+    });
+});


### PR DESCRIPTION
close #171 Public issuer trust registry / directory


Problem: Verifiers can't easily tell which institutions are legitimately onboarded.

Tasks

Build a public directory of verified issuers (name, domain, verification date, on-chain issuer address).
Link each verified credential to its issuer's registry entry.
Make the registry searchable and cross-checkable against on-chain authorization.
Acceptance criteria: A verifier can confirm an issuer is a real, vetted institution from a public page that matches on-chain authorization.  make very small contribution 