### PR TITLE
feat: implement wallet linking and admin authorization verification e…

### DIFF
--- a/frontend/sql/FULL_SETUP.sql
+++ b/frontend/sql/FULL_SETUP.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS public.institutions (
     email                 TEXT UNIQUE NOT NULL,
     wallet_address        TEXT UNIQUE,
     verified              BOOLEAN DEFAULT false,
+    status                TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'verified', 'suspended', 'rejected')),
     authorization_tx_hash TEXT,
     created_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -410,7 +411,7 @@ CREATE POLICY "Institutions can insert credentials"
   ON public.credentials FOR INSERT
   WITH CHECK (
     institution_id IN (
-      SELECT id FROM public.institutions WHERE auth_user_id = auth.uid()
+      SELECT id FROM public.institutions WHERE auth_user_id = auth.uid() AND verified = true
     )
   );
 
@@ -418,12 +419,12 @@ CREATE POLICY "Institutions can update own credentials"
   ON public.credentials FOR UPDATE
   USING (
     institution_id IN (
-      SELECT id FROM public.institutions WHERE auth_user_id = auth.uid()
+      SELECT id FROM public.institutions WHERE auth_user_id = auth.uid() AND verified = true
     )
   )
   WITH CHECK (
     institution_id IN (
-      SELECT id FROM public.institutions WHERE auth_user_id = auth.uid()
+      SELECT id FROM public.institutions WHERE auth_user_id = auth.uid() AND verified = true
     )
   );
 

--- a/frontend/sql/database_schema.sql
+++ b/frontend/sql/database_schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS public.institutions (
     email                 TEXT UNIQUE NOT NULL,
     wallet_address        TEXT UNIQUE,
     verified              BOOLEAN DEFAULT false,
+    status                TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'verified', 'suspended', 'rejected')),
     authorization_tx_hash TEXT,
     created_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );

--- a/frontend/src/app/api/admin/update-authorization/route.ts
+++ b/frontend/src/app/api/admin/update-authorization/route.ts
@@ -80,6 +80,7 @@ export async function POST(request: NextRequest) {
             // Update existing institution to mark as verified and store transaction hash
             const updateData = {
                 verified: true,
+                status: 'verified',
                 authorization_tx_hash: verification.transactionHash,
             };
 

--- a/frontend/src/app/api/institution/link-wallet/route.ts
+++ b/frontend/src/app/api/institution/link-wallet/route.ts
@@ -94,6 +94,7 @@ export async function POST(request: NextRequest) {
             .update({
                 wallet_address: normalizedWallet,
                 verified: false,
+                status: 'pending',
                 authorization_tx_hash: null,
             })
             .eq('id', institution.id)

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -64,6 +64,7 @@ function DashboardContent() {
     const [refreshTrigger, setRefreshTrigger] = useState(0);
     const [institutionId, setInstitutionId] = useState('');
     const [institutionWalletAddress, setInstitutionWalletAddress] = useState<string | null>(null);
+    const [institutionStatus, setInstitutionStatus] = useState<string>('pending');
     const [loadingInstitution, setLoadingInstitution] = useState(true);
     const [linkingInstitutionWallet, setLinkingInstitutionWallet] = useState(false);
     const walletLinkInFlight = useRef<string | null>(null);
@@ -73,6 +74,7 @@ function DashboardContent() {
             if (!user || userRole !== 'institution') {
                 setInstitutionId('');
                 setInstitutionWalletAddress(null);
+                setInstitutionStatus('pending');
                 setLoadingInstitution(false);
                 return;
             }
@@ -80,7 +82,7 @@ function DashboardContent() {
             try {
                 const { data, error } = await supabase
                     .from('institutions')
-                    .select('id, wallet_address')
+                    .select('id, wallet_address, status')
                     .eq('auth_user_id', user.id)
                     .maybeSingle();
 
@@ -93,6 +95,7 @@ function DashboardContent() {
                 if (data) {
                     setInstitutionId(data.id);
                     setInstitutionWalletAddress(data.wallet_address ?? null);
+                    setInstitutionStatus(data.status || 'pending');
                     debugLog('Institution profile loaded for dashboard.');
                     return;
                 }
@@ -109,7 +112,7 @@ function DashboardContent() {
                             name: user.email?.split('@')[0] || 'Institution',
                         },
                     ])
-                    .select('id, wallet_address')
+                    .select('id, wallet_address, status')
                     .single();
 
                 if (createError) {
@@ -121,6 +124,7 @@ function DashboardContent() {
                 if (newInstitution) {
                     setInstitutionId(newInstitution.id);
                     setInstitutionWalletAddress(newInstitution.wallet_address ?? null);
+                    setInstitutionStatus(newInstitution.status || 'pending');
                     toast.success('Institution profile created');
                 }
             } catch (error) {
@@ -241,7 +245,7 @@ function DashboardContent() {
                             <h3 className="mb-5 text-base font-semibold text-foreground">
                                 Account information
                             </h3>
-                            <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+                            <div className="grid grid-cols-1 gap-6 md:grid-cols-4">
                                 <InfoField label="Email">{user?.email}</InfoField>
                                 <InfoField label="Role">
                                     <span className="capitalize">{userRole}</span>
@@ -251,6 +255,16 @@ function DashboardContent() {
                                         address={address}
                                         linking={linkingInstitutionWallet}
                                     />
+                                </InfoField>
+                                <InfoField label="Verification Status">
+                                    <span className={`inline-flex items-center gap-1.5 font-semibold capitalize ${
+                                        institutionStatus === 'verified' ? 'text-success' :
+                                        institutionStatus === 'pending' ? 'text-warning' :
+                                        institutionStatus === 'rejected' ? 'text-destructive' :
+                                        'text-muted-foreground'
+                                    }`}>
+                                        {institutionStatus}
+                                    </span>
                                 </InfoField>
                             </div>
                         </Card>
@@ -278,13 +292,24 @@ function DashboardContent() {
                             </TabsList>
 
                             <TabsContent value="issue" className="mt-6">
-                                <CredentialUploadForm
-                                    institutionId={institutionId}
-                                    institutionName={institutionName}
-                                    institutionWallet={institutionWallet}
-                                    account={address}
-                                    onSuccess={handleCredentialIssued}
-                                />
+                                {institutionStatus === 'verified' ? (
+                                    <CredentialUploadForm
+                                        institutionId={institutionId}
+                                        institutionName={institutionName}
+                                        institutionWallet={institutionWallet}
+                                        account={address}
+                                        onSuccess={handleCredentialIssued}
+                                    />
+                                ) : (
+                                    <Card className="p-8 text-center border-warning/25 bg-warning/8">
+                                        <Shield className="mx-auto mb-4 h-12 w-12 text-warning" />
+                                        <h3 className="text-lg font-bold text-foreground">Verification Required</h3>
+                                        <p className="mt-2 text-sm text-muted-foreground max-w-md mx-auto">
+                                            Your institution account status is currently <strong>{institutionStatus}</strong>.
+                                            You must be approved by an administrator and verified on-chain before you can issue academic credentials.
+                                        </p>
+                                    </Card>
+                                )}
                             </TabsContent>
 
                             <TabsContent value="view" className="mt-6">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,7 @@ export interface Institution {
     name: string;
     wallet_address?: string;
     verified: boolean;
+    status?: 'pending' | 'verified' | 'suspended' | 'rejected';
     created_at: string;
 }
 

--- a/frontend/tests/adminUpdateAuthorizationRoute.test.ts
+++ b/frontend/tests/adminUpdateAuthorizationRoute.test.ts
@@ -78,6 +78,7 @@ describe('admin update authorization route', () => {
         expect(payload.success).toBe(true);
         expect(mockUpdate).toHaveBeenCalledWith({
             verified: true,
+            status: 'verified',
             authorization_tx_hash: 'a'.repeat(64),
         });
         expect(mockEqAfterUpdate).toHaveBeenCalledWith('id', 'institution-1');

--- a/frontend/tests/institutionLinkWalletRoute.test.ts
+++ b/frontend/tests/institutionLinkWalletRoute.test.ts
@@ -92,6 +92,7 @@ describe('institution link wallet route', () => {
         expect(mockUpdate).toHaveBeenCalledWith({
             wallet_address: walletAddress,
             verified: false,
+            status: 'pending',
             authorization_tx_hash: null,
         });
         expect(mockFirstEqAfterUpdate).toHaveBeenCalledWith('id', 'institution-1');


### PR DESCRIPTION

close #157 Institution onboarding & issuer verification (KYB)

Problem: Any signed-up "institution" can currently request issuance. In a real product, only vetted institutions may issue — otherwise the credentials mean nothing.

Tasks

Add an institution verification workflow: application → document/domain check → admin approval → on-chain issuer authorization.
Add institution status states (pending, verified, suspended, rejected) in the DB; gate issuance UI/API on verified.
Verify institution domain ownership (email-domain match / DNS TXT record) as a lightweight trust signal.
Call authorize_issuer on-chain only after admin approval; record who approved and when (audit trail).
Surface verification status in the institution dashboard.
Acceptance criteria: An unverified institution cannot issue via UI or API; verification state is auditable; on-chain authorization is granted only post-approval.


   make very small contribution
