### PR TITLE
have implemented a Postgres-backed job queue as the foundation 

### DIFF
--- a/frontend/sql/FULL_SETUP.sql
+++ b/frontend/sql/FULL_SETUP.sql
@@ -208,6 +208,45 @@ REVOKE ALL ON FUNCTION public.is_admin() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.is_admin() TO authenticated;
 
 -- ---------------------------------------------------------------------
+-- Function: next_job(p_worker_id text)
+-- Picks and locks the next pending job that is ready to run.
+-- Uses FOR UPDATE SKIP LOCKED to prevent multiple workers from picking
+-- the same job concurrently.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.next_job(p_worker_id text)
+RETURNS SETOF public.jobs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_job_id uuid;
+BEGIN
+    SELECT id INTO v_job_id
+    FROM public.jobs
+    WHERE status = 'pending' AND run_at <= NOW()
+    ORDER BY run_at ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED;
+
+    IF v_job_id IS NOT NULL THEN
+        UPDATE public.jobs
+        SET status = 'processing',
+            locked_at = NOW(),
+            locked_by = p_worker_id,
+            attempts = attempts + 1,
+            updated_at = NOW()
+        WHERE id = v_job_id;
+
+        RETURN QUERY SELECT * FROM public.jobs WHERE id = v_job_id;
+    END IF;
+END;
+$$;
+
+-- next_job is NOT accessible to public / authenticated users.
+REVOKE ALL ON FUNCTION public.next_job(text) FROM PUBLIC;
+
+-- ---------------------------------------------------------------------
 -- Triggers (drop-before-create so re-runs are clean)
 -- ---------------------------------------------------------------------
 DROP TRIGGER IF EXISTS prevent_profile_role_escalation ON public.profiles;
@@ -275,6 +314,7 @@ ALTER TABLE IF EXISTS public.institutions      ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS public.students          ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS public.credentials       ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS public.verification_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.jobs              ENABLE ROW LEVEL SECURITY;
 
 -- ---------------------------------------------------------------------
 -- Drop any legacy / permissive policies before recreating (idempotent)
@@ -316,6 +356,9 @@ DROP POLICY IF EXISTS "Admin can insert verification logs"              ON publi
 
 DROP POLICY IF EXISTS "Users can view own erasure requests"             ON public.erasure_requests;
 DROP POLICY IF EXISTS "Admin can view all erasure requests"             ON public.erasure_requests;
+
+DROP POLICY IF EXISTS "Admin can view jobs"                             ON public.jobs;
+DROP POLICY IF EXISTS "Admin can manage jobs"                           ON public.jobs;
 
 -- ---------------------------------------------------------------------
 -- Profiles policies
@@ -473,6 +516,43 @@ CREATE POLICY "Users can view own erasure requests"
 CREATE POLICY "Admin can view all erasure requests"
     ON public.erasure_requests FOR SELECT
     USING (public.is_admin());
+
+-- ---------------------------------------------------------------------
+-- Job queue table (created by job_queue.sql; policies here
+-- ensure idempotent policy management in this consolidated setup file)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.jobs (
+    id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name             TEXT NOT NULL,
+    payload          JSONB NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    attempts         INTEGER NOT NULL DEFAULT 0,
+    max_attempts     INTEGER NOT NULL DEFAULT 3,
+    run_at           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    locked_at        TIMESTAMP WITH TIME ZONE,
+    locked_by        TEXT,
+    error_log        TEXT,
+    idempotency_key  TEXT UNIQUE,
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.jobs IS
+    'Postgres-backed job queue for background asynchronous tasks (re-pinning, indexing, notifications).';
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status_run_at 
+    ON public.jobs (status, run_at) 
+    WHERE status = 'pending';
+
+CREATE POLICY "Admin can view jobs"
+    ON public.jobs FOR SELECT
+    USING (public.is_admin());
+
+CREATE POLICY "Admin can manage jobs"
+    ON public.jobs FOR ALL
+    USING (public.is_admin())
+    WITH CHECK (public.is_admin());
 
 COMMIT;
 

--- a/frontend/sql/database_schema.sql
+++ b/frontend/sql/database_schema.sql
@@ -80,8 +80,33 @@ CREATE INDEX IF NOT EXISTS idx_verification_logs_created_at ON public.verificati
 CREATE INDEX IF NOT EXISTS idx_verification_logs_result_type
     ON public.verification_logs ((verification_result->>'result_type'));
 
+CREATE TABLE IF NOT EXISTS public.jobs (
+    id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name             TEXT NOT NULL,
+    payload          JSONB NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    attempts         INTEGER NOT NULL DEFAULT 0,
+    max_attempts     INTEGER NOT NULL DEFAULT 3,
+    run_at           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    locked_at        TIMESTAMP WITH TIME ZONE,
+    locked_by        TEXT,
+    error_log        TEXT,
+    idempotency_key  TEXT UNIQUE,
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.jobs IS
+    'Postgres-backed job queue for background asynchronous tasks (re-pinning, indexing, notifications).';
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status_run_at 
+    ON public.jobs (status, run_at) 
+    WHERE status = 'pending';
+
 ALTER TABLE IF EXISTS public.profiles          ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS public.institutions      ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS public.students          ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS public.credentials       ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS public.verification_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS public.jobs              ENABLE ROW LEVEL SECURITY;

--- a/frontend/sql/job_queue.sql
+++ b/frontend/sql/job_queue.sql
@@ -1,0 +1,87 @@
+-- =====================================================================
+-- ACREDIA-STELLAR — JOB QUEUE SCHEMA (IDEMPOTENT)
+-- Issue #167: Background worker / job queue
+-- =====================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.jobs (
+    id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name             TEXT NOT NULL,
+    payload          JSONB NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    attempts         INTEGER NOT NULL DEFAULT 0,
+    max_attempts     INTEGER NOT NULL DEFAULT 3,
+    run_at           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    locked_at        TIMESTAMP WITH TIME ZONE,
+    locked_by        TEXT,
+    error_log        TEXT,
+    idempotency_key  TEXT UNIQUE,
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.jobs IS
+    'Postgres-backed job queue for background asynchronous tasks (re-pinning, indexing, notifications).';
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status_run_at 
+    ON public.jobs (status, run_at) 
+    WHERE status = 'pending';
+
+-- Enable Row Level Security (RLS)
+ALTER TABLE IF EXISTS public.jobs ENABLE ROW LEVEL SECURITY;
+
+-- Only Admins (via service_role or admin check) can view/manage jobs directly.
+-- The worker process will use the service_role key to bypass RLS policies.
+DROP POLICY IF EXISTS "Admin can view jobs" ON public.jobs;
+CREATE POLICY "Admin can view jobs"
+    ON public.jobs FOR SELECT
+    USING (public.is_admin());
+
+DROP POLICY IF EXISTS "Admin can manage jobs" ON public.jobs;
+CREATE POLICY "Admin can manage jobs"
+    ON public.jobs FOR ALL
+    USING (public.is_admin())
+    WITH CHECK (public.is_admin());
+
+-- ---------------------------------------------------------------------
+-- Function: next_job(p_worker_id text)
+-- Picks and locks the next pending job that is ready to run.
+-- Uses FOR UPDATE SKIP LOCKED to prevent multiple workers from picking
+-- the same job concurrently.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.next_job(p_worker_id text)
+RETURNS SETOF public.jobs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_job_id uuid;
+BEGIN
+    SELECT id INTO v_job_id
+    FROM public.jobs
+    WHERE status = 'pending' AND run_at <= NOW()
+    ORDER BY run_at ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED;
+
+    IF v_job_id IS NOT NULL THEN
+        UPDATE public.jobs
+        SET status = 'processing',
+            locked_at = NOW(),
+            locked_by = p_worker_id,
+            attempts = attempts + 1,
+            updated_at = NOW()
+        WHERE id = v_job_id;
+
+        RETURN QUERY SELECT * FROM public.jobs WHERE id = v_job_id;
+    END IF;
+END;
+$$;
+
+-- next_job is NOT accessible to public / authenticated users.
+REVOKE ALL ON FUNCTION public.next_job(text) FROM PUBLIC;
+
+COMMIT;

--- a/frontend/src/lib/queue.ts
+++ b/frontend/src/lib/queue.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SupabaseClient } from '@supabase/supabase-js';
+
+export interface Job {
+    id: string;
+    name: string;
+    payload: Record<string, unknown> | unknown;
+    status: 'pending' | 'processing' | 'completed' | 'failed';
+    attempts: number;
+    max_attempts: number;
+    run_at: string;
+    locked_at: string | null;
+    locked_by: string | null;
+    error_log: string | null;
+    idempotency_key: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export type JobHandler = (payload: any) => Promise<void> | void;
+
+/**
+ * Enqueue a new background job.
+ * If a unique idempotencyKey is provided and conflicts with an existing job,
+ * this function will gracefully ignore the insert and return the existing job.
+ */
+export async function enqueueJob(
+    client: SupabaseClient,
+    name: string,
+    payload: Record<string, unknown> | unknown,
+    options?: {
+        idempotencyKey?: string;
+        runAt?: Date;
+        maxAttempts?: number;
+    }
+): Promise<{ success: boolean; job?: Job; error?: string }> {
+    const data = {
+        name,
+        payload,
+        status: 'pending',
+        idempotency_key: options?.idempotencyKey || null,
+        run_at: options?.runAt ? options.runAt.toISOString() : new Date().toISOString(),
+        max_attempts: options?.maxAttempts !== undefined ? options.maxAttempts : 3,
+    };
+
+    const { data: inserted, error } = await client
+        .from('jobs')
+        .insert([data])
+        .select()
+        .maybeSingle();
+
+    if (error) {
+        // Unique constraint violation code is 23505
+        if (error.code === '23505' && options?.idempotencyKey) {
+            const { data: existing } = await client
+                .from('jobs')
+                .select('*')
+                .eq('idempotency_key', options.idempotencyKey)
+                .maybeSingle();
+            return { success: true, job: existing as Job };
+        }
+        return { success: false, error: error.message };
+    }
+
+    return { success: true, job: inserted as Job };
+}
+
+/**
+ * Poll for a single pending job, lock it, process it using the provided handlers,
+ * and record success or handle retries/failure logging.
+ * Returns true if a job was found and processed.
+ */
+export async function pollAndProcessJob(
+    client: SupabaseClient,
+    workerId: string,
+    handlers: Record<string, JobHandler>
+): Promise<{ processed: boolean; job?: Job; error?: string }> {
+    // 1. Fetch next job and mark status as processing using Skip Locked via next_job RPC function
+    const { data: jobData, error: lockError } = await client.rpc('next_job', {
+        p_worker_id: workerId,
+    });
+
+    if (lockError) {
+        return { processed: false, error: `Failed to lock job: ${lockError.message}` };
+    }
+
+    const job = (Array.isArray(jobData) ? jobData[0] : jobData) as Job | undefined;
+    if (!job) {
+        return { processed: false };
+    }
+
+    const handler = handlers[job.name];
+    if (!handler) {
+        const errorMsg = `No handler registered for job name: ${job.name}`;
+        await client
+            .from('jobs')
+            .update({
+                status: 'failed',
+                error_log: errorMsg,
+                updated_at: new Date().toISOString(),
+            })
+            .eq('id', job.id);
+        return { processed: true, job: { ...job, status: 'failed', error_log: errorMsg } };
+    }
+
+    try {
+        await handler(job.payload);
+
+        // Success: Mark completed
+        const { data: completedJob } = await client
+            .from('jobs')
+            .update({
+                status: 'completed',
+                updated_at: new Date().toISOString(),
+            })
+            .eq('id', job.id)
+            .select()
+            .single();
+
+        return { processed: true, job: completedJob as Job };
+    } catch (err: unknown) {
+        // Failure: Check attempts vs max_attempts to retry or mark failed
+        const failed = job.attempts >= job.max_attempts;
+        const errorStack = err instanceof Error ? err.stack || err.message : String(err);
+
+        const { data: updatedJob } = await client
+            .from('jobs')
+            .update({
+                status: failed ? 'failed' : 'pending',
+                error_log: errorStack,
+                updated_at: new Date().toISOString(),
+            })
+            .eq('id', job.id)
+            .select()
+            .single();
+
+        return { processed: true, job: updatedJob as Job };
+    }
+}
+

--- a/frontend/tests/queue.test.ts
+++ b/frontend/tests/queue.test.ts
@@ -1,0 +1,194 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Top-level mocks must be declared before any imports of the mocked modules.
+vi.mock('@/lib/runtimeConfig', () => ({
+    runtimeConfig: {
+        supabase: { url: 'https://test.supabase.co', anonKey: 'test-anon-key' },
+        isProduction: false,
+        stellar: {},
+        contracts: {},
+        ipfs: { gatewayUrl: '' },
+        debug: { enableLogs: false },
+    },
+    serverRuntimeConfig: {
+        admin: { emailAllowlist: [] },
+        auth: { serviceRoleKey: '' },
+        ipfs: { jwt: '' },
+        verification: { hashSecret: '' },
+        debug: { enableLogs: false },
+    },
+}));
+
+describe('Background Job Queue client', async () => {
+    const { enqueueJob, pollAndProcessJob } = await import('@/lib/queue');
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('enqueues a job successfully', async () => {
+        const mockJob = {
+            id: 'job-1',
+            name: 'test_job',
+            payload: { value: 123 },
+            status: 'pending',
+            attempts: 0,
+            max_attempts: 3,
+            run_at: new Date().toISOString(),
+        };
+
+        const mockClient = {
+            from: vi.fn().mockReturnValue({
+                insert: vi.fn().mockReturnThis(),
+                select: vi.fn().mockReturnThis(),
+                maybeSingle: vi.fn().mockResolvedValue({ data: mockJob, error: null }),
+            }),
+        };
+
+        const res = await enqueueJob(mockClient as any, 'test_job', { value: 123 });
+        expect(res.success).toBe(true);
+        expect(res.job?.name).toBe('test_job');
+        expect(res.job?.payload.value).toBe(123);
+    });
+
+    it('handles unique constraint violation with idempotency key', async () => {
+        const mockExistingJob = {
+            id: 'existing-job',
+            name: 'test_job',
+            payload: { value: 456 },
+            status: 'pending',
+            attempts: 0,
+            max_attempts: 3,
+            idempotency_key: 'unique-key',
+        };
+
+        const mockClient = {
+            from: vi.fn().mockImplementation((table) => {
+                if (table === 'jobs') {
+                    return {
+                        insert: vi.fn().mockReturnThis(),
+                        select: vi.fn().mockReturnThis(),
+                        // Simulate unique violation error on insert
+                        maybeSingle: vi.fn().mockResolvedValue({
+                            data: null,
+                            error: { code: '23505', message: 'duplicate key value' },
+                        }),
+                        eq: vi.fn().mockReturnThis(),
+                    };
+                }
+                return {};
+            }),
+        };
+
+        // Stub find call when unique violation happens
+        mockClient.from = vi.fn().mockImplementation(() => {
+            return {
+                insert: vi.fn().mockReturnThis(),
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                maybeSingle: vi.fn().mockImplementation(async () => {
+                    // First call is insert (which fails), second call is select existing
+                    if (mockClient.from.mock.calls.length === 1) {
+                        return { data: null, error: { code: '23505', message: 'duplicate key' } };
+                    }
+                    return { data: mockExistingJob, error: null };
+                }),
+            };
+        });
+
+        const res = await enqueueJob(mockClient as any, 'test_job', { value: 456 }, {
+            idempotencyKey: 'unique-key',
+        });
+
+        expect(res.success).toBe(true);
+        expect(res.job?.id).toBe('existing-job');
+    });
+
+    it('polls and processes next job successfully', async () => {
+        const mockJob = {
+            id: 'job-1',
+            name: 'success_job',
+            payload: { data: 'ok' },
+            attempts: 1,
+            max_attempts: 3,
+        };
+
+        const mockClient = {
+            rpc: vi.fn().mockResolvedValue({ data: [mockJob], error: null }),
+            from: vi.fn().mockReturnValue({
+                update: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                select: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: { ...mockJob, status: 'completed' }, error: null }),
+            }),
+        };
+
+        const mockHandler = vi.fn().mockResolvedValue(undefined);
+        const res = await pollAndProcessJob(mockClient as any, 'worker-1', {
+            success_job: mockHandler,
+        });
+
+        expect(res.processed).toBe(true);
+        expect(res.job?.status).toBe('completed');
+        expect(mockHandler).toHaveBeenCalledWith({ data: 'ok' });
+    });
+
+    it('retries job on handler failure', async () => {
+        const mockJob = {
+            id: 'job-1',
+            name: 'retry_job',
+            payload: { value: 1 },
+            attempts: 1,
+            max_attempts: 3,
+        };
+
+        const mockClient = {
+            rpc: vi.fn().mockResolvedValue({ data: [mockJob], error: null }),
+            from: vi.fn().mockReturnValue({
+                update: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                select: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: { ...mockJob, status: 'pending', error_log: 'Error: Failed' }, error: null }),
+            }),
+        };
+
+        const mockHandler = vi.fn().mockRejectedValue(new Error('Failed'));
+        const res = await pollAndProcessJob(mockClient as any, 'worker-1', {
+            retry_job: mockHandler,
+        });
+
+        expect(res.processed).toBe(true);
+        expect(res.job?.status).toBe('pending');
+        expect(res.job?.error_log).toContain('Error: Failed');
+    });
+
+    it('marks job as failed when attempts reach max_attempts', async () => {
+        const mockJob = {
+            id: 'job-1',
+            name: 'fail_job',
+            payload: { value: 1 },
+            attempts: 3, // already reached max
+            max_attempts: 3,
+        };
+
+        const mockClient = {
+            rpc: vi.fn().mockResolvedValue({ data: [mockJob], error: null }),
+            from: vi.fn().mockReturnValue({
+                update: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                select: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: { ...mockJob, status: 'failed', error_log: 'Error: Fatal' }, error: null }),
+            }),
+        };
+
+        const mockHandler = vi.fn().mockRejectedValue(new Error('Fatal'));
+        const res = await pollAndProcessJob(mockClient as any, 'worker-1', {
+            fail_job: mockHandler,
+        });
+
+        expect(res.processed).toBe(true);
+        expect(res.job?.status).toBe('failed');
+        expect(res.job?.error_log).toContain('Error: Fatal');
+    });
+});


### PR DESCRIPTION
close #167 Background worker / job queue


Problem: Everything runs inline in Next.js API routes. Long-running/retryable work (indexing, re-pinning, emails, webhooks) needs a queue.

Tasks

Introduce a job queue + worker (e.g., Redis/Postgres-backed) with retries and dead-letter handling.
Move re-pinning (#9), indexing (#11), and notifications (#13) onto the queue.
Add idempotency keys so retries are safe.
Add health checks and metrics for the worker.
Acceptance criteria: Async tasks are retried on failure, observable, and don't block API requests.  make a very small contribution 