### PR TITLE
 Distributed rate limiting (Redis)

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -58,9 +58,43 @@ NEXT_PUBLIC_ENABLE_DEBUG_LOGS=false
 # Server-only deployments may use OBSERVABILITY_INGEST_URL instead.
 # NEXT_PUBLIC_OBSERVABILITY_INGEST_URL=https://observability.example.com/ingest
 
-# Optional distributed rate limiting via Upstash Redis REST.
-# When unset, API routes fall back to in-memory limits for local development.
-# UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
+# Distributed rate limiting via Upstash Redis REST.
+# When unset, all API routes fall back to in-memory limits (resets per instance — not suitable for
+# horizontally scaled deployments). Set both variables to activate the shared Redis store.
+# UPSTASH_REDIS_REST_URL=https://your-database.upstash.io
 # UPSTASH_REDIS_REST_TOKEN=your_upstash_rest_token
-# Per-route overrides use RATE_LIMIT_<PREFIX>_MAX_REQUESTS or RATE_LIMIT_<PREFIX>_WINDOW_SECONDS.
-# Example: RATE_LIMIT_VERIFY_MAX_REQUESTS=30
+#
+# Per-route overrides — format: RATE_LIMIT_<PREFIX>_MAX_REQUESTS or RATE_LIMIT_<PREFIX>_WINDOW_SECONDS
+# The prefix is the value passed to `enforceRateLimit` in each route, uppercased with non-alphanumeric
+# characters replaced by underscores. Omit a variable to keep the coded default.
+#
+# Public / unauthenticated routes
+# RATE_LIMIT_VERIFY_MAX_REQUESTS=10
+# RATE_LIMIT_VERIFY_WINDOW_SECONDS=60
+# RATE_LIMIT_ISSUERS_PUBLIC_MAX_REQUESTS=60
+#
+# Admin routes
+# RATE_LIMIT_ADMIN_STATS_MAX_REQUESTS=60
+# RATE_LIMIT_ADMIN_UPDATE_AUTHORIZATION_MAX_REQUESTS=60
+#
+# Student routes
+# RATE_LIMIT_STUDENT_CREDENTIALS_MAX_REQUESTS=60
+# RATE_LIMIT_STUDENT_PROVISION_MAX_REQUESTS=60
+#
+# IPFS upload routes (dual-layer: IP + per-user)
+# RATE_LIMIT_IPFS_FILE_IP_MAX_REQUESTS=20
+# RATE_LIMIT_IPFS_FILE_USER_MAX_REQUESTS=10
+# RATE_LIMIT_IPFS_JSON_IP_MAX_REQUESTS=20
+# RATE_LIMIT_IPFS_JSON_USER_MAX_REQUESTS=10
+#
+# Institution routes (dual-layer: IP + per-user)
+# RATE_LIMIT_INSTITUTION_CREDENTIALS_IP_MAX_REQUESTS=30
+# RATE_LIMIT_INSTITUTION_CREDENTIALS_USER_MAX_REQUESTS=60
+# RATE_LIMIT_INSTITUTION_ANALYTICS_IP_MAX_REQUESTS=20
+# RATE_LIMIT_INSTITUTION_ANALYTICS_USER_MAX_REQUESTS=20
+# RATE_LIMIT_INSTITUTION_EXPORT_IP_MAX_REQUESTS=10
+# RATE_LIMIT_INSTITUTION_EXPORT_USER_MAX_REQUESTS=10
+#
+# Account management
+# RATE_LIMIT_ACCOUNT_ERASE_MAX_REQUESTS=5
+# RATE_LIMIT_INSTITUTION_LINK_WALLET_MAX_REQUESTS=30

--- a/frontend/src/app/api/institution/analytics/route.ts
+++ b/frontend/src/app/api/institution/analytics/route.ts
@@ -4,14 +4,32 @@ import {
     hasServiceRoleEnv,
     requireAuthenticatedRequest,
 } from '@/lib/serverAuth';
+import { enforceRateLimit } from '@/lib/rateLimit';
 import { last12Months, groupByMonth, fillMonths, topVerified } from '@/lib/analyticsAggregation';
 import { captureException, structuredLog } from '@/lib/debug';
+
+// Analytics aggregates the full credential + verification log set for an institution.
+// Each request is relatively expensive, so limits are tighter than the credential list.
+const INSTITUTION_ANALYTICS_IP_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 20,
+    prefix: 'institution-analytics-ip',
+} as const;
+
+const INSTITUTION_ANALYTICS_USER_QUOTA = {
+    windowSeconds: 60,
+    maxRequests: 20,
+    prefix: 'institution-analytics-user',
+} as const;
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') ?? 'unknown';
     try {
+        const ipRateLimitResponse = await enforceRateLimit(request, INSTITUTION_ANALYTICS_IP_LIMIT);
+        if (ipRateLimitResponse) return ipRateLimitResponse;
+
         const authCheck = await requireAuthenticatedRequest(request);
         if (!authCheck.ok) {
             return NextResponse.json(
@@ -19,6 +37,12 @@ export async function GET(request: NextRequest) {
                 { status: authCheck.status },
             );
         }
+
+        const userRateLimitResponse = await enforceRateLimit(request, {
+            ...INSTITUTION_ANALYTICS_USER_QUOTA,
+            identifier: authCheck.userId,
+        });
+        if (userRateLimitResponse) return userRateLimitResponse;
 
         const supabase = hasServiceRoleEnv()
             ? getServiceRoleClient()

--- a/frontend/src/app/api/institution/credentials/route.ts
+++ b/frontend/src/app/api/institution/credentials/route.ts
@@ -4,13 +4,33 @@ import {
     hasServiceRoleEnv,
     requireAuthenticatedRequest,
 } from '@/lib/serverAuth';
+import { enforceRateLimit } from '@/lib/rateLimit';
 import { structuredLog, captureException } from '@/lib/debug';
+
+// Coarse per-IP guard applied before auth to prevent anonymous floods from
+// driving Supabase token verification on this potentially expensive query.
+const INSTITUTION_CREDENTIALS_IP_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 30,
+    prefix: 'institution-credentials-ip',
+} as const;
+
+// Tighter per-account quota; institutions browsing their own credential list
+// should not need more than 60 paginated fetches per minute.
+const INSTITUTION_CREDENTIALS_USER_QUOTA = {
+    windowSeconds: 60,
+    maxRequests: 60,
+    prefix: 'institution-credentials-user',
+} as const;
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') || 'unknown';
     try {
+        const ipRateLimitResponse = await enforceRateLimit(request, INSTITUTION_CREDENTIALS_IP_LIMIT);
+        if (ipRateLimitResponse) return ipRateLimitResponse;
+
         const authCheck = await requireAuthenticatedRequest(request);
         if (!authCheck.ok) {
             return NextResponse.json(
@@ -18,6 +38,12 @@ export async function GET(request: NextRequest) {
                 { status: authCheck.status }
             );
         }
+
+        const userRateLimitResponse = await enforceRateLimit(request, {
+            ...INSTITUTION_CREDENTIALS_USER_QUOTA,
+            identifier: authCheck.userId,
+        });
+        if (userRateLimitResponse) return userRateLimitResponse;
 
         const supabase = hasServiceRoleEnv()
             ? getServiceRoleClient()

--- a/frontend/src/app/api/institution/export/route.ts
+++ b/frontend/src/app/api/institution/export/route.ts
@@ -4,14 +4,31 @@ import {
     hasServiceRoleEnv,
     requireAuthenticatedRequest,
 } from '@/lib/serverAuth';
+import { enforceRateLimit } from '@/lib/rateLimit';
 import { toCsv } from '@/lib/analyticsAggregation';
 import { captureException, structuredLog } from '@/lib/debug';
+
+// CSV export streams the full credential set; treat it as expensive as analytics.
+const INSTITUTION_EXPORT_IP_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 10,
+    prefix: 'institution-export-ip',
+} as const;
+
+const INSTITUTION_EXPORT_USER_QUOTA = {
+    windowSeconds: 60,
+    maxRequests: 10,
+    prefix: 'institution-export-user',
+} as const;
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') ?? 'unknown';
     try {
+        const ipRateLimitResponse = await enforceRateLimit(request, INSTITUTION_EXPORT_IP_LIMIT);
+        if (ipRateLimitResponse) return ipRateLimitResponse;
+
         const authCheck = await requireAuthenticatedRequest(request);
         if (!authCheck.ok) {
             return NextResponse.json(
@@ -19,6 +36,12 @@ export async function GET(request: NextRequest) {
                 { status: authCheck.status },
             );
         }
+
+        const userRateLimitResponse = await enforceRateLimit(request, {
+            ...INSTITUTION_EXPORT_USER_QUOTA,
+            identifier: authCheck.userId,
+        });
+        if (userRateLimitResponse) return userRateLimitResponse;
 
         const supabase = hasServiceRoleEnv()
             ? getServiceRoleClient()

--- a/frontend/src/lib/rateLimit.ts
+++ b/frontend/src/lib/rateLimit.ts
@@ -89,43 +89,113 @@ export function createInMemoryRateLimitStore(
     };
 }
 
-function createUpstashRateLimitStore(): RateLimitStore | null {
+export function createUpstashRateLimitStore(): RateLimitStore | null {
     const url = process.env.UPSTASH_REDIS_REST_URL?.replace(/\/$/, '');
     const token = process.env.UPSTASH_REDIS_REST_TOKEN;
     if (!url || !token) return null;
 
+    // Capture at store-creation time so a later env mutation cannot change which
+    // endpoint is in use for this store instance.
+    const restUrl = url;
+    const restToken = token;
+
+    // Fallback in-memory store used transparently when Redis is temporarily
+    // unreachable so individual requests are never outright dropped due to an
+    // infrastructure hiccup.
+    const fallback = createInMemoryRateLimitStore();
+
     return {
         async increment(key: string, windowSeconds: number) {
-            const response = await fetch(`${url}/pipeline`, {
-                method: 'POST',
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify([
-                    ['INCR', key],
-                    ['EXPIRE', key, windowSeconds, 'NX'],
-                    ['TTL', key],
-                ]),
-            });
+            try {
+                const response = await fetch(`${restUrl}/pipeline`, {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${restToken}`,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify([
+                        ['INCR', key],
+                        ['EXPIRE', key, windowSeconds, 'NX'],
+                        ['TTL', key],
+                    ]),
+                });
 
-            if (!response.ok) {
-                throw new Error(`Redis rate limit check failed: ${response.status}`);
+                if (!response.ok) {
+                    throw new Error(`Upstash responded ${response.status}`);
+                }
+
+                const [countResult, , ttlResult] = await response.json() as Array<{ result?: unknown }>;
+                const count = Number(countResult?.result ?? 1);
+                const ttl = Number(ttlResult?.result ?? windowSeconds);
+
+                return {
+                    count,
+                    resetAt: Date.now() + Math.max(1, ttl) * 1000,
+                };
+            } catch (err) {
+                // Degrade gracefully: log and fall back to per-instance memory store.
+                // This means limits may not be globally enforced during an outage, but
+                // legitimate traffic is never blocked by a Redis error.
+                console.error('[rateLimit] Upstash error, falling back to in-memory:', err);
+                return fallback.increment(key, windowSeconds);
             }
+        },
+        // Flush all rate-limit keys in the configured Upstash database.
+        // Uses SCAN + DEL to avoid blocking the server with a FLUSHDB.
+        // Intended for test harnesses and ops tooling — not for production hot paths.
+        async reset() {
+            try {
+                let cursor = '0';
+                const keysToDelete: string[] = [];
 
-            const [countResult, , ttlResult] = await response.json() as Array<{ result?: unknown }>;
-            const count = Number(countResult?.result ?? 1);
-            const ttl = Number(ttlResult?.result ?? windowSeconds);
+                do {
+                    const scanResponse = await fetch(`${restUrl}/pipeline`, {
+                        method: 'POST',
+                        headers: {
+                            Authorization: `Bearer ${restToken}`,
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify([['SCAN', cursor, 'MATCH', '*', 'COUNT', '100']]),
+                    });
 
-            return {
-                count,
-                resetAt: Date.now() + Math.max(1, ttl) * 1000,
-            };
+                    if (!scanResponse.ok) break;
+
+                    const [scanResult] = await scanResponse.json() as Array<{ result?: [string, string[]] }>;
+                    const [nextCursor, keys] = scanResult?.result ?? ['0', []];
+                    cursor = nextCursor;
+                    keysToDelete.push(...keys);
+                } while (cursor !== '0');
+
+                if (keysToDelete.length > 0) {
+                    await fetch(`${restUrl}/pipeline`, {
+                        method: 'POST',
+                        headers: {
+                            Authorization: `Bearer ${restToken}`,
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify(keysToDelete.map((k) => ['DEL', k])),
+                    });
+                }
+
+                // Also flush the local fallback store
+                fallback.reset?.();
+            } catch (err) {
+                console.error('[rateLimit] Upstash reset error:', err);
+                fallback.reset?.();
+            }
         },
     };
 }
 
-let activeStore = createUpstashRateLimitStore() ?? createInMemoryRateLimitStore(fixedBuckets);
+let activeStore: RateLimitStore = createUpstashRateLimitStore() ?? createInMemoryRateLimitStore(fixedBuckets);
+
+/**
+ * Re-read the Upstash environment variables and replace the active store.
+ * Useful when env vars are injected after module load (e.g., in test bootstraps).
+ */
+export function reinitRateLimitStore(): void {
+    activeStore = createUpstashRateLimitStore() ?? createInMemoryRateLimitStore(fixedBuckets);
+}
 
 function readEnvOverride(prefix: string | undefined, name: 'WINDOW_SECONDS' | 'MAX_REQUESTS'): number | null {
     if (!prefix) return null;

--- a/frontend/tests/institution-route-rate-limit.test.ts
+++ b/frontend/tests/institution-route-rate-limit.test.ts
@@ -1,0 +1,264 @@
+/// <reference types="vitest/globals" />
+import { GET as credentialsGET } from '@/app/api/institution/credentials/route';
+import { GET as analyticsGET } from '@/app/api/institution/analytics/route';
+import { GET as exportGET } from '@/app/api/institution/export/route';
+import { resetRateLimitStore } from '@/lib/rateLimit';
+
+// ─── serverAuth mock ──────────────────────────────────────────────────────────
+// All three routes call requireAuthenticatedRequest; we return a valid session
+// with a stable userId so per-user quota tests work predictably.
+
+vi.mock('@/lib/serverAuth', () => ({
+    requireAuthenticatedRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        userId: 'user-inst-test',
+        user: { id: 'user-inst-test' },
+        accessToken: 'tok',
+    }),
+    hasServiceRoleEnv: () => true,
+    getServiceRoleClient: () => supabaseStub(),
+}));
+
+// ─── Supabase stub ────────────────────────────────────────────────────────────
+// Returns the minimal fluent chain each route needs without hitting the network.
+
+function supabaseStub() {
+    const credentialsRow = {
+        id: 'cred-1',
+        token_id: 'tok-1',
+        issued_at: new Date().toISOString(),
+        revoked: false,
+        metadata: { credentialData: { credentialType: 'Degree', studentName: 'Alice' } },
+    };
+
+    const chain = {
+        select: () => chain,
+        eq: () => chain,
+        maybeSingle: async () => ({ data: { id: 'inst-1' }, error: null }),
+        order: () => chain,
+        range: () => chain,
+        gte: () => chain,
+        lte: () => chain,
+        or: () => chain,
+        in: () => chain,
+        // Called by credentials route (count variant)
+        then: undefined as unknown,
+    };
+
+    // Credentials route uses { count: 'exact' } select and awaits the query directly.
+    const countChain = {
+        ...chain,
+        // Vitest awaits the object via its promise interface if we add then().
+        // Instead we make the chain itself thenable so `await query` works.
+        // The route destructures { data, error, count } from the resolved value.
+        [Symbol.asyncIterator]: undefined,
+    };
+
+    return {
+        from: (table: string) => {
+            if (table === 'institutions') {
+                return {
+                    select: () => ({
+                        eq: () => ({
+                            maybeSingle: async () => ({ data: { id: 'inst-1' }, error: null }),
+                        }),
+                    }),
+                };
+            }
+            if (table === 'credentials') {
+                // Return a promise-like so `await query` resolves with { data, error, count }
+                const credQuery = {
+                    select: () => credQuery,
+                    eq: () => credQuery,
+                    order: () => credQuery,
+                    range: () => credQuery,
+                    gte: () => credQuery,
+                    lte: () => credQuery,
+                    or: () => credQuery,
+                    then(resolve: (v: unknown) => void) {
+                        resolve({ data: [credentialsRow], error: null, count: 1 });
+                    },
+                };
+                return credQuery;
+            }
+            if (table === 'verification_logs') {
+                return {
+                    select: () => ({
+                        in: async () => ({ data: [], error: null }),
+                    }),
+                };
+            }
+            return chain;
+        },
+    };
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(path: string, ip = '203.0.113.20'): Request {
+    return new Request(`http://localhost${path}`, {
+        headers: { 'x-forwarded-for': ip },
+    });
+}
+
+type RouteHandler = (req: Request) => Promise<Response>;
+
+async function assertRateLimitEnforced(
+    handler: RouteHandler,
+    requestFactory: () => Request,
+    allowedCount: number,
+) {
+    for (let i = 0; i < allowedCount; i++) {
+        const res = await handler(requestFactory());
+        expect(res.status, `request ${i + 1} should succeed`).not.toBe(429);
+    }
+
+    const blocked = await handler(requestFactory());
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('Retry-After')).toBeTruthy();
+    await expect(blocked.json()).resolves.toEqual({
+        success: false,
+        error: 'Too many requests',
+    });
+}
+
+// ─── setup / teardown ─────────────────────────────────────────────────────────
+
+const ENV_OVERRIDES: Record<string, string> = {
+    // Reduce limits to small numbers so tests run in milliseconds.
+    RATE_LIMIT_INSTITUTION_CREDENTIALS_IP_MAX_REQUESTS: '3',
+    RATE_LIMIT_INSTITUTION_CREDENTIALS_USER_MAX_REQUESTS: '3',
+    RATE_LIMIT_INSTITUTION_ANALYTICS_IP_MAX_REQUESTS: '3',
+    RATE_LIMIT_INSTITUTION_ANALYTICS_USER_MAX_REQUESTS: '3',
+    RATE_LIMIT_INSTITUTION_EXPORT_IP_MAX_REQUESTS: '3',
+    RATE_LIMIT_INSTITUTION_EXPORT_USER_MAX_REQUESTS: '3',
+};
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+    for (const k of Object.keys(ENV_OVERRIDES)) savedEnv[k] = process.env[k];
+    Object.assign(process.env, ENV_OVERRIDES);
+    resetRateLimitStore();
+});
+
+afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+        if (typeof v === 'undefined') delete process.env[k];
+        else process.env[k] = v;
+    }
+});
+
+// ─── institution/credentials ──────────────────────────────────────────────────
+
+describe('GET /api/institution/credentials rate limiting', () => {
+    it('returns 429 with Retry-After after the IP limit is exceeded', async () => {
+        // IP limit is 3; all three succeed, fourth is blocked.
+        await assertRateLimitEnforced(
+            (req) => credentialsGET(req as Parameters<typeof credentialsGET>[0]),
+            () => makeRequest('/api/institution/credentials', '10.10.10.1'),
+            3,
+        );
+    });
+
+    it('returns 429 with Retry-After after the per-user limit is exceeded', async () => {
+        // Use a unique IP per request so IP limit is never the trigger;
+        // the user quota (keyed by userId from the mock) must be the one that fires.
+        let ipCounter = 1;
+        await assertRateLimitEnforced(
+            (req) => credentialsGET(req as Parameters<typeof credentialsGET>[0]),
+            () => makeRequest('/api/institution/credentials', `10.20.30.${ipCounter++}`),
+            3,
+        );
+    });
+
+    it('IP limit is scoped per-address and does not bleed into other IPs', async () => {
+        // Make 2 requests from IP A (within the 3-request IP limit).
+        for (let i = 0; i < 2; i++) {
+            const res = await credentialsGET(
+                makeRequest('/api/institution/credentials', '10.10.10.2') as Parameters<typeof credentialsGET>[0],
+            );
+            expect(res.status, `IP-A request ${i + 1} should succeed`).not.toBe(429);
+        }
+        // Make 1 request from IP B — it has its own fresh IP bucket, so it must succeed
+        // (user bucket for the shared test userId is at 2/3 from IP-A above).
+        const resB = await credentialsGET(
+            makeRequest('/api/institution/credentials', '10.10.10.4') as Parameters<typeof credentialsGET>[0],
+        );
+        expect(resB.status).not.toBe(429);
+    });
+});
+
+// ─── institution/analytics ────────────────────────────────────────────────────
+
+describe('GET /api/institution/analytics rate limiting', () => {
+    it('returns 429 with Retry-After after the IP limit is exceeded', async () => {
+        await assertRateLimitEnforced(
+            (req) => analyticsGET(req as Parameters<typeof analyticsGET>[0]),
+            () => makeRequest('/api/institution/analytics', '10.10.20.1'),
+            3,
+        );
+    });
+
+    it('returns 429 with Retry-After after the per-user limit is exceeded', async () => {
+        let ipCounter = 100;
+        await assertRateLimitEnforced(
+            (req) => analyticsGET(req as Parameters<typeof analyticsGET>[0]),
+            () => makeRequest('/api/institution/analytics', `10.20.40.${ipCounter++}`),
+            3,
+        );
+    });
+
+    it('response body is standard rate limit error shape', async () => {
+        for (let i = 0; i < 3; i++) {
+            await analyticsGET(
+                makeRequest('/api/institution/analytics', '10.10.20.5') as Parameters<typeof analyticsGET>[0],
+            );
+        }
+        const blocked = await analyticsGET(
+            makeRequest('/api/institution/analytics', '10.10.20.5') as Parameters<typeof analyticsGET>[0],
+        );
+        expect(blocked.status).toBe(429);
+        await expect(blocked.json()).resolves.toMatchObject({
+            success: false,
+            error: 'Too many requests',
+        });
+    });
+});
+
+// ─── institution/export ───────────────────────────────────────────────────────
+
+describe('GET /api/institution/export rate limiting', () => {
+    it('returns 429 with Retry-After after the IP limit is exceeded', async () => {
+        await assertRateLimitEnforced(
+            (req) => exportGET(req as Parameters<typeof exportGET>[0]),
+            () => makeRequest('/api/institution/export', '10.10.30.1'),
+            3,
+        );
+    });
+
+    it('returns 429 with Retry-After after the per-user limit is exceeded', async () => {
+        let ipCounter = 200;
+        await assertRateLimitEnforced(
+            (req) => exportGET(req as Parameters<typeof exportGET>[0]),
+            () => makeRequest('/api/institution/export', `10.20.50.${ipCounter++}`),
+            3,
+        );
+    });
+
+    it('Retry-After header is a positive integer string', async () => {
+        for (let i = 0; i < 3; i++) {
+            await exportGET(
+                makeRequest('/api/institution/export', '10.10.30.9') as Parameters<typeof exportGET>[0],
+            );
+        }
+        const blocked = await exportGET(
+            makeRequest('/api/institution/export', '10.10.30.9') as Parameters<typeof exportGET>[0],
+        );
+        const retryAfter = blocked.headers.get('Retry-After');
+        expect(retryAfter).not.toBeNull();
+        const parsed = parseInt(retryAfter!, 10);
+        expect(Number.isInteger(parsed)).toBe(true);
+        expect(parsed).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/frontend/tests/rateLimit.test.ts
+++ b/frontend/tests/rateLimit.test.ts
@@ -1,71 +1,334 @@
-import { afterEach, describe, expect, it } from 'vitest';
+/// <reference types="vitest/globals" />
 import {
     checkRateLimit,
     createInMemoryRateLimitStore,
+    createUpstashRateLimitStore,
     resetRateLimitStore,
     setRateLimitStoreForTests,
     type RateLimitBucket,
 } from '@/lib/rateLimit';
 
-const originalVerifyLimit = process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS;
+// ─── helpers ──────────────────────────────────────────────────────────────────
 
-afterEach(() => {
-    if (typeof originalVerifyLimit === 'undefined') {
-        delete process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS;
-    } else {
-        process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS = originalVerifyLimit;
-    }
-
-    setRateLimitStoreForTests(createInMemoryRateLimitStore());
-    resetRateLimitStore();
-});
-
-function requestFrom(ip: string): Request {
-    return new Request('http://localhost/api/verify/token-123', {
+function requestFrom(ip: string, path = '/api/verify/token-123'): Request {
+    return new Request(`http://localhost${path}`, {
         headers: { 'x-forwarded-for': ip },
     });
 }
 
-describe('rateLimit', () => {
+/** Build the JSON body Upstash returns for a pipeline of [INCR, EXPIRE NX, TTL]. */
+function upstashPipelineResponse(count: number, ttl: number) {
+    return JSON.stringify([
+        { result: count }, // INCR
+        { result: 1 },     // EXPIRE NX
+        { result: ttl },   // TTL
+    ]);
+}
+
+// Env keys touched by tests — saved/restored around every test.
+const ENV_KEYS = [
+    'RATE_LIMIT_VERIFY_MAX_REQUESTS',
+    'UPSTASH_REDIS_REST_URL',
+    'UPSTASH_REDIS_REST_TOKEN',
+] as const;
+
+// ─── in-memory: core behaviour ────────────────────────────────────────────────
+
+describe('in-memory store', () => {
+    afterEach(() => {
+        setRateLimitStoreForTests(createInMemoryRateLimitStore());
+        resetRateLimitStore();
+        vi.restoreAllMocks();
+    });
+
     it('enforces limits across simulated instances that share a backing store', async () => {
         const backingStore = new Map<string, RateLimitBucket>();
         const instanceA = createInMemoryRateLimitStore(backingStore);
         const instanceB = createInMemoryRateLimitStore(backingStore);
 
         setRateLimitStoreForTests(instanceA);
-        await expect(checkRateLimit(requestFrom('203.0.113.50'), {
-            prefix: 'verify',
-            windowSeconds: 60,
-            maxRequests: 2,
-        })).resolves.toMatchObject({ success: true, remaining: 1 });
+        await expect(
+            checkRateLimit(requestFrom('203.0.113.50'), { prefix: 'verify', windowSeconds: 60, maxRequests: 2 }),
+        ).resolves.toMatchObject({ success: true, remaining: 1 });
 
         setRateLimitStoreForTests(instanceB);
-        await expect(checkRateLimit(requestFrom('203.0.113.50'), {
-            prefix: 'verify',
-            windowSeconds: 60,
-            maxRequests: 2,
-        })).resolves.toMatchObject({ success: true, remaining: 0 });
+        await expect(
+            checkRateLimit(requestFrom('203.0.113.50'), { prefix: 'verify', windowSeconds: 60, maxRequests: 2 }),
+        ).resolves.toMatchObject({ success: true, remaining: 0 });
 
-        await expect(checkRateLimit(requestFrom('203.0.113.50'), {
-            prefix: 'verify',
-            windowSeconds: 60,
-            maxRequests: 2,
-        })).resolves.toMatchObject({ success: false, remaining: 0 });
+        // Third request — different instance, shared backing map — must be blocked globally.
+        await expect(
+            checkRateLimit(requestFrom('203.0.113.50'), { prefix: 'verify', windowSeconds: 60, maxRequests: 2 }),
+        ).resolves.toMatchObject({ success: false, remaining: 0 });
     });
 
-    it('allows env overrides per route prefix', async () => {
+    it('isolates limits by IP', async () => {
+        setRateLimitStoreForTests(createInMemoryRateLimitStore());
+
+        await checkRateLimit(requestFrom('10.0.0.1'), { prefix: 'verify', windowSeconds: 60, maxRequests: 1 });
+        // Different IP must still be allowed
+        await expect(
+            checkRateLimit(requestFrom('10.0.0.2'), { prefix: 'verify', windowSeconds: 60, maxRequests: 1 }),
+        ).resolves.toMatchObject({ success: true });
+    });
+
+    it('isolates limits by identifier (per-user quota)', async () => {
+        setRateLimitStoreForTests(createInMemoryRateLimitStore());
+        const opts = { prefix: 'institution-credentials-user', windowSeconds: 60, maxRequests: 1 };
+
+        await checkRateLimit(requestFrom('1.2.3.4'), { ...opts, identifier: 'user-aaa' });
+
+        // Same IP, different user identifier → must succeed
+        await expect(
+            checkRateLimit(requestFrom('1.2.3.4'), { ...opts, identifier: 'user-bbb' }),
+        ).resolves.toMatchObject({ success: true });
+
+        // Same user again → must be blocked
+        await expect(
+            checkRateLimit(requestFrom('1.2.3.4'), { ...opts, identifier: 'user-aaa' }),
+        ).resolves.toMatchObject({ success: false });
+    });
+
+    it('returns a positive integer retryAfter on a blocked result', async () => {
+        setRateLimitStoreForTests(createInMemoryRateLimitStore());
+
+        await checkRateLimit(requestFrom('5.5.5.5'), { prefix: 'verify', windowSeconds: 60, maxRequests: 1 });
+        const result = await checkRateLimit(requestFrom('5.5.5.5'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 1,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.retryAfter).toBeGreaterThanOrEqual(1);
+        expect(Number.isInteger(result.retryAfter)).toBe(true);
+    });
+
+    it('cross-instance limits hold for institution-analytics-ip prefix', async () => {
+        const backing = new Map<string, RateLimitBucket>();
+        const a = createInMemoryRateLimitStore(backing);
+        const b = createInMemoryRateLimitStore(backing);
+        const opts = { prefix: 'institution-analytics-ip', windowSeconds: 60, maxRequests: 2 };
+        const req = requestFrom('192.0.2.1', '/api/institution/analytics');
+
+        setRateLimitStoreForTests(a);
+        await expect(checkRateLimit(req, opts)).resolves.toMatchObject({ success: true, remaining: 1 });
+
+        setRateLimitStoreForTests(b);
+        await expect(checkRateLimit(req, opts)).resolves.toMatchObject({ success: true, remaining: 0 });
+        await expect(checkRateLimit(req, opts)).resolves.toMatchObject({ success: false, remaining: 0 });
+    });
+
+    it('cross-instance limits hold for institution-export-user prefix', async () => {
+        const backing = new Map<string, RateLimitBucket>();
+        const a = createInMemoryRateLimitStore(backing);
+        const b = createInMemoryRateLimitStore(backing);
+        const opts = { prefix: 'institution-export-user', windowSeconds: 60, maxRequests: 1 };
+        const req = requestFrom('192.0.2.2', '/api/institution/export');
+
+        setRateLimitStoreForTests(a);
+        await expect(
+            checkRateLimit(req, { ...opts, identifier: 'user-xyz' }),
+        ).resolves.toMatchObject({ success: true });
+
+        setRateLimitStoreForTests(b);
+        await expect(
+            checkRateLimit(req, { ...opts, identifier: 'user-xyz' }),
+        ).resolves.toMatchObject({ success: false });
+    });
+});
+
+// ─── env overrides ────────────────────────────────────────────────────────────
+
+describe('env overrides', () => {
+    const saved: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+        for (const k of ENV_KEYS) saved[k] = process.env[k];
+        for (const k of ENV_KEYS) delete process.env[k];
+        setRateLimitStoreForTests(createInMemoryRateLimitStore());
+        resetRateLimitStore();
+    });
+
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (typeof saved[k] === 'undefined') delete process.env[k];
+            else process.env[k] = saved[k];
+        }
+    });
+
+    it('respects RATE_LIMIT_<PREFIX>_MAX_REQUESTS override', async () => {
         process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS = '1';
 
-        await expect(checkRateLimit(requestFrom('203.0.113.51'), {
-            prefix: 'verify',
-            windowSeconds: 60,
-            maxRequests: 10,
-        })).resolves.toMatchObject({ success: true });
+        await expect(
+            checkRateLimit(requestFrom('203.0.113.51'), { prefix: 'verify', windowSeconds: 60, maxRequests: 10 }),
+        ).resolves.toMatchObject({ success: true });
 
-        await expect(checkRateLimit(requestFrom('203.0.113.51'), {
+        await expect(
+            checkRateLimit(requestFrom('203.0.113.51'), { prefix: 'verify', windowSeconds: 60, maxRequests: 10 }),
+        ).resolves.toMatchObject({ success: false });
+    });
+
+    it('ignores a malformed override value and uses the coded default', async () => {
+        process.env.RATE_LIMIT_VERIFY_MAX_REQUESTS = 'not-a-number';
+
+        const opts = { prefix: 'verify', windowSeconds: 60, maxRequests: 10 };
+        // Coded default is 10; first two requests should both succeed
+        await expect(checkRateLimit(requestFrom('203.0.113.52'), opts)).resolves.toMatchObject({ success: true });
+        await expect(checkRateLimit(requestFrom('203.0.113.52'), opts)).resolves.toMatchObject({ success: true });
+    });
+});
+
+// ─── Upstash store ────────────────────────────────────────────────────────────
+
+describe('Upstash store', () => {
+    const FAKE_URL = 'https://fake-redis.upstash.io';
+    const FAKE_TOKEN = 'fake-token';
+    const saved: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+        for (const k of ENV_KEYS) saved[k] = process.env[k];
+        for (const k of ENV_KEYS) delete process.env[k];
+        process.env.UPSTASH_REDIS_REST_URL = FAKE_URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = FAKE_TOKEN;
+        setRateLimitStoreForTests(createInMemoryRateLimitStore());
+        resetRateLimitStore();
+    });
+
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (typeof saved[k] === 'undefined') delete process.env[k];
+            else process.env[k] = saved[k];
+        }
+        vi.restoreAllMocks();
+    });
+
+    it('createUpstashRateLimitStore returns null when env vars are absent', () => {
+        delete process.env.UPSTASH_REDIS_REST_URL;
+        delete process.env.UPSTASH_REDIS_REST_TOKEN;
+        expect(createUpstashRateLimitStore()).toBeNull();
+    });
+
+    it('createUpstashRateLimitStore returns a store when env vars are present', () => {
+        expect(createUpstashRateLimitStore()).not.toBeNull();
+    });
+
+    it('increments via Upstash pipeline and returns correct count + resetAt', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+            new Response(upstashPipelineResponse(1, 60), { status: 200 }),
+        );
+
+        const store = createUpstashRateLimitStore()!;
+        const result = await store.increment('verify:1.2.3.4', 60);
+
+        expect(result.count).toBe(1);
+        expect(result.resetAt).toBeGreaterThan(Date.now());
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe(`${FAKE_URL}/pipeline`);
+        expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${FAKE_TOKEN}`);
+        const body = JSON.parse(init.body as string) as unknown[][];
+        expect(body[0]).toEqual(['INCR', 'verify:1.2.3.4']);
+        expect(body[1]).toEqual(['EXPIRE', 'verify:1.2.3.4', 60, 'NX']);
+        expect(body[2]).toEqual(['TTL', 'verify:1.2.3.4']);
+    });
+
+    it('blocks when Upstash returns a count exceeding maxRequests', async () => {
+        // Simulate counter already at 11 with 45 s TTL remaining
+        vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+            new Response(upstashPipelineResponse(11, 45), { status: 200 }),
+        );
+
+        const store = createUpstashRateLimitStore()!;
+        setRateLimitStoreForTests(store);
+
+        const result = await checkRateLimit(requestFrom('9.9.9.9'), {
             prefix: 'verify',
             windowSeconds: 60,
             maxRequests: 10,
-        })).resolves.toMatchObject({ success: false });
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.remaining).toBe(0);
+        expect(result.retryAfter).toBeGreaterThanOrEqual(1);
+    });
+
+    it('falls back to in-memory when fetch throws a network error', async () => {
+        vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+
+        const store = createUpstashRateLimitStore()!;
+        setRateLimitStoreForTests(store);
+
+        // Must not throw; fallback in-memory allows the first request through
+        const result = await checkRateLimit(requestFrom('8.8.8.8'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 5,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.remaining).toBe(4);
+    });
+
+    it('falls back to in-memory when Upstash returns a non-OK HTTP status', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+            new Response('Service Unavailable', { status: 503 }),
+        );
+
+        const store = createUpstashRateLimitStore()!;
+        setRateLimitStoreForTests(store);
+
+        const result = await checkRateLimit(requestFrom('7.7.7.7'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 5,
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    it('enforces global limit across two store instances backed by Upstash', async () => {
+        vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(new Response(upstashPipelineResponse(1, 60), { status: 200 }))
+            .mockResolvedValueOnce(new Response(upstashPipelineResponse(2, 59), { status: 200 }))
+            .mockResolvedValueOnce(new Response(upstashPipelineResponse(3, 58), { status: 200 }));
+
+        const storeA = createUpstashRateLimitStore()!;
+        const storeB = createUpstashRateLimitStore()!;
+
+        setRateLimitStoreForTests(storeA);
+        await expect(
+            checkRateLimit(requestFrom('203.0.113.99'), { prefix: 'verify', windowSeconds: 60, maxRequests: 2 }),
+        ).resolves.toMatchObject({ success: true, remaining: 1 });
+
+        setRateLimitStoreForTests(storeB);
+        await expect(
+            checkRateLimit(requestFrom('203.0.113.99'), { prefix: 'verify', windowSeconds: 60, maxRequests: 2 }),
+        ).resolves.toMatchObject({ success: true, remaining: 0 });
+
+        // Counter at 3, limit 2 → blocked globally
+        await expect(
+            checkRateLimit(requestFrom('203.0.113.99'), { prefix: 'verify', windowSeconds: 60, maxRequests: 2 }),
+        ).resolves.toMatchObject({ success: false, remaining: 0 });
+    });
+
+    it('Retry-After is a positive integer on a blocked Upstash result', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(upstashPipelineResponse(99, 30), { status: 200 }),
+        );
+
+        const store = createUpstashRateLimitStore()!;
+        setRateLimitStoreForTests(store);
+
+        const result = await checkRateLimit(requestFrom('6.6.6.6'), {
+            prefix: 'verify',
+            windowSeconds: 60,
+            maxRequests: 10,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.retryAfter).toBeGreaterThanOrEqual(1);
+        expect(Number.isInteger(result.retryAfter)).toBe(true);
     });
 });


### PR DESCRIPTION
close #165 Distributed rate limiting (Redis)


Problem: Rate limiting is in-memory, so it resets per instance and doesn't hold across a horizontally scaled deployment.

Tasks

Back rate limiting with a shared store (e.g., Upstash Redis) keyed by IP/user/route.
Apply consistent limits to verify, IPFS, admin, and auth-adjacent routes.
Return standard 429 + Retry-After; make limits env-configurable.
Add tests for limit enforcement across simulated instances.
Acceptance criteria: Limits hold globally across instances; bursts get 429; legitimate traffic is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Added rate limiting to institution analytics, credential, and export endpoints.
  * Added support for shared Upstash Redis rate limiting across application instances.
  * Requests automatically fall back to local rate limiting if Redis is unavailable.

* **Documentation**
  * Expanded environment configuration guidance for distributed rate limiting and route-specific limits.

* **Bug Fixes**
  * Improved rate-limit recovery behavior and reset handling when external storage fails.

* **Tests**
  * Added comprehensive coverage for endpoint limits, retry responses, configuration overrides, Redis behavior, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->