### PR TITLE
implement rate limiting across various API endpoints and add tests fo…

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -57,3 +57,10 @@ NEXT_PUBLIC_ENABLE_DEBUG_LOGS=false
 # Point this at a Sentry/OTel/log-drain bridge, webhook collector, or hosted log pipeline.
 # Server-only deployments may use OBSERVABILITY_INGEST_URL instead.
 # NEXT_PUBLIC_OBSERVABILITY_INGEST_URL=https://observability.example.com/ingest
+
+# Optional distributed rate limiting via Upstash Redis REST.
+# When unset, API routes fall back to in-memory limits for local development.
+# UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=your_upstash_rest_token
+# Per-route overrides use RATE_LIMIT_<PREFIX>_MAX_REQUESTS or RATE_LIMIT_<PREFIX>_WINDOW_SECONDS.
+# Example: RATE_LIMIT_VERIFY_MAX_REQUESTS=30

--- a/frontend/src/app/api/account/erase/route.ts
+++ b/frontend/src/app/api/account/erase/route.ts
@@ -2,8 +2,15 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedRequest, getServiceRoleClient } from '@/lib/serverAuth';
 import { unpinFromPinata } from '@/lib/ipfsServer';
 import { captureException } from '@/lib/debug';
+import { enforceRateLimit } from '@/lib/rateLimit';
 
 export const dynamic = 'force-dynamic';
+
+const ACCOUNT_ERASE_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 5,
+    prefix: 'account-erase',
+} as const;
 
 /**
  * POST /api/account/erase
@@ -28,6 +35,11 @@ export async function POST(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
 
     try {
+        const rateLimitResponse = await enforceRateLimit(request, ACCOUNT_ERASE_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
         // 1. Authenticate.
         const authCheck = await requireAuthenticatedRequest(request);
         if (!authCheck.ok) {

--- a/frontend/src/app/api/admin/stats/route.ts
+++ b/frontend/src/app/api/admin/stats/route.ts
@@ -15,7 +15,7 @@ const ADMIN_STATS_RATE_LIMIT = {
 export async function GET(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
     try {
-        const rateLimitResponse = enforceRateLimit(request, ADMIN_STATS_RATE_LIMIT);
+        const rateLimitResponse = await enforceRateLimit(request, ADMIN_STATS_RATE_LIMIT);
         if (rateLimitResponse) {
             return rateLimitResponse;
         }

--- a/frontend/src/app/api/admin/update-authorization/route.ts
+++ b/frontend/src/app/api/admin/update-authorization/route.ts
@@ -15,7 +15,7 @@ const ADMIN_UPDATE_AUTHORIZATION_RATE_LIMIT = {
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
     try {
-        const rateLimitResponse = enforceRateLimit(request, ADMIN_UPDATE_AUTHORIZATION_RATE_LIMIT);
+        const rateLimitResponse = await enforceRateLimit(request, ADMIN_UPDATE_AUTHORIZATION_RATE_LIMIT);
         if (rateLimitResponse) {
             return rateLimitResponse;
         }

--- a/frontend/src/app/api/institution/link-wallet/route.ts
+++ b/frontend/src/app/api/institution/link-wallet/route.ts
@@ -25,7 +25,7 @@ function getAccessToken(request: NextRequest): string {
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
     try {
-        const rateLimitResponse = enforceRateLimit(request, INSTITUTION_LINK_WALLET_RATE_LIMIT);
+        const rateLimitResponse = await enforceRateLimit(request, INSTITUTION_LINK_WALLET_RATE_LIMIT);
         if (rateLimitResponse) {
             return rateLimitResponse;
         }

--- a/frontend/src/app/api/ipfs/file/route.ts
+++ b/frontend/src/app/api/ipfs/file/route.ts
@@ -25,7 +25,7 @@ const IPFS_FILE_USER_QUOTA = {
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
     try {
-        const ipRateLimitResponse = enforceRateLimit(request, IPFS_FILE_IP_RATE_LIMIT);
+        const ipRateLimitResponse = await enforceRateLimit(request, IPFS_FILE_IP_RATE_LIMIT);
         if (ipRateLimitResponse) {
             return ipRateLimitResponse;
         }
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        const userRateLimitResponse = enforceRateLimit(request, {
+        const userRateLimitResponse = await enforceRateLimit(request, {
             ...IPFS_FILE_USER_QUOTA,
             identifier: authCheck.userId,
         });

--- a/frontend/src/app/api/ipfs/json/route.ts
+++ b/frontend/src/app/api/ipfs/json/route.ts
@@ -25,7 +25,7 @@ const IPFS_JSON_USER_QUOTA = {
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
     try {
-        const ipRateLimitResponse = enforceRateLimit(request, IPFS_JSON_IP_RATE_LIMIT);
+        const ipRateLimitResponse = await enforceRateLimit(request, IPFS_JSON_IP_RATE_LIMIT);
         if (ipRateLimitResponse) {
             return ipRateLimitResponse;
         }
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        const userRateLimitResponse = enforceRateLimit(request, {
+        const userRateLimitResponse = await enforceRateLimit(request, {
             ...IPFS_JSON_USER_QUOTA,
             identifier: authCheck.userId,
         });

--- a/frontend/src/app/api/issuers/route.ts
+++ b/frontend/src/app/api/issuers/route.ts
@@ -25,7 +25,7 @@ export const dynamic = 'force-dynamic';
  * }
  */
 export async function GET(request: NextRequest) {
-    const rateLimitResponse = enforceRateLimit(request, {
+    const rateLimitResponse = await enforceRateLimit(request, {
         windowSeconds: 60,
         maxRequests: 60,
         prefix: 'issuers-public',

--- a/frontend/src/app/api/student/credentials/route.ts
+++ b/frontend/src/app/api/student/credentials/route.ts
@@ -30,7 +30,7 @@ type CredentialRow = {
 export async function GET(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
     try {
-        const rateLimitResponse = enforceRateLimit(request, STUDENT_CREDENTIALS_RATE_LIMIT);
+        const rateLimitResponse = await enforceRateLimit(request, STUDENT_CREDENTIALS_RATE_LIMIT);
         if (rateLimitResponse) {
             return rateLimitResponse;
         }

--- a/frontend/src/app/api/student/provision/route.ts
+++ b/frontend/src/app/api/student/provision/route.ts
@@ -17,7 +17,7 @@ const STUDENT_PROVISION_RATE_LIMIT = {
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
     try {
-        const rateLimitResponse = enforceRateLimit(request, STUDENT_PROVISION_RATE_LIMIT);
+        const rateLimitResponse = await enforceRateLimit(request, STUDENT_PROVISION_RATE_LIMIT);
         if (rateLimitResponse) {
             return rateLimitResponse;
         }

--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -124,7 +124,7 @@ export async function GET(
             );
         }
 
-        const rateLimitResponse = enforceRateLimit(request, VERIFY_RATE_LIMIT);
+        const rateLimitResponse = await enforceRateLimit(request, VERIFY_RATE_LIMIT);
         if (rateLimitResponse) {
             return rateLimitResponse;
         }

--- a/frontend/src/lib/rateLimit.ts
+++ b/frontend/src/lib/rateLimit.ts
@@ -18,9 +18,16 @@ type RateLimitResult = {
     retryAfter: number;
 };
 
-const buckets = new Map<string, number[]>();
+export type RateLimitBucket = { count: number; resetAt: number };
 
-const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // every 5 minutes
+export type RateLimitStore = {
+    increment: (key: string, windowSeconds: number) => Promise<{ count: number; resetAt: number }>;
+    reset?: () => void;
+};
+
+const fixedBuckets = new Map<string, RateLimitBucket>();
+
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 let lastCleanup = Date.now();
 
 export const getClientIp = (request: Request): string => {
@@ -45,64 +52,125 @@ export const getClientIp = (request: Request): string => {
     return 'unknown';
 };
 
-function cleanupStaleBuckets(now: number) {
-    for (const [key, timestamps] of buckets.entries()) {
-        // Remove entries with no activity in the last 10 minutes
-        const active = timestamps.filter((ts) => now - ts < 10 * 60 * 1000);
-        if (active.length === 0) {
-            buckets.delete(key);
-        } else {
-            buckets.set(key, active);
+function cleanupStaleBuckets(now: number, store = fixedBuckets) {
+    for (const [key, bucket] of store.entries()) {
+        if (bucket.resetAt <= now) {
+            store.delete(key);
         }
     }
     lastCleanup = now;
 }
 
-export const checkRateLimit = (
+export function createInMemoryRateLimitStore(
+    store: Map<string, RateLimitBucket> = new Map(),
+): RateLimitStore {
+    return {
+        async increment(key: string, windowSeconds: number) {
+            const now = Date.now();
+            if (now - lastCleanup > CLEANUP_INTERVAL_MS) {
+                cleanupStaleBuckets(now, store);
+            }
+
+            const existing = store.get(key);
+            if (!existing || existing.resetAt <= now) {
+                const bucket = { count: 1, resetAt: now + windowSeconds * 1000 };
+                store.set(key, bucket);
+                return bucket;
+            }
+
+            existing.count += 1;
+            store.set(key, existing);
+            return existing;
+        },
+        reset() {
+            store.clear();
+            lastCleanup = Date.now();
+        },
+    };
+}
+
+function createUpstashRateLimitStore(): RateLimitStore | null {
+    const url = process.env.UPSTASH_REDIS_REST_URL?.replace(/\/$/, '');
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) return null;
+
+    return {
+        async increment(key: string, windowSeconds: number) {
+            const response = await fetch(`${url}/pipeline`, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify([
+                    ['INCR', key],
+                    ['EXPIRE', key, windowSeconds, 'NX'],
+                    ['TTL', key],
+                ]),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Redis rate limit check failed: ${response.status}`);
+            }
+
+            const [countResult, , ttlResult] = await response.json() as Array<{ result?: unknown }>;
+            const count = Number(countResult?.result ?? 1);
+            const ttl = Number(ttlResult?.result ?? windowSeconds);
+
+            return {
+                count,
+                resetAt: Date.now() + Math.max(1, ttl) * 1000,
+            };
+        },
+    };
+}
+
+let activeStore = createUpstashRateLimitStore() ?? createInMemoryRateLimitStore(fixedBuckets);
+
+function readEnvOverride(prefix: string | undefined, name: 'WINDOW_SECONDS' | 'MAX_REQUESTS'): number | null {
+    if (!prefix) return null;
+    const envName = `RATE_LIMIT_${prefix.replace(/[^a-z0-9]/gi, '_').toUpperCase()}_${name}`;
+    const raw = process.env[envName];
+    if (!raw) return null;
+
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export const setRateLimitStoreForTests = (store: RateLimitStore) => {
+    activeStore = store;
+};
+
+export const checkRateLimit = async (
     request: Request,
     { windowSeconds, maxRequests, prefix = 'api', identifier }: RateLimitOptions,
-): RateLimitResult => {
-    const now = Date.now();
-    const windowMs = windowSeconds * 1000;
+): Promise<RateLimitResult> => {
+    const effectiveWindowSeconds = readEnvOverride(prefix, 'WINDOW_SECONDS') ?? windowSeconds;
+    const effectiveMaxRequests = readEnvOverride(prefix, 'MAX_REQUESTS') ?? maxRequests;
     const subject = identifier?.trim() || getClientIp(request);
     const key = `${prefix}:${subject}`;
+    const bucket = await activeStore.increment(key, effectiveWindowSeconds);
 
-    // Run cleanup periodically to prevent memory leak
-    if (now - lastCleanup > CLEANUP_INTERVAL_MS) {
-        cleanupStaleBuckets(now);
-    }
-
-    const timestamps = buckets.get(key) ?? [];
-    const activeTimestamps = timestamps.filter((timestamp) => now - timestamp < windowMs);
-
-    if (activeTimestamps.length >= maxRequests) {
-        const oldestTimestamp = activeTimestamps[0] ?? now;
-        const retryAfter = Math.max(1, Math.ceil((oldestTimestamp + windowMs - now) / 1000));
-
-        buckets.set(key, activeTimestamps);
-
+    if (bucket.count > effectiveMaxRequests) {
         return {
             success: false,
             remaining: 0,
-            retryAfter,
+            retryAfter: Math.max(1, Math.ceil((bucket.resetAt - Date.now()) / 1000)),
         };
     }
 
-    activeTimestamps.push(now);
-    buckets.set(key, activeTimestamps);
-
     return {
         success: true,
-        remaining: Math.max(0, maxRequests - activeTimestamps.length),
+        remaining: Math.max(0, effectiveMaxRequests - bucket.count),
         retryAfter: 0,
     };
 };
 
-export const enforceRateLimit = (
+export const enforceRateLimit = async (
     request: Request,
     options: RateLimitOptions,
-): NextResponse | null => {
-    const result = checkRateLimit(request, options);
+): Promise<NextResponse | null> => {
+    const result = await checkRateLimit(request, options);
 
     if (result.success) {
         return null;
@@ -120,6 +188,5 @@ export const enforceRateLimit = (
 };
 
 export const resetRateLimitStore = () => {
-    buckets.clear();
-    lastCleanup = Date.now();
+    activeStore.reset?.();
 };

--- a/frontend/tests/rateLimit.test.ts
+++ b/frontend/tests/rateLimit.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    checkRateLimit,
+    createInMemoryRateLimitStore,
+    resetRateLimitStore,
+    setRateLimitStoreForTests,
+    type RateLimitBucket,
+} from '@/lib/rateLimit';
+
+const originalVerifyLimit = process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS;
+
+afterEach(() => {
+    if (typeof originalVerifyLimit === 'undefined') {
+        delete process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS;
+    } else {
+        process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS = originalVerifyLimit;
+    }
+
+    setRateLimitStoreForTests(createInMemoryRateLimitStore());
+    resetRateLimitStore();
+});
+
+function requestFrom(ip: string): Request {
+    return new Request('http://localhost/api/verify/token-123', {
+        headers: { 'x-forwarded-for': ip },
+    });
+}
+
+describe('rateLimit', () => {
+    it('enforces limits across simulated instances that share a backing store', async () => {
+        const backingStore = new Map<string, RateLimitBucket>();
+        const instanceA = createInMemoryRateLimitStore(backingStore);
+        const instanceB = createInMemoryRateLimitStore(backingStore);
+
+        setRateLimitStoreForTests(instanceA);
+        await expect(checkRateLimit(requestFrom('203.0.113.50'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 2,
+        })).resolves.toMatchObject({ success: true, remaining: 1 });
+
+        setRateLimitStoreForTests(instanceB);
+        await expect(checkRateLimit(requestFrom('203.0.113.50'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 2,
+        })).resolves.toMatchObject({ success: true, remaining: 0 });
+
+        await expect(checkRateLimit(requestFrom('203.0.113.50'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 2,
+        })).resolves.toMatchObject({ success: false, remaining: 0 });
+    });
+
+    it('allows env overrides per route prefix', async () => {
+        process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS = '1';
+
+        await expect(checkRateLimit(requestFrom('203.0.113.51'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 10,
+        })).resolves.toMatchObject({ success: true });
+
+        await expect(checkRateLimit(requestFrom('203.0.113.51'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 10,
+        })).resolves.toMatchObject({ success: false });
+    });
+});


### PR DESCRIPTION
close #165 Distributed rate limiting (Redis)


Problem: Rate limiting is in-memory, so it resets per instance and doesn't hold across a horizontally scaled deployment.

Tasks

Back rate limiting with a shared store (e.g., Upstash Redis) keyed by IP/user/route.
Apply consistent limits to verify, IPFS, admin, and auth-adjacent routes.
Return standard 429 + Retry-After; make limits env-configurable.
Add tests for limit enforcement across simulated instances.
Acceptance criteria: Limits hold globally across instances; bursts get 429; legitimate traffic is unaffected.