### PR TITLE
Implement verifiable credential generation and enhance hashing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,10 +357,10 @@ graph TD
     style AUTH fill:#10b981,color:#fff
 ```
 
-> **Deeper dive:** see [`docs/architecture.md`](docs/architecture.md) for component responsibilities and the full issue / verify / revoke data flows.
+> **Deeper dive:** see [`docs/architecture.md`](docs/architecture.md) for component responsibilities and the full issue / verify / revoke data flows, and [`frontend/VERIFIABLE_CREDENTIALS.md`](frontend/VERIFIABLE_CREDENTIALS.md) for the W3C Verifiable Credential / Open Badges 3.0 metadata schema, field mapping, and a third-party verification recipe.
 
 **Data flow (summary)**
-- **Issue:** institution fills the form → document + metadata pinned to IPFS → SHA-256 hash computed over the canonical payload → issuer signs `issue_credential(student, issuer, hash, ipfs_uri)` via Freighter → the credential is written on-chain and indexed in Postgres.
+- **Issue:** institution fills the form → document + metadata (modeled as a W3C VC / Open Badges 3.0 document) pinned to IPFS → SHA-256 hash computed over the canonical payload → issuer signs `issue_credential(student, issuer, hash, ipfs_uri)` via Freighter → the credential is written on-chain and indexed in Postgres.
 - **Verify:** anyone opens `/verify` (token/QR) → the app reads the credential from the contract via Soroban RPC → shows authenticity + revocation status; a privacy-safe entry is recorded in `verification_logs`.
 - **Revoke:** the original issuer signs `revoke_credential(token_id, issuer)` → the on-chain record is flagged revoked (still readable, so verifiers see "revoked" not "missing") → the index is updated.
 

--- a/frontend/VERIFIABLE_CREDENTIALS.md
+++ b/frontend/VERIFIABLE_CREDENTIALS.md
@@ -1,0 +1,233 @@
+# Verifiable Credentials (W3C VC / Open Badges 3.0) — Contributor & Verifier Guide
+
+> **Audience:** Developers contributing to ACREDIA-STELLAR, and third parties
+> (HR systems, other wallets, badge platforms) that want to ingest or
+> independently verify an Acredia credential.
+
+---
+
+## 1. Why
+
+Credential metadata used to be a bespoke NFT-style JSON blob
+(`name`/`description`/`attributes`/`credentialData`). That's fine for this
+app's own UI, but nothing outside Acredia — LinkedIn, an ATS, another wallet
+— has any idea what to do with it.
+
+Every credential issued now is instead modeled as a **W3C Verifiable
+Credential (VC Data Model 1.1)** that also conforms to the **1EdTech Open
+Badges 3.0 `OpenBadgeCredential` profile**. It's the same JSON document that
+gets uploaded to IPFS and canonically hashed on-chain — there is no separate
+"export format"; what you download *is* what was anchored.
+
+## 2. Where this lives in code
+
+| Concern | Module |
+|---|---|
+| Builds the VC/OBv3 document | `src/lib/verifiableCredential.ts` (`buildAcrediaVerifiableCredential`) |
+| Validates the document shape | `src/lib/schemas.ts` (`VerifiableCredentialSchema` / `validateVerifiableCredential`) |
+| Canonicalizes + hashes for on-chain anchoring | `src/lib/credentialHash.ts` (`buildCanonicalCredentialPayloadV2`, `generateCanonicalCredentialHash`, `deriveCredentialHash`) |
+| Issues the credential (builds → validates → uploads → hashes → anchors) | `src/lib/credentialService.ts` (`issueCredential`) |
+| Builds the downloadable export (adds the on-chain anchor block) | `src/lib/standardsExport.ts` (`buildStandardsExportDocument`) |
+| "Download VC (.json)" UI | Student dashboard (`StudentCredentialsList.tsx`) and the public showcase page (`PublicCredentialCard.tsx`) |
+
+## 3. Document shape
+
+```jsonc
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+    { "acredia": "https://acredia.app/ns#", "credentialData": "acredia:credentialData", "onChainAnchor": "acredia:onChainAnchor" }
+  ],
+  "id": "urn:uuid:5f2b...",
+  "type": ["VerifiableCredential", "OpenBadgeCredential"],
+  "name": "degree - Ada Lovelace",
+  "description": "Academic credential issued by Acredia Academy to Ada Lovelace",
+  "image": "https://gateway.pinata.cloud/ipfs/<file-cid>",
+  "issuer": {
+    "id": "https://stellar.expert/explorer/testnet/account/GISSUER...",
+    "type": ["Profile"],
+    "name": "Acredia Academy"
+  },
+  "issuanceDate": "2026-05-31T00:00:00.000Z",
+  "credentialSubject": {
+    "id": "https://stellar.expert/explorer/testnet/account/GSTUDENT...",
+    "type": ["AchievementSubject"],
+    "name": "Ada Lovelace",
+    "achievement": {
+      "id": "urn:acredia:achievement:gissuer...:degree:bsc-computer-science",
+      "type": ["Achievement"],
+      "name": "BSc Computer Science",
+      "description": "Academic degree verified on the Stellar blockchain.",
+      "achievementType": "Degree",
+      "criteria": { "narrative": "Issued upon successful completion and verification of the stated academic requirements." }
+    },
+    "result": [{ "type": ["Result"], "resultDescription": "GPA", "value": "3.9" }]
+  },
+  "evidence": [
+    {
+      "id": "https://gateway.pinata.cloud/ipfs/<file-cid>",
+      "type": ["Evidence"],
+      "name": "Original credential document",
+      "description": "Source document uploaded by Acredia Academy at issuance."
+    }
+  ],
+  "credentialData": {
+    "studentName": "Ada Lovelace",
+    "studentWallet": "GSTUDENT...",
+    "degree": "BSc Computer Science",
+    "major": "Software Engineering",
+    "gpa": "3.9",
+    "issueDate": "2026-05-31",
+    "institutionName": "Acredia Academy",
+    "credentialType": "degree",
+    "subjects": [{ "id": "math-101", "name": "Mathematics", "marks": "95", "maxMarks": "100", "grade": "A" }]
+  }
+}
+```
+
+Downloaded copies additionally carry two properties that are **never** part
+of the hashed/anchored core (see §5):
+
+```jsonc
+{
+  "credentialStatus": {
+    "id": "https://acredia.app/verify?token=42",
+    "type": "StellarSorobanRevocationStatus2024",
+    "stellarNetwork": "testnet",
+    "stellarContractId": "CCON...",
+    "stellarTokenId": "42"
+  },
+  "onChainAnchor": {
+    "network": "testnet",
+    "contractId": "CCON...",
+    "tokenId": "42",
+    "transactionHash": "TX...",
+    "credentialHash": "5b1c...",
+    "hashAlgorithm": "sha256:canonical-json:v2",
+    "canonicalizationAlgorithm": "sha256:canonical-json (see this doc)",
+    "verifyUrl": "https://acredia.app/verify?token=42",
+    "hashCoversThisDocument": true
+  }
+}
+```
+
+## 4. Field mapping
+
+| Standard concept | Field | Source |
+|---|---|---|
+| Issuer | `issuer.id` / `issuer.name` | Institution's Stellar wallet (resolvable Stellar Expert account URL) / institution name |
+| Subject | `credentialSubject.id` / `.name` | Student's Stellar wallet (resolvable account URL) / student name |
+| Achievement | `credentialSubject.achievement` | Degree/credential type, mapped `achievementType` (`Degree`, `Diploma`, `Certificate`, `Transcript`, `Achievement` — the 1EdTech controlled vocabulary) |
+| Issuance date | `issuanceDate` | Form `issueDate`, normalized to a full ISO 8601 datetime |
+| Evidence | `evidence[0]` | IPFS URL of the uploaded source document (transcript/diploma scan) |
+| Result | `credentialSubject.result` | GPA, when provided |
+| Legacy internal fields | `credentialData` | Kept so existing dashboards/search continue to work — not a VC/OBv3 standard property, but a properly namespaced JSON-LD extension (see `@context`) |
+
+## 5. Canonicalization & the on-chain hash
+
+`issue_credential` on the Soroban contract stores a SHA-256 hash and an IPFS
+URI — not the document itself. The hash must be reproducible by anyone who
+has the document, so it's computed over a **canonical** form, not raw
+`JSON.stringify` (key order and incidental fields would otherwise change the
+hash for byte-identical *meaning*).
+
+`buildCanonicalCredentialPayloadV2` (`src/lib/credentialHash.ts`) extracts an
+explicit allowlist of fields — `@context`, `id`, `type`, `name`,
+`description`, `image`, `issuer`, `issuanceDate`, `credentialSubject`,
+`evidence`, `credentialData` — normalizes them, and `canonicalJson` recursively
+sorts object keys (arrays keep their order). The result is SHA-256'd.
+
+**`credentialStatus` and `onChainAnchor` are never part of that allowlist.**
+They can't be: `onChainAnchor.tokenId`/`transactionHash` are only known
+*after* the chain transaction succeeds, but the hash has to be computed
+*before* it (it's an argument to `issue_credential`). Any real Data Integrity
+proof works the same way — canonicalize and sign/hash first, attach the
+proof afterward.
+
+This is why there is **no `proof` block** in the hashed core: this system's
+proof of issuance is the Stellar transaction + on-chain hash, not an embedded
+Ed25519/JWS signature. Don't fabricate one — an earlier version of the export
+labeled a transaction hash as an `Ed25519Signature2020` `proofValue`, which is
+actively wrong (any verifier that understands that cryptosuite would attempt
+real signature verification and fail). If your use case needs a resolvable
+DID + embedded Data Integrity Proof, that's a larger, separate feature
+(institution DID/key custody) — track it as a follow-up rather than
+approximating it.
+
+## 6. Verification recipe (for third parties)
+
+Given a token ID (from a QR code, a shared link, or the exported JSON's
+`onChainAnchor.tokenId`):
+
+1. **Read the on-chain record.** Call the `AcrediaCredential` contract's
+   `get_credential(token_id)` (via Soroban RPC, or the convenience endpoint
+   `GET /api/verify/{token}` on this app, which does this for you and also
+   checks issuer authorization and revocation). This returns the credential's
+   `credential_hash` (32 bytes) and `ipfs_uri`.
+2. **Fetch the document.** Resolve `ipfs_uri` via any IPFS gateway
+   (`https://<gateway>/ipfs/<cid>`).
+3. **Recompute the hash.** Run the fetched document through the same
+   canonicalization as §5 (`buildCanonicalCredentialPayloadV2` +
+   `canonicalJson`, SHA-256) — **excluding** `credentialStatus` and
+   `onChainAnchor` if your copy has them attached (e.g. a downloaded export;
+   the IPFS-hosted document itself never has them).
+4. **Compare.** The recomputed hash must equal the on-chain `credential_hash`
+   from step 1. If it doesn't, or the token doesn't exist, or
+   `is_revoked(token_id)` is `true`, do not trust the credential.
+5. **Check issuer standing (optional but recommended).** `is_authorized_issuer(issuer)`
+   tells you whether the issuing institution is *currently* authorized — a
+   credential issued by a since-deauthorized issuer is still valid/immutable,
+   but you may want to flag it.
+
+A minimal Node.js/browser implementation of steps 2–3:
+
+```ts
+import { canonicalJson, buildCanonicalCredentialPayloadV2 } from './src/lib/credentialHash';
+
+async function verify(document: unknown, onChainHashHex: string): Promise<boolean> {
+  const core = buildCanonicalCredentialPayloadV2(document);
+  const serialized = canonicalJson(core as any);
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(serialized));
+  const hex = Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('');
+  return hex === onChainHashHex.toLowerCase();
+}
+```
+
+Or, more simply, trust this app's own `GET /api/verify/{token}` endpoint,
+which performs exactly this check server-side and returns
+`verification.onChainMatch` / `verification.verified`.
+
+### Legacy (schema v1) credentials
+
+Credentials issued before this feature shipped used a different (NFT-style)
+canonical form (`hash_algorithm: "sha256:canonical-json:v1"`,
+`metadata_schema_version: 1`). Downloading one still produces a valid
+VC/OBv3 document for interoperability, but
+`onChainAnchor.hashCoversThisDocument` will be `false` — the on-chain hash for
+those tokens covers the *original* stored metadata shape, not the
+reconstructed VC. Verify legacy credentials via `GET /api/verify/{token}`
+rather than recomputing a hash from the downloaded VC.
+
+## 7. Exporting from the app
+
+- **Student dashboard** (`/dashboard`, "My Credentials"): every credential
+  card has a **"Download VC (.json)"** button.
+- **Public showcase page** (`/credentials/{token}`): a
+  **"Download Verifiable Credential (.json)"** button, built only from data
+  already public on that page (no GPA/subjects/evidence — see the code
+  comments in `standardsExport.ts` for the privacy rationale).
+
+## 8. Non-goals / known limitations
+
+- No DID method — `issuer.id`/`credentialSubject.id` are resolvable
+  `https://stellar.expert/...` account URLs, not `did:...` identifiers. There
+  is no officially registered DID method for Stellar accounts; inventing one
+  (e.g. `did:stellar:...`) would be unresolvable by any real DID resolver,
+  which is worse than an honest HTTPS URL.
+- No embedded Data Integrity Proof / VC-JWT signature. Authenticity is
+  established by the Stellar on-chain hash, not by verifying a signature
+  inside the document (see §5).
+- `credentialSubject.result` only carries GPA today; per-subject marks live
+  in the `credentialData` extension, not the stricter OBv3
+  `achievement.resultDescriptions` linkage (out of scope for this pass).

--- a/frontend/src/app/api/student/credentials/route.ts
+++ b/frontend/src/app/api/student/credentials/route.ts
@@ -22,6 +22,8 @@ type CredentialRow = {
     ipfs_hash: string;
     blockchain_hash: string;
     metadata: unknown;
+    metadata_schema_version: number | null;
+    hash_algorithm: string | null;
     issued_at: string;
     revoked: boolean;
     institution?: { name?: string }[] | { name?: string } | null;
@@ -89,8 +91,8 @@ export async function GET(request: NextRequest) {
         let query = supabase
             .from('credentials')
             .select(
-                `id, token_id, ipfs_hash, blockchain_hash, metadata, issued_at, revoked,
-                 institution:institutions(name)`,
+                `id, token_id, ipfs_hash, blockchain_hash, metadata, metadata_schema_version, hash_algorithm,
+                 issued_at, revoked, institution:institutions(name)`,
                 { count: 'exact' }
             )
             .eq('student_id', studentRow.id)

--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -161,6 +161,7 @@ export async function GET(
                 metadata_schema_version,
                 hash_algorithm,
                 ipfs_hash,
+                blockchain_hash,
                 student_wallet_address,
                 issuer_wallet_address,
                 institution:institutions!credentials_institution_id_fkey (
@@ -263,6 +264,15 @@ export async function GET(
                 degree: credentialData.degree ?? null,
                 major: credentialData.major ?? null,
                 issueDate: credentialData.issueDate ?? null,
+                // Stellar account addresses, not sensitive: already readable
+                // on-chain by anyone who queries this token_id directly.
+                studentWallet: onChain?.student ?? data.student_wallet_address ?? null,
+                institutionWallet: onChain?.issuer ?? data.issuer_wallet_address ?? null,
+                metadataSchemaVersion: data.metadata_schema_version ?? null,
+                hashAlgorithm: data.hash_algorithm ?? null,
+                onChainHash: onChain?.hash ?? null,
+                blockchainHash: data.blockchain_hash ?? null,
+                ipfsHash: data.ipfs_hash ?? null,
             },
             verification: {
                 verified,

--- a/frontend/src/app/credentials/[token]/page.tsx
+++ b/frontend/src/app/credentials/[token]/page.tsx
@@ -65,13 +65,18 @@ export default function PublicCredentialPage({ params }: PublicCredentialPagePro
                     setCredential({
                         tokenId: c.tokenId,
                         studentName: c.studentName || 'Credential Holder',
+                        studentWallet: c.studentWallet || undefined,
                         degree: c.degree || 'Academic Credential',
                         credentialType: c.credentialType || 'diploma',
                         institutionName: c.institutionName || 'Issuing Institution',
+                        issuerWallet: c.institutionWallet || undefined,
                         issueDate: c.issueDate || '2024-01-01',
                         revoked: Boolean(c.revoked),
                         blockchainHash: c.blockchainHash,
                         ipfsHash: c.ipfsHash,
+                        onChainHash: c.onChainHash || undefined,
+                        metadataSchemaVersion: c.metadataSchemaVersion ?? undefined,
+                        hashAlgorithm: c.hashAlgorithm || undefined,
                         isPublic: true,
                     });
                 }

--- a/frontend/src/components/student/PublicCredentialCard.tsx
+++ b/frontend/src/components/student/PublicCredentialCard.tsx
@@ -18,12 +18,8 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import QRCodeModal from './QRCodeModal';
-import {
-    downloadJsonFile,
-    exportOpenBadgesV3,
-    exportW3cVerifiableCredential,
-    getLinkedInShareUrl,
-} from '@/lib/standardsExport';
+import { buildStandardsExportDocument, downloadJsonFile, getLinkedInShareUrl } from '@/lib/standardsExport';
+import { captureException } from '@/lib/debug';
 
 export interface PublicCredentialCardData {
     tokenId: string;
@@ -40,6 +36,9 @@ export interface PublicCredentialCardData {
     isPublic?: boolean;
     blockchainHash?: string;
     ipfsHash?: string;
+    onChainHash?: string;
+    metadataSchemaVersion?: number;
+    hashAlgorithm?: string;
 }
 
 interface PublicCredentialCardProps {
@@ -49,6 +48,7 @@ interface PublicCredentialCardProps {
 export function PublicCredentialCard({ credential }: PublicCredentialCardProps) {
     const [qrOpen, setQrOpen] = useState(false);
     const [copied, setCopied] = useState(false);
+    const [downloading, setDownloading] = useState(false);
 
     if (credential.isPublic === false) {
         return (
@@ -85,14 +85,30 @@ export function PublicCredentialCard({ credential }: PublicCredentialCardProps) 
         setTimeout(() => setCopied(false), 2000);
     };
 
-    const handleDownloadVc = () => {
-        const data = exportW3cVerifiableCredential(credential);
-        downloadJsonFile(data, `credential-${credential.tokenId}-w3c-vc.json`);
-    };
-
-    const handleDownloadObv3 = () => {
-        const data = exportOpenBadgesV3(credential);
-        downloadJsonFile(data, `credential-${credential.tokenId}-openbadges-v3.json`);
+    const handleDownloadVc = async () => {
+        setDownloading(true);
+        try {
+            const document = await buildStandardsExportDocument({
+                tokenId: credential.tokenId,
+                blockchainHash: credential.blockchainHash,
+                onChainHash: credential.onChainHash,
+                metadataSchemaVersion: credential.metadataSchemaVersion,
+                hashAlgorithm: credential.hashAlgorithm,
+                studentName: credential.studentName,
+                studentWallet: credential.studentWallet,
+                institutionName: credential.institutionName,
+                issuerWallet: credential.issuerWallet,
+                degree: credential.degree,
+                credentialType: credential.credentialType,
+                issueDate: credential.issueDate,
+            });
+            downloadJsonFile(document, `credential-${credential.tokenId}-verifiable-credential.json`);
+        } catch (err) {
+            captureException(err, { context: 'PublicCredentialCard_downloadVc' });
+            alert('Failed to build the Verifiable Credential export. Please try again.');
+        } finally {
+            setDownloading(false);
+        }
     };
 
     return (
@@ -163,12 +179,9 @@ export function PublicCredentialCard({ credential }: PublicCredentialCardProps) 
                         <Share2 className="mr-2 h-4 w-4" /> {copied ? 'Copied Link!' : 'Copy Share Link'}
                     </Button>
 
-                    <Button onClick={handleDownloadVc} variant="outline" size="sm">
-                        <Download className="mr-2 h-4 w-4" /> W3C VC (.json)
-                    </Button>
-
-                    <Button onClick={handleDownloadObv3} variant="outline" size="sm">
-                        <Download className="mr-2 h-4 w-4" /> Open Badges v3
+                    <Button onClick={handleDownloadVc} variant="outline" size="sm" disabled={downloading}>
+                        <Download className="mr-2 h-4 w-4" />
+                        {downloading ? 'Preparing...' : 'Download Verifiable Credential (.json)'}
                     </Button>
                 </div>
             </Card>

--- a/frontend/src/components/student/StudentCredentialsList.tsx
+++ b/frontend/src/components/student/StudentCredentialsList.tsx
@@ -9,6 +9,7 @@ import {
     Award,
     Building2,
     Calendar,
+    Download,
     ExternalLink,
     GraduationCap,
     QrCode,
@@ -23,6 +24,7 @@ import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import QRCodeModal from './QRCodeModal';
 import { getIPFSUrl } from '@/lib/ipfs';
+import { buildStandardsExportDocument, downloadJsonFile } from '@/lib/standardsExport';
 import { debugLog, captureException } from '@/lib/debug';
 import { supabase } from '@/lib/supabase';
 
@@ -45,6 +47,8 @@ interface Credential {
             credentialType: string;
         };
     };
+    metadata_schema_version?: number | null;
+    hash_algorithm?: string | null;
     issued_at: string;
     revoked: boolean;
     institution?: { name: string } | null;
@@ -351,11 +355,31 @@ function CredentialCard({ credential }: { credential: Credential }) {
         : null;
 
     const [showQRModal, setShowQRModal] = useState(false);
+    const [downloading, setDownloading] = useState(false);
 
     const handleShare = () => {
         const shareUrl = `${window.location.origin}/verify?token=${credential.token_id}`;
         navigator.clipboard.writeText(shareUrl);
         alert('Share link copied to clipboard!');
+    };
+
+    const handleDownloadVc = async () => {
+        setDownloading(true);
+        try {
+            const document = await buildStandardsExportDocument({
+                tokenId: credential.token_id,
+                metadata: credential.metadata,
+                metadataSchemaVersion: credential.metadata_schema_version,
+                hashAlgorithm: credential.hash_algorithm,
+                blockchainHash: credential.blockchain_hash,
+            });
+            downloadJsonFile(document, `credential-${credential.token_id}-verifiable-credential.json`);
+        } catch (err) {
+            captureException(err, { context: 'StudentCredentialsList_downloadVc' });
+            alert('Failed to build the Verifiable Credential export. Please try again.');
+        } finally {
+            setDownloading(false);
+        }
     };
 
     return (
@@ -420,6 +444,10 @@ function CredentialCard({ credential }: { credential: Credential }) {
                         </Button>
                         <Button onClick={handleShare} variant="outline" size="sm">
                             <Share2 className="mr-1 h-4 w-4" />Copy Link
+                        </Button>
+                        <Button onClick={handleDownloadVc} variant="outline" size="sm" disabled={downloading}>
+                            <Download className="mr-1 h-4 w-4" />
+                            {downloading ? 'Preparing...' : 'Download VC (.json)'}
                         </Button>
                         {ipfsUrl && (
                             <a href={ipfsUrl} target="_blank" rel="noopener noreferrer">

--- a/frontend/src/lib/credentialHash.ts
+++ b/frontend/src/lib/credentialHash.ts
@@ -1,16 +1,26 @@
 export const LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION = 0;
-export const CREDENTIAL_METADATA_SCHEMA_VERSION = 1;
-export const CREDENTIAL_HASH_ALGORITHM = 'sha256:canonical-json:v1';
+/** Custom NFT-style metadata shape (`name`/`description`/`attributes`/`credentialData`). Superseded by V2 but still derivable for already-issued credentials. */
+export const CREDENTIAL_METADATA_SCHEMA_VERSION_V1 = 1;
+/** W3C Verifiable Credential / Open Badges 3.0 JSON-LD document. Default for all new issuances (see verifiableCredential.ts). */
+export const CREDENTIAL_METADATA_SCHEMA_VERSION_V2 = 2;
+/** The schema version used for newly-issued credentials. */
+export const CREDENTIAL_METADATA_SCHEMA_VERSION = CREDENTIAL_METADATA_SCHEMA_VERSION_V2;
+
+export const CREDENTIAL_HASH_ALGORITHM_V1 = 'sha256:canonical-json:v1';
+export const CREDENTIAL_HASH_ALGORITHM_V2 = 'sha256:canonical-json:v2';
+/** The hash algorithm identifier used for newly-issued credentials. */
+export const CREDENTIAL_HASH_ALGORITHM = CREDENTIAL_HASH_ALGORITHM_V2;
 export const LEGACY_CREDENTIAL_HASH_ALGORITHM = 'sha256:json-stringify';
 
 export type CredentialMetadataSchemaVersion =
     | typeof LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION
-    | typeof CREDENTIAL_METADATA_SCHEMA_VERSION;
+    | typeof CREDENTIAL_METADATA_SCHEMA_VERSION_V1
+    | typeof CREDENTIAL_METADATA_SCHEMA_VERSION_V2;
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 
 export interface CanonicalCredentialPayloadV1 {
-    schemaVersion: typeof CREDENTIAL_METADATA_SCHEMA_VERSION;
+    schemaVersion: typeof CREDENTIAL_METADATA_SCHEMA_VERSION_V1;
     name: string;
     description: string;
     image: string;
@@ -30,6 +40,138 @@ export interface CanonicalCredentialPayloadV1 {
             maxMarks: string;
             grade: string | null;
         }>;
+    };
+}
+
+/**
+ * Canonical shape for a W3C Verifiable Credential / Open Badges 3.0 metadata
+ * document (see `verifiableCredential.ts` for the builder that produces the
+ * full document this is extracted from). Only these fields participate in
+ * the on-chain hash — anything added to the document *after* hashing (e.g.
+ * a `credentialStatus`/on-chain-anchor block attached only to a downloaded
+ * export copy) is deliberately excluded, mirroring V1's explicit-allowlist
+ * approach so the hash stays stable regardless of incidental extra fields.
+ */
+export interface CanonicalCredentialPayloadV2 {
+    schemaVersion: typeof CREDENTIAL_METADATA_SCHEMA_VERSION_V2;
+    '@context': string[];
+    id: string;
+    type: string[];
+    name: string;
+    description: string;
+    image: string | null;
+    issuer: {
+        id: string;
+        type: string[];
+        name: string;
+    };
+    issuanceDate: string;
+    credentialSubject: {
+        id: string;
+        type: string[];
+        name: string;
+        achievement: {
+            id: string;
+            type: string[];
+            name: string;
+            description: string;
+            achievementType: string | null;
+            criteria: { narrative: string };
+        };
+        result: Array<{
+            type: string[];
+            resultDescription: string;
+            value: string;
+        }>;
+    };
+    evidence: Array<{
+        id: string;
+        type: string[];
+        name: string;
+        description: string;
+    }>;
+    /** Legacy-shaped extension retained for backward-compatible internal display (search filters, dashboards). Not part of the VC/OBv3 standard fields. */
+    credentialData: CanonicalCredentialPayloadV1['credentialData'];
+}
+
+function requiredStringArray(value: unknown): string[] {
+    return Array.isArray(value) ? value.map((item) => requiredString(item)) : [];
+}
+
+export function buildCanonicalCredentialPayloadV2(metadata: unknown): CanonicalCredentialPayloadV2 {
+    const root = asRecord(metadata);
+    const issuer = asRecord(root.issuer);
+    const credentialSubject = asRecord(root.credentialSubject);
+    const achievement = asRecord(credentialSubject.achievement);
+    const results = Array.isArray(credentialSubject.result) ? credentialSubject.result : [];
+    const evidence = Array.isArray(root.evidence) ? root.evidence : [];
+    const credentialData = asRecord(root.credentialData);
+    const subjects = Array.isArray(credentialData.subjects) ? credentialData.subjects : [];
+
+    return {
+        schemaVersion: CREDENTIAL_METADATA_SCHEMA_VERSION_V2,
+        '@context': requiredStringArray(root['@context']),
+        id: requiredString(root.id),
+        type: requiredStringArray(root.type),
+        name: requiredString(root.name),
+        description: requiredString(root.description),
+        image: optionalString(root.image),
+        issuer: {
+            id: requiredString(issuer.id),
+            type: requiredStringArray(issuer.type),
+            name: requiredString(issuer.name),
+        },
+        issuanceDate: requiredString(root.issuanceDate),
+        credentialSubject: {
+            id: requiredString(credentialSubject.id),
+            type: requiredStringArray(credentialSubject.type),
+            name: requiredString(credentialSubject.name),
+            achievement: {
+                id: requiredString(achievement.id),
+                type: requiredStringArray(achievement.type),
+                name: requiredString(achievement.name),
+                description: requiredString(achievement.description),
+                achievementType: optionalString(achievement.achievementType),
+                criteria: { narrative: requiredString(asRecord(achievement.criteria).narrative) },
+            },
+            result: results.map((result) => {
+                const item = asRecord(result);
+                return {
+                    type: requiredStringArray(item.type),
+                    resultDescription: requiredString(item.resultDescription),
+                    value: requiredString(item.value),
+                };
+            }),
+        },
+        evidence: evidence.map((item) => {
+            const record = asRecord(item);
+            return {
+                id: requiredString(record.id),
+                type: requiredStringArray(record.type),
+                name: requiredString(record.name),
+                description: requiredString(record.description),
+            };
+        }),
+        credentialData: {
+            studentName: requiredString(credentialData.studentName),
+            studentWallet: requiredString(credentialData.studentWallet),
+            degree: requiredString(credentialData.degree),
+            major: optionalString(credentialData.major),
+            gpa: optionalString(credentialData.gpa),
+            issueDate: requiredDateString(credentialData.issueDate),
+            institutionName: requiredString(credentialData.institutionName),
+            credentialType: requiredString(credentialData.credentialType),
+            subjects: subjects.map((subject) => {
+                const item = asRecord(subject);
+                return {
+                    id: requiredString(item.id),
+                    name: requiredString(item.name),
+                    marks: requiredString(item.marks),
+                    maxMarks: requiredString(item.maxMarks),
+                    grade: optionalString(item.grade),
+                };
+            }),
+        },
     };
 }
 
@@ -68,7 +210,7 @@ export function buildCanonicalCredentialPayloadV1(metadata: unknown): CanonicalC
     const subjects = Array.isArray(credentialData.subjects) ? credentialData.subjects : [];
 
     return {
-        schemaVersion: CREDENTIAL_METADATA_SCHEMA_VERSION,
+        schemaVersion: CREDENTIAL_METADATA_SCHEMA_VERSION_V1,
         name: requiredString(root.name),
         description: requiredString(root.description),
         image: requiredString(root.image),
@@ -128,7 +270,11 @@ export function serializeCredentialMetadataForHash(
     metadata: unknown,
     schemaVersion: number | null | undefined = CREDENTIAL_METADATA_SCHEMA_VERSION,
 ): string {
-    if (schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION) {
+    if (schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION_V2) {
+        return canonicalJson(buildCanonicalCredentialPayloadV2(metadata) as unknown as JsonValue);
+    }
+
+    if (schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION_V1) {
         return canonicalJson(buildCanonicalCredentialPayloadV1(metadata) as unknown as JsonValue);
     }
 
@@ -143,10 +289,11 @@ export function serializeCredentialMetadataForHash(
     throw new Error(`Unsupported credential metadata schema version: ${schemaVersion}`);
 }
 
-export async function generateCanonicalCredentialHash(metadata: unknown): Promise<string> {
-    return sha256Hex(
-        serializeCredentialMetadataForHash(metadata, CREDENTIAL_METADATA_SCHEMA_VERSION),
-    );
+export async function generateCanonicalCredentialHash(
+    metadata: unknown,
+    schemaVersion: number = CREDENTIAL_METADATA_SCHEMA_VERSION,
+): Promise<string> {
+    return sha256Hex(serializeCredentialMetadataForHash(metadata, schemaVersion));
 }
 
 export async function deriveCredentialHash(
@@ -155,10 +302,17 @@ export async function deriveCredentialHash(
     hashAlgorithm?: string | null,
 ): Promise<string> {
     if (
-        schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION &&
-        hashAlgorithm === CREDENTIAL_HASH_ALGORITHM
+        schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION_V2 &&
+        hashAlgorithm === CREDENTIAL_HASH_ALGORITHM_V2
     ) {
-        return generateCanonicalCredentialHash(metadata);
+        return generateCanonicalCredentialHash(metadata, CREDENTIAL_METADATA_SCHEMA_VERSION_V2);
+    }
+
+    if (
+        schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION_V1 &&
+        hashAlgorithm === CREDENTIAL_HASH_ALGORITHM_V1
+    ) {
+        return generateCanonicalCredentialHash(metadata, CREDENTIAL_METADATA_SCHEMA_VERSION_V1);
     }
 
     if (

--- a/frontend/src/lib/credentialService.ts
+++ b/frontend/src/lib/credentialService.ts
@@ -6,6 +6,9 @@ import {
     revokeCredentialOnStellar,
 } from './contracts';
 import { CREDENTIAL_HASH_ALGORITHM, CREDENTIAL_METADATA_SCHEMA_VERSION } from './credentialHash';
+import { buildAcrediaVerifiableCredential, type AcrediaVerifiableCredential } from './verifiableCredential';
+import { validateVerifiableCredential } from './schemas';
+import { runtimeConfig } from './runtimeConfig';
 import { debugLog, captureException, recordMetric } from './debug';
 import { getE2eState, updateE2eState } from './e2e';
 
@@ -33,26 +36,13 @@ export interface CredentialData {
     file: File;
 }
 
-export interface CredentialMetadata {
-    name: string;
-    description: string;
-    image: string;
-    attributes: Array<{
-        trait_type: string;
-        value: string;
-    }>;
-    credentialData: {
-        studentName: string;
-        studentWallet: string;
-        degree: string;
-        major?: string;
-        gpa?: string;
-        issueDate: string;
-        institutionName: string;
-        credentialType: string;
-        subjects?: Subject[];
-    };
-}
+/**
+ * Credential metadata is modeled as a W3C Verifiable Credential / Open
+ * Badges 3.0 JSON-LD document (see verifiableCredential.ts). This alias is
+ * kept so existing imports of `CredentialMetadata` from this module keep
+ * working.
+ */
+export type CredentialMetadata = AcrediaVerifiableCredential;
 
 export type CredentialIssueProgressStep = 'upload-ipfs' | 'sign-transaction' | 'save-database';
 
@@ -120,65 +110,24 @@ export async function issueCredential(
         const fileUrl = getIPFSUrl(fileCID);
         debugLog('Credential file uploaded to IPFS.');
 
-        debugLog('Generating credential metadata.');
-        const metadata: CredentialMetadata = {
-            name: `${data.credentialType} - ${data.studentName}`,
-            description: `Academic credential issued by ${data.institutionName} to ${data.studentName}`,
-            image: fileUrl,
-            attributes: [
-                {
-                    trait_type: 'Credential Type',
-                    value: data.credentialType,
-                },
-                {
-                    trait_type: 'Degree',
-                    value: data.degree,
-                },
-                {
-                    trait_type: 'Institution',
-                    value: data.institutionName,
-                },
-                {
-                    trait_type: 'Issue Date',
-                    value: data.issueDate,
-                },
-                ...(data.major
-                    ? [
-                          {
-                              trait_type: 'Major',
-                              value: data.major,
-                          },
-                      ]
-                    : []),
-                ...(data.gpa
-                    ? [
-                          {
-                              trait_type: 'GPA',
-                              value: data.gpa,
-                          },
-                      ]
-                    : []),
-                ...(data.subjects && data.subjects.length > 0
-                    ? [
-                          {
-                              trait_type: 'Total Subjects',
-                              value: data.subjects.length.toString(),
-                          },
-                      ]
-                    : []),
-            ],
-            credentialData: {
+        debugLog('Generating credential metadata as a W3C VC / Open Badges 3.0 document.');
+        const metadata: CredentialMetadata = buildAcrediaVerifiableCredential(
+            {
                 studentName: data.studentName,
                 studentWallet: data.studentWallet,
                 degree: data.degree,
                 major: data.major,
                 gpa: data.gpa,
                 issueDate: data.issueDate,
-                institutionName: data.institutionName,
                 credentialType: data.credentialType,
+                institutionName: data.institutionName,
+                institutionWallet: data.institutionWallet,
                 subjects: data.subjects,
             },
-        };
+            runtimeConfig.stellar.explorerBaseUrl,
+            fileUrl,
+        );
+        validateVerifiableCredential(metadata);
 
         debugLog('Uploading credential metadata to IPFS.');
         const metadataPath = await uploadJSONToIPFS(metadata);

--- a/frontend/src/lib/schemas.ts
+++ b/frontend/src/lib/schemas.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+// ─── Legacy V1 (custom NFT-style) metadata schema ───────────────────────────
+// No longer produced for new issuances (see verifiableCredential.ts / V2
+// below), but kept so already-issued credentials with this shape can still
+// be parsed/validated (e.g. by tooling that reads historical `metadata` rows).
+
 export const SubjectSchema = z.object({
     name: z.string().optional(),
     marks: z.string().optional(),
@@ -34,3 +39,82 @@ export const CredentialMetadataSchema = z.object({
 
 export type CredentialDataPayload = z.infer<typeof CredentialDataSchema>;
 export type CredentialMetadataPayload = z.infer<typeof CredentialMetadataSchema>;
+
+// ─── V2: W3C Verifiable Credential / Open Badges 3.0 metadata schema ────────
+// This is the shape built by `buildAcrediaVerifiableCredential` in
+// verifiableCredential.ts and produced for every new credential issuance.
+// `credentialService.ts` validates the built document against this schema
+// before it is uploaded to IPFS / hashed on-chain, so a malformed document
+// never gets anchored.
+
+const jsonLdContextEntrySchema = z.union([z.string(), z.record(z.string(), z.unknown())]);
+
+export const AchievementResultSchema = z.object({
+    type: z.array(z.string()).min(1),
+    resultDescription: z.string(),
+    value: z.string(),
+});
+
+export const AchievementSchema = z.object({
+    id: z.string().min(1),
+    type: z.array(z.string()).min(1),
+    name: z.string().min(1),
+    description: z.string(),
+    achievementType: z.string().nullable(),
+    criteria: z.object({ narrative: z.string() }),
+});
+
+export const AchievementSubjectSchema = z.object({
+    id: z.string().min(1),
+    type: z.array(z.string()).min(1),
+    name: z.string().min(1),
+    achievement: AchievementSchema,
+    result: z.array(AchievementResultSchema),
+});
+
+export const IssuerProfileSchema = z.object({
+    id: z.string().min(1),
+    type: z.array(z.string()).min(1),
+    name: z.string().min(1),
+});
+
+export const EvidenceSchema = z.object({
+    id: z.string().min(1),
+    type: z.array(z.string()).min(1),
+    name: z.string(),
+    description: z.string(),
+});
+
+export const LegacyCredentialDataExtensionSchema = z.object({
+    studentName: z.string(),
+    studentWallet: z.string(),
+    degree: z.string(),
+    major: z.string().optional(),
+    gpa: z.string().optional(),
+    issueDate: z.string(),
+    institutionName: z.string(),
+    credentialType: z.string(),
+    subjects: z.array(SubjectSchema).optional(),
+});
+
+export const VerifiableCredentialSchema = z.object({
+    '@context': z.array(jsonLdContextEntrySchema).min(2),
+    id: z.string().min(1),
+    type: z.array(z.string()).refine((types) => types.includes('VerifiableCredential'), {
+        message: 'type must include "VerifiableCredential"',
+    }),
+    name: z.string().min(1),
+    description: z.string(),
+    image: z.string().nullable(),
+    issuer: IssuerProfileSchema,
+    issuanceDate: z.string().min(1),
+    credentialSubject: AchievementSubjectSchema,
+    evidence: z.array(EvidenceSchema),
+    credentialData: LegacyCredentialDataExtensionSchema,
+});
+
+export type VerifiableCredentialPayload = z.infer<typeof VerifiableCredentialSchema>;
+
+export function validateVerifiableCredential(document: unknown): VerifiableCredentialPayload {
+    return VerifiableCredentialSchema.parse(document);
+}

--- a/frontend/src/lib/standardsExport.ts
+++ b/frontend/src/lib/standardsExport.ts
@@ -1,5 +1,41 @@
-export interface ExportCredentialData {
+import { getContractAddress } from './stellar';
+import { runtimeConfig } from './runtimeConfig';
+import {
+    CREDENTIAL_HASH_ALGORITHM_V1,
+    CREDENTIAL_HASH_ALGORITHM_V2,
+    CREDENTIAL_METADATA_SCHEMA_VERSION_V1,
+    CREDENTIAL_METADATA_SCHEMA_VERSION_V2,
+    deriveCredentialHash,
+} from './credentialHash';
+import {
+    attachOnChainAnchor,
+    buildAcrediaVerifiableCredential,
+    type AcrediaVerifiableCredential,
+    type OnChainAnchor,
+} from './verifiableCredential';
+
+/**
+ * Shape of a `credentials` row (or the curated subset the public `/verify`
+ * API returns) needed to produce a standards-compliant export. All fields
+ * are optional except `tokenId` because the public-facing caller has less
+ * data available than the authenticated student-dashboard caller.
+ */
+export interface StandardsExportCredentialRow {
     tokenId: string;
+    metadata?: unknown;
+    metadataSchemaVersion?: number | null;
+    hashAlgorithm?: string | null;
+    blockchainHash?: string | null;
+    /**
+     * The credential's actual on-chain hash (hex), when already known from a
+     * server-side chain read (e.g. the `/api/verify/[token]` response). When
+     * provided, this is trusted over recomputing from `metadata` — useful
+     * for the public verify page, which doesn't receive the full metadata
+     * blob but does know the real on-chain hash.
+     */
+    onChainHash?: string | null;
+    // Fallback fields used only when `metadata` isn't a V2 VC document
+    // (legacy credentials, or the curated public verify response).
     studentName?: string;
     studentWallet?: string;
     institutionName?: string;
@@ -7,75 +43,123 @@ export interface ExportCredentialData {
     degree?: string;
     credentialType?: string;
     issueDate?: string;
-    issuedAt?: string;
-    ipfsHash?: string;
-    blockchainHash?: string;
-    revoked?: boolean;
 }
 
-export function exportW3cVerifiableCredential(credential: ExportCredentialData): Record<string, unknown> {
-    const issueDate = credential.issueDate || credential.issuedAt || new Date().toISOString();
-    return {
-        '@context': [
-            'https://www.w3.org/2018/credentials/v1',
-            'https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.1.json',
-        ],
-        id: `urn:uuid:acredia-token-${credential.tokenId}`,
-        type: ['VerifiableCredential', 'OpenBadgeCredential'],
-        issuer: {
-            id: credential.issuerWallet ? `did:stellar:${credential.issuerWallet}` : 'urn:acredia:issuer:unknown',
-            name: credential.institutionName || 'Acredia Institution',
-        },
-        issuanceDate: new Date(issueDate).toISOString(),
-        credentialSubject: {
-            id: credential.studentWallet ? `did:stellar:${credential.studentWallet}` : `urn:acredia:student:${credential.tokenId}`,
-            name: credential.studentName || 'Student',
-            degree: credential.degree || 'Academic Credential',
-            credentialType: credential.credentialType || 'diploma',
-        },
-        proof: {
-            type: 'Ed25519Signature2020',
-            created: new Date(issueDate).toISOString(),
-            proofPurpose: 'assertionMethod',
-            verificationMethod: credential.issuerWallet
-                ? `did:stellar:${credential.issuerWallet}#key-1`
-                : 'urn:acredia:issuer:key-1',
-            proofValue: credential.blockchainHash || `e2e-proof-${credential.tokenId}`,
-        },
-    };
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-export function exportOpenBadgesV3(credential: ExportCredentialData): Record<string, unknown> {
-    const issueDate = credential.issueDate || credential.issuedAt || new Date().toISOString();
-    return {
-        '@context': [
-            'https://www.w3.org/2018/credentials/v1',
-            'https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.1.json',
-        ],
-        id: `urn:uuid:acredia-obv3-${credential.tokenId}`,
-        type: ['VerifiableCredential', 'OpenBadgeCredential'],
-        name: credential.degree || 'Academic Credential',
-        description: `Verified ${credential.credentialType || 'credential'} issued by ${credential.institutionName || 'Acredia Institution'} on the Stellar blockchain.`,
-        issuer: {
-            id: credential.issuerWallet ? `urn:acredia:issuer:${credential.issuerWallet}` : 'urn:acredia:issuer:unknown',
-            type: ['Profile'],
-            name: credential.institutionName || 'Acredia Institution',
-        },
-        issuanceDate: new Date(issueDate).toISOString(),
-        credentialSubject: {
-            id: credential.studentWallet ? `urn:acredia:student:${credential.studentWallet}` : `urn:acredia:student:${credential.tokenId}`,
-            type: ['AchievementSubject'],
-            achievement: {
-                id: `urn:acredia:achievement:${credential.tokenId}`,
-                type: ['Achievement'],
-                name: credential.degree || 'Academic Credential',
-                description: `Academic ${credential.credentialType || 'credential'} verified on-chain.`,
-                criteria: {
-                    narrative: 'Issued upon successful completion and verification of academic requirements.',
-                },
+/** True when `metadata` already has the shape produced by `buildAcrediaVerifiableCredential`. */
+function isVerifiableCredentialDocument(metadata: unknown): metadata is AcrediaVerifiableCredential {
+    return (
+        isRecord(metadata) &&
+        Array.isArray(metadata.type) &&
+        (metadata.type as unknown[]).includes('VerifiableCredential') &&
+        isRecord(metadata.credentialSubject)
+    );
+}
+
+function verifyUrl(tokenId: string): string {
+    if (typeof window === 'undefined') {
+        return `/verify?token=${encodeURIComponent(tokenId)}`;
+    }
+
+    return `${window.location.origin}/verify?token=${encodeURIComponent(tokenId)}`;
+}
+
+/**
+ * Builds the exact standards-compliant document a student/verifier should
+ * download for a given credential, enriched with a non-hashed on-chain
+ * anchor block.
+ *
+ * - When the stored metadata is already a schema-v2 VC/OBv3 document (the
+ *   default for every credential issued after this feature shipped), the
+ *   export is that *exact* stored object — byte-identical to what was
+ *   canonically hashed and anchored on-chain — plus the anchor block.
+ * - Otherwise (legacy credentials, or the curated public verify response
+ *   which doesn't carry the full metadata blob), a best-effort VC/OBv3
+ *   document is reconstructed from whatever fields are available. Its
+ *   `onChainAnchor.hashCoversThisDocument` is `false`: the reconstruction is
+ *   for interoperability/readability, not a byte-exact copy of the anchored
+ *   data.
+ */
+export async function buildStandardsExportDocument(
+    row: StandardsExportCredentialRow,
+): Promise<AcrediaVerifiableCredential & { credentialStatus: Record<string, unknown>; onChainAnchor: OnChainAnchor }> {
+    const network = runtimeConfig.stellar.networkName;
+    const contractId = getContractAddress('CREDENTIAL_NFT');
+    const explorerBaseUrl = runtimeConfig.stellar.explorerBaseUrl;
+    const schemaVersion = row.metadataSchemaVersion ?? null;
+
+    let credential: AcrediaVerifiableCredential;
+    let hashCoversThisDocument = false;
+    let credentialHash = '';
+    let hashAlgorithm = row.hashAlgorithm || 'unknown';
+
+    if (schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION_V2 && isVerifiableCredentialDocument(row.metadata)) {
+        credential = row.metadata;
+        hashAlgorithm = CREDENTIAL_HASH_ALGORITHM_V2;
+        credentialHash = await deriveCredentialHash(
+            row.metadata,
+            CREDENTIAL_METADATA_SCHEMA_VERSION_V2,
+            CREDENTIAL_HASH_ALGORITHM_V2,
+        );
+        hashCoversThisDocument = true;
+    } else {
+        const legacyData = isRecord(row.metadata) ? isRecord(row.metadata.credentialData) ? row.metadata.credentialData : {} : {};
+        credential = buildAcrediaVerifiableCredential(
+            {
+                studentName: String(legacyData.studentName ?? row.studentName ?? 'Credential Holder'),
+                studentWallet: String(legacyData.studentWallet ?? row.studentWallet ?? ''),
+                degree: String(legacyData.degree ?? row.degree ?? 'Academic Credential'),
+                major: (legacyData.major as string | undefined) ?? undefined,
+                gpa: (legacyData.gpa as string | undefined) ?? undefined,
+                issueDate: String(legacyData.issueDate ?? row.issueDate ?? new Date().toISOString()),
+                credentialType: String(legacyData.credentialType ?? row.credentialType ?? 'credential'),
+                institutionName: String(legacyData.institutionName ?? row.institutionName ?? 'Issuing Institution'),
+                institutionWallet: String(row.issuerWallet ?? ''),
+                subjects: Array.isArray(legacyData.subjects) ? legacyData.subjects : undefined,
             },
-        },
+            explorerBaseUrl,
+            null,
+        );
+
+        // A real on-chain hash may still exist for schema-v1 credentials —
+        // report it for transparency, but it covers the *original* stored
+        // metadata shape, not this reconstructed VC document.
+        if (schemaVersion === CREDENTIAL_METADATA_SCHEMA_VERSION_V1 && row.metadata) {
+            hashAlgorithm = CREDENTIAL_HASH_ALGORITHM_V1;
+            credentialHash = await deriveCredentialHash(
+                row.metadata,
+                CREDENTIAL_METADATA_SCHEMA_VERSION_V1,
+                CREDENTIAL_HASH_ALGORITHM_V1,
+            );
+        }
+    }
+
+    // A caller that already read the chain (e.g. the public /verify API)
+    // knows the real on-chain hash even when the full metadata blob wasn't
+    // sent to build/recompute it from. Trust that value when present.
+    if (row.onChainHash) {
+        credentialHash = row.onChainHash;
+        if (row.hashAlgorithm) {
+            hashAlgorithm = row.hashAlgorithm;
+        }
+    }
+
+    const anchor: OnChainAnchor = {
+        network,
+        contractId,
+        tokenId: row.tokenId,
+        transactionHash: row.blockchainHash || '',
+        credentialHash,
+        hashAlgorithm,
+        canonicalizationAlgorithm: 'sha256:canonical-json (see docs/VERIFIABLE_CREDENTIALS.md)',
+        verifyUrl: verifyUrl(row.tokenId),
+        hashCoversThisDocument,
     };
+
+    return attachOnChainAnchor(credential, anchor);
 }
 
 export function getLinkedInShareUrl(credential: {
@@ -102,7 +186,7 @@ export function getLinkedInShareUrl(credential: {
     return `https://www.linkedin.com/profile/add?${params.toString()}`;
 }
 
-export function downloadJsonFile(data: Record<string, unknown>, filename: string): void {
+export function downloadJsonFile(data: object, filename: string): void {
     if (typeof window === 'undefined') return;
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);

--- a/frontend/src/lib/verifiableCredential.ts
+++ b/frontend/src/lib/verifiableCredential.ts
@@ -1,0 +1,294 @@
+/**
+ * Builds Acredia credential metadata as a W3C Verifiable Credential (VC Data
+ * Model 1.1) that also conforms to the 1EdTech Open Badges 3.0
+ * `OpenBadgeCredential` profile.
+ *
+ * This is the single source of truth for the document shape: the exact
+ * object built here is what gets uploaded to IPFS and canonically hashed
+ * on-chain at issuance time (see `credentialService.ts` and
+ * `buildCanonicalCredentialPayloadV2` in `credentialHash.ts`), and it is also
+ * what the student-dashboard/public "download standards-compliant credential"
+ * export re-serves later. Keeping one builder means the exported file is
+ * always byte-identical to what was hashed, never a lossy re-derivation.
+ *
+ * Design notes:
+ *  - `@context` pins the real, versioned W3C VC 1.1 and 1EdTech OBv3 contexts,
+ *    plus a small local vocabulary (`acredia:`) for the two extension
+ *    properties this app adds: `credentialData` (legacy-shaped fields kept
+ *    for backward-compatible internal display/search) and `onChainAnchor`
+ *    (attached only to *exported* copies, never part of the hashed core —
+ *    see `attachOnChainAnchor`).
+ *  - Subject/issuer `id`s are real, resolvable `https://` Stellar Expert
+ *    account URLs rather than an invented, unregistered DID method — a
+ *    generic VC/OBv3 consumer can actually open them.
+ *  - No `proof` block is embedded in the hashed core: this system's proof of
+ *    issuance is the Stellar on-chain transaction + anchored hash, not an
+ *    embedded Data Integrity signature. See docs/VERIFIABLE_CREDENTIALS.md
+ *    for the verification recipe.
+ */
+
+export interface VerifiableCredentialSubject {
+    id: string;
+    name: string;
+    marks: string;
+    maxMarks: string;
+    grade?: string;
+}
+
+export interface BuildVerifiableCredentialInput {
+    studentName: string;
+    studentWallet: string;
+    degree: string;
+    major?: string;
+    gpa?: string;
+    issueDate: string;
+    credentialType: string;
+    institutionName: string;
+    institutionWallet: string;
+    subjects?: VerifiableCredentialSubject[];
+}
+
+export interface AchievementResult {
+    type: string[];
+    resultDescription: string;
+    value: string;
+}
+
+export interface AcrediaAchievement {
+    id: string;
+    type: string[];
+    name: string;
+    description: string;
+    achievementType: string | null;
+    criteria: { narrative: string };
+}
+
+export interface AcrediaCredentialSubject {
+    id: string;
+    type: string[];
+    name: string;
+    achievement: AcrediaAchievement;
+    result: AchievementResult[];
+}
+
+export interface AcrediaEvidence {
+    id: string;
+    type: string[];
+    name: string;
+    description: string;
+}
+
+export interface AcrediaVerifiableCredential {
+    '@context': (string | Record<string, unknown>)[];
+    id: string;
+    type: string[];
+    name: string;
+    description: string;
+    image: string | null;
+    issuer: {
+        id: string;
+        type: string[];
+        name: string;
+    };
+    issuanceDate: string;
+    credentialSubject: AcrediaCredentialSubject;
+    evidence: AcrediaEvidence[];
+    /** Legacy NFT-style fields, kept so existing dashboards/search continue to work unmodified. Not a VC/OBv3 standard property. */
+    credentialData: {
+        studentName: string;
+        studentWallet: string;
+        degree: string;
+        major?: string;
+        gpa?: string;
+        issueDate: string;
+        institutionName: string;
+        credentialType: string;
+        subjects?: VerifiableCredentialSubject[];
+    };
+}
+
+export const VC_CONTEXT_V1 = 'https://www.w3.org/2018/credentials/v1';
+export const OBV3_CONTEXT = 'https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json';
+export const ACREDIA_VOCAB_CONTEXT = {
+    acredia: 'https://acredia.app/ns#',
+    credentialData: 'acredia:credentialData',
+    onChainAnchor: 'acredia:onChainAnchor',
+};
+
+const ACHIEVEMENT_TYPE_BY_CREDENTIAL_TYPE: Record<string, string> = {
+    diploma: 'Diploma',
+    degree: 'Degree',
+    transcript: 'Transcript',
+    certificate: 'Certificate',
+    achievement: 'Achievement',
+};
+
+function slugify(value: string): string {
+    return (
+        value
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '') || 'na'
+    );
+}
+
+function mintUuid(): string {
+    if (typeof globalThis.crypto?.randomUUID === 'function') {
+        return globalThis.crypto.randomUUID();
+    }
+
+    // Fallback RFC 4122 v4 generator for environments without crypto.randomUUID.
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+        const random = (Math.random() * 16) | 0;
+        const value = char === 'x' ? random : (random & 0x3) | 0x8;
+        return value.toString(16);
+    });
+}
+
+function toIsoDateTime(issueDate: string): string {
+    const date = new Date(issueDate);
+    if (!Number.isNaN(date.getTime())) {
+        return date.toISOString();
+    }
+
+    return new Date().toISOString();
+}
+
+function accountUrl(explorerBaseUrl: string, wallet: string): string {
+    return `${explorerBaseUrl}/account/${wallet}`;
+}
+
+/**
+ * Builds the W3C VC / OBv3 credential document for a newly-issued credential.
+ *
+ * @param data Form/issuance data for this credential.
+ * @param explorerBaseUrl Stellar Expert explorer base URL for the active
+ *   network (e.g. `runtimeConfig.stellar.explorerBaseUrl`), used to build
+ *   resolvable `issuer.id` / `credentialSubject.id` URIs.
+ * @param evidenceUrl Public IPFS gateway URL of the uploaded source document
+ *   (transcript/diploma scan), if any.
+ */
+export function buildAcrediaVerifiableCredential(
+    data: BuildVerifiableCredentialInput,
+    explorerBaseUrl: string,
+    evidenceUrl?: string | null,
+): AcrediaVerifiableCredential {
+    const achievementType = ACHIEVEMENT_TYPE_BY_CREDENTIAL_TYPE[data.credentialType] ?? 'Achievement';
+    const achievementId = `urn:acredia:achievement:${slugify(data.institutionWallet)}:${slugify(
+        data.credentialType,
+    )}:${slugify(data.degree)}`;
+
+    const result: AchievementResult[] = [];
+    if (data.gpa) {
+        result.push({
+            type: ['Result'],
+            resultDescription: 'GPA',
+            value: data.gpa,
+        });
+    }
+
+    const evidence: AcrediaEvidence[] = evidenceUrl
+        ? [
+              {
+                  id: evidenceUrl,
+                  type: ['Evidence'],
+                  name: 'Original credential document',
+                  description: `Source document uploaded by ${data.institutionName} at issuance.`,
+              },
+          ]
+        : [];
+
+    return {
+        '@context': [VC_CONTEXT_V1, OBV3_CONTEXT, ACREDIA_VOCAB_CONTEXT],
+        id: `urn:uuid:${mintUuid()}`,
+        type: ['VerifiableCredential', 'OpenBadgeCredential'],
+        name: `${data.credentialType} - ${data.studentName}`,
+        description: `Academic credential issued by ${data.institutionName} to ${data.studentName}`,
+        image: evidenceUrl ?? null,
+        issuer: {
+            id: accountUrl(explorerBaseUrl, data.institutionWallet),
+            type: ['Profile'],
+            name: data.institutionName,
+        },
+        issuanceDate: toIsoDateTime(data.issueDate),
+        credentialSubject: {
+            id: accountUrl(explorerBaseUrl, data.studentWallet),
+            type: ['AchievementSubject'],
+            name: data.studentName,
+            achievement: {
+                id: achievementId,
+                type: ['Achievement'],
+                name: data.degree,
+                description: `Academic ${data.credentialType} verified on the Stellar blockchain.`,
+                achievementType,
+                criteria: {
+                    narrative:
+                        'Issued upon successful completion and verification of the stated academic requirements.',
+                },
+            },
+            result,
+        },
+        evidence,
+        credentialData: {
+            studentName: data.studentName,
+            studentWallet: data.studentWallet,
+            degree: data.degree,
+            major: data.major,
+            gpa: data.gpa,
+            issueDate: data.issueDate,
+            institutionName: data.institutionName,
+            credentialType: data.credentialType,
+            subjects: data.subjects,
+        },
+    };
+}
+
+export interface OnChainAnchor {
+    network: string;
+    contractId: string;
+    tokenId: string;
+    transactionHash: string;
+    credentialHash: string;
+    hashAlgorithm: string;
+    canonicalizationAlgorithm: string;
+    verifyUrl: string;
+    /**
+     * True only when `credentialHash` is the hash of exactly *this* exported
+     * document's core fields (schema v2). Older credentials issued before
+     * this format was byte-for-byte anchored on the VC form (schema v1) can
+     * still report their real on-chain hash here, but it covers the legacy
+     * metadata shape, not this reconstructed VC — set to `false` in that
+     * case so downstream consumers don't assume a hash match that doesn't
+     * hold. See docs/VERIFIABLE_CREDENTIALS.md.
+     */
+    hashCoversThisDocument: boolean;
+}
+
+/**
+ * Attaches a non-hashed `credentialStatus` + `onChainAnchor` block to a copy
+ * of the credential for download/export. This is deliberately never part of
+ * the hashed core (see `buildCanonicalCredentialPayloadV2`): a verifier
+ * checks authenticity by stripping these two properties, canonicalizing the
+ * rest, and comparing the resulting hash to `onChainAnchor.credentialHash`
+ * (which itself should match what is stored on-chain for the token).
+ */
+export function attachOnChainAnchor(
+    credential: AcrediaVerifiableCredential,
+    anchor: OnChainAnchor,
+): AcrediaVerifiableCredential & {
+    credentialStatus: Record<string, unknown>;
+    onChainAnchor: OnChainAnchor;
+} {
+    return {
+        ...credential,
+        credentialStatus: {
+            id: anchor.verifyUrl,
+            type: 'StellarSorobanRevocationStatus2024',
+            stellarNetwork: anchor.network,
+            stellarContractId: anchor.contractId,
+            stellarTokenId: anchor.tokenId,
+        },
+        onChainAnchor: anchor,
+    };
+}

--- a/frontend/tests/credentialHash.test.ts
+++ b/frontend/tests/credentialHash.test.ts
@@ -3,17 +3,24 @@ import { createHash } from 'crypto';
 import { describe, expect, it } from 'vitest';
 import {
     CREDENTIAL_HASH_ALGORITHM,
+    CREDENTIAL_HASH_ALGORITHM_V1,
+    CREDENTIAL_HASH_ALGORITHM_V2,
     CREDENTIAL_METADATA_SCHEMA_VERSION,
+    CREDENTIAL_METADATA_SCHEMA_VERSION_V1,
+    CREDENTIAL_METADATA_SCHEMA_VERSION_V2,
     LEGACY_CREDENTIAL_HASH_ALGORITHM,
     LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION,
     buildCanonicalCredentialPayloadV1,
+    buildCanonicalCredentialPayloadV2,
     canonicalJson,
     deriveCredentialHash,
     generateCanonicalCredentialHash,
     serializeCredentialMetadataForHash,
 } from '../src/lib/credentialHash';
 
-const metadata = {
+// ─── V1 (legacy NFT-style) canonicalization — still fully supported ────────
+
+const metadataV1 = {
     name: 'Degree - Alice Smith',
     description: 'Academic credential issued by Acredia Academy to Alice Smith',
     image: 'ipfs://file-cid',
@@ -38,25 +45,25 @@ const metadata = {
     },
 };
 
-const canonicalVector =
+const canonicalVectorV1 =
     '{"credentialData":{"credentialType":"Degree","degree":"BSc Computer Science","gpa":null,"institutionName":"Acredia Academy","issueDate":"2026-05-31","major":"Software Engineering","studentName":"Alice Smith","studentWallet":"GSTUDENTADDRESS","subjects":[{"grade":null,"id":"math-101","marks":"95","maxMarks":"100","name":"Mathematics"}]},"description":"Academic credential issued by Acredia Academy to Alice Smith","image":"ipfs://file-cid","name":"Degree - Alice Smith","schemaVersion":1}';
 
-const canonicalHashVector = 'feca52dc50aee21c1942333a13873250b5bda373e09a4e2aff29b80a44a78545';
+const canonicalHashVectorV1 = 'feca52dc50aee21c1942333a13873250b5bda373e09a4e2aff29b80a44a78545';
 
-describe('canonical credential metadata hashing', () => {
+describe('canonical credential metadata hashing — schema v1 (legacy NFT-style)', () => {
     it('serializes schema v1 payloads to a stable canonical test vector', () => {
-        expect(serializeCredentialMetadataForHash(metadata)).toBe(canonicalVector);
+        expect(serializeCredentialMetadataForHash(metadataV1, CREDENTIAL_METADATA_SCHEMA_VERSION_V1)).toBe(
+            canonicalVectorV1,
+        );
     });
 
     it('hashes schema v1 payloads to the shared browser/server test vector', async () => {
-        await expect(generateCanonicalCredentialHash(metadata)).resolves.toBe(canonicalHashVector);
         await expect(
-            deriveCredentialHash(
-                metadata,
-                CREDENTIAL_METADATA_SCHEMA_VERSION,
-                CREDENTIAL_HASH_ALGORITHM,
-            ),
-        ).resolves.toBe(canonicalHashVector);
+            generateCanonicalCredentialHash(metadataV1, CREDENTIAL_METADATA_SCHEMA_VERSION_V1),
+        ).resolves.toBe(canonicalHashVectorV1);
+        await expect(
+            deriveCredentialHash(metadataV1, CREDENTIAL_METADATA_SCHEMA_VERSION_V1, CREDENTIAL_HASH_ALGORITHM_V1),
+        ).resolves.toBe(canonicalHashVectorV1);
     });
 
     it('keeps semantically equivalent metadata stable across key ordering and optional fields', async () => {
@@ -84,50 +91,54 @@ describe('canonical credential metadata hashing', () => {
             name: 'Degree - Alice Smith',
         };
 
-        await expect(generateCanonicalCredentialHash(reordered)).resolves.toBe(canonicalHashVector);
+        await expect(
+            generateCanonicalCredentialHash(reordered, CREDENTIAL_METADATA_SCHEMA_VERSION_V1),
+        ).resolves.toBe(canonicalHashVectorV1);
     });
 
     it('normalizes equivalent issue date representations in schema v1', async () => {
         const withIsoTimestamp = {
-            ...metadata,
+            ...metadataV1,
             credentialData: {
-                ...metadata.credentialData,
+                ...metadataV1.credentialData,
                 issueDate: '2026-05-31T00:00:00.000Z',
             },
         };
 
         const withDateObject = {
-            ...metadata,
+            ...metadataV1,
             credentialData: {
-                ...metadata.credentialData,
+                ...metadataV1.credentialData,
                 issueDate: new Date('2026-05-31T00:00:00.000Z'),
             },
         };
 
-        await expect(generateCanonicalCredentialHash(withIsoTimestamp)).resolves.toBe(
-            canonicalHashVector,
-        );
-        await expect(generateCanonicalCredentialHash(withDateObject)).resolves.toBe(
-            canonicalHashVector,
-        );
+        await expect(
+            generateCanonicalCredentialHash(withIsoTimestamp, CREDENTIAL_METADATA_SCHEMA_VERSION_V1),
+        ).resolves.toBe(canonicalHashVectorV1);
+        await expect(
+            generateCanonicalCredentialHash(withDateObject, CREDENTIAL_METADATA_SCHEMA_VERSION_V1),
+        ).resolves.toBe(canonicalHashVectorV1);
     });
 
     it('matches Node SHA-256 over the same canonical payload string', async () => {
-        const payload = buildCanonicalCredentialPayloadV1(metadata);
+        const payload = buildCanonicalCredentialPayloadV1(metadataV1);
         const serialized = canonicalJson(payload as any);
         const nodeHash = createHash('sha256').update(serialized).digest('hex');
 
-        expect(serialized).toBe(canonicalVector);
-        await expect(generateCanonicalCredentialHash(metadata)).resolves.toBe(nodeHash);
+        expect(serialized).toBe(canonicalVectorV1);
+        await expect(
+            generateCanonicalCredentialHash(metadataV1, CREDENTIAL_METADATA_SCHEMA_VERSION_V1),
+        ).resolves.toBe(nodeHash);
     });
 
     it('preserves legacy JSON.stringify hashing for unstamped credentials', async () => {
-        const legacyHash = createHash('sha256').update(JSON.stringify(metadata)).digest('hex');
+        const legacyHash = createHash('sha256').update(JSON.stringify(metadataV1)).digest('hex');
 
-        await expect(deriveCredentialHash(metadata, null, null)).resolves.toBe(legacyHash);
+        await expect(deriveCredentialHash(metadataV1, null, null)).resolves.toBe(legacyHash);
         await expect(
             deriveCredentialHash(
-                metadata,
+                metadataV1,
                 LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION,
                 LEGACY_CREDENTIAL_HASH_ALGORITHM,
             ),
@@ -135,8 +146,138 @@ describe('canonical credential metadata hashing', () => {
     });
 
     it('rejects unsupported stamped hash schemas instead of guessing', async () => {
-        await expect(deriveCredentialHash(metadata, 99, CREDENTIAL_HASH_ALGORITHM)).rejects.toThrow(
+        await expect(deriveCredentialHash(metadataV1, 99, CREDENTIAL_HASH_ALGORITHM)).rejects.toThrow(
             /Unsupported credential metadata hash schema/,
         );
+    });
+});
+
+// ─── V2 (W3C VC / Open Badges 3.0) canonicalization — current default ──────
+
+const metadataV2 = {
+    '@context': [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json',
+        { acredia: 'https://acredia.app/ns#' },
+    ],
+    id: 'urn:uuid:00000000-0000-4000-8000-000000000000',
+    type: ['VerifiableCredential', 'OpenBadgeCredential'],
+    name: 'Degree - Alice Smith',
+    description: 'Academic credential issued by Acredia Academy to Alice Smith',
+    image: 'ipfs://file-cid',
+    issuer: {
+        id: 'https://stellar.expert/explorer/testnet/account/GISSUERADDRESS',
+        type: ['Profile'],
+        name: 'Acredia Academy',
+    },
+    issuanceDate: '2026-05-31T00:00:00.000Z',
+    credentialSubject: {
+        id: 'https://stellar.expert/explorer/testnet/account/GSTUDENTADDRESS',
+        type: ['AchievementSubject'],
+        name: 'Alice Smith',
+        achievement: {
+            id: 'urn:acredia:achievement:gissuer:degree:bsc-computer-science',
+            type: ['Achievement'],
+            name: 'BSc Computer Science',
+            description: 'Academic degree verified on the Stellar blockchain.',
+            achievementType: 'Degree',
+            criteria: { narrative: 'Issued upon successful completion and verification.' },
+        },
+        result: [{ type: ['Result'], resultDescription: 'GPA', value: '3.9' }],
+    },
+    evidence: [
+        {
+            id: 'ipfs://evidence-cid',
+            type: ['Evidence'],
+            name: 'Original credential document',
+            description: 'Source document uploaded by Acredia Academy at issuance.',
+        },
+    ],
+    credentialData: {
+        studentName: 'Alice Smith',
+        studentWallet: 'GSTUDENTADDRESS',
+        degree: 'BSc Computer Science',
+        major: 'Software Engineering',
+        gpa: '3.9',
+        issueDate: '2026-05-31',
+        institutionName: 'Acredia Academy',
+        credentialType: 'Degree',
+        subjects: [{ id: 'math-101', name: 'Mathematics', marks: 95, maxMarks: '100' }],
+    },
+};
+
+describe('canonical credential metadata hashing — schema v2 (W3C VC / Open Badges 3.0)', () => {
+    it('is the default schema version and hash algorithm for new issuances', () => {
+        expect(CREDENTIAL_METADATA_SCHEMA_VERSION).toBe(CREDENTIAL_METADATA_SCHEMA_VERSION_V2);
+        expect(CREDENTIAL_HASH_ALGORITHM).toBe(CREDENTIAL_HASH_ALGORITHM_V2);
+    });
+
+    it('produces a stable canonical JSON string that only includes the whitelisted VC fields', () => {
+        const payload = buildCanonicalCredentialPayloadV2(metadataV2);
+        expect(payload.schemaVersion).toBe(2);
+        expect(payload.issuer.name).toBe('Acredia Academy');
+        expect(payload.credentialSubject.achievement.name).toBe('BSc Computer Science');
+        expect(payload.credentialSubject.result).toEqual([
+            { type: ['Result'], resultDescription: 'GPA', value: '3.9' },
+        ]);
+        expect(payload.evidence).toHaveLength(1);
+        expect(payload.credentialData.studentName).toBe('Alice Smith');
+
+        const serialized = canonicalJson(payload as any);
+        const nodeHash = createHash('sha256').update(serialized).digest('hex');
+        expect(serialized).toBe(canonicalJson(buildCanonicalCredentialPayloadV2(metadataV2) as any));
+
+        return expect(
+            generateCanonicalCredentialHash(metadataV2, CREDENTIAL_METADATA_SCHEMA_VERSION_V2),
+        ).resolves.toBe(nodeHash);
+    });
+
+    it('routes the default (unversioned) call through V2 canonicalization', async () => {
+        const viaDefault = await generateCanonicalCredentialHash(metadataV2);
+        const viaExplicitV2 = await generateCanonicalCredentialHash(
+            metadataV2,
+            CREDENTIAL_METADATA_SCHEMA_VERSION_V2,
+        );
+        expect(viaDefault).toBe(viaExplicitV2);
+
+        await expect(
+            deriveCredentialHash(metadataV2, CREDENTIAL_METADATA_SCHEMA_VERSION_V2, CREDENTIAL_HASH_ALGORITHM_V2),
+        ).resolves.toBe(viaDefault);
+    });
+
+    it('is stable across key reordering and ignores fields outside the whitelist (e.g. a post-hoc onChainAnchor)', async () => {
+        const withExtraField = {
+            ...metadataV2,
+            onChainAnchor: { contractId: 'CAAA...', tokenId: '1' },
+            credentialStatus: { type: 'StellarSorobanRevocationStatus2024' },
+        };
+
+        const reordered = {
+            credentialData: metadataV2.credentialData,
+            evidence: metadataV2.evidence,
+            credentialSubject: metadataV2.credentialSubject,
+            issuanceDate: metadataV2.issuanceDate,
+            issuer: metadataV2.issuer,
+            image: metadataV2.image,
+            description: metadataV2.description,
+            name: metadataV2.name,
+            type: metadataV2.type,
+            id: metadataV2.id,
+            '@context': metadataV2['@context'],
+        };
+
+        const baseline = await generateCanonicalCredentialHash(metadataV2, CREDENTIAL_METADATA_SCHEMA_VERSION_V2);
+        await expect(
+            generateCanonicalCredentialHash(withExtraField, CREDENTIAL_METADATA_SCHEMA_VERSION_V2),
+        ).resolves.toBe(baseline);
+        await expect(
+            generateCanonicalCredentialHash(reordered, CREDENTIAL_METADATA_SCHEMA_VERSION_V2),
+        ).resolves.toBe(baseline);
+    });
+
+    it('does not cross-contaminate with the V1 canonicalization for the same input', async () => {
+        const asV1 = await generateCanonicalCredentialHash(metadataV2, CREDENTIAL_METADATA_SCHEMA_VERSION_V1);
+        const asV2 = await generateCanonicalCredentialHash(metadataV2, CREDENTIAL_METADATA_SCHEMA_VERSION_V2);
+        expect(asV1).not.toBe(asV2);
     });
 });

--- a/frontend/tests/playwright/e2e-support.ts
+++ b/frontend/tests/playwright/e2e-support.ts
@@ -178,6 +178,13 @@ export async function installE2eRoutes(page: Page) {
                     degree: credential.metadata?.credentialData?.degree ?? 'Degree',
                     major: credential.metadata?.credentialData?.major ?? null,
                     issueDate: credential.metadata?.credentialData?.issueDate ?? null,
+                    studentWallet: credential.student_wallet_address ?? null,
+                    institutionWallet: credential.issuer_wallet_address ?? null,
+                    metadataSchemaVersion: null,
+                    hashAlgorithm: null,
+                    onChainHash: null,
+                    blockchainHash: credential.blockchain_hash ?? null,
+                    ipfsHash: credential.ipfs_hash ?? null,
                 },
                 verification: {
                     verified: !credential.revoked,

--- a/frontend/tests/playwright/publicCredentialPage.spec.ts
+++ b/frontend/tests/playwright/publicCredentialPage.spec.ts
@@ -39,6 +39,7 @@ test('renders public credential showcase page with verify CTA, QR, LinkedIn, and
     await expect(page.getByRole('link', { name: 'Verify Credential' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'QR Code' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Add to LinkedIn' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'W3C VC (.json)' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Open Badges v3' })).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Download Verifiable Credential (.json)' }),
+    ).toBeVisible();
 });

--- a/frontend/tests/standardsExport.test.ts
+++ b/frontend/tests/standardsExport.test.ts
@@ -1,45 +1,87 @@
 import { describe, expect, it } from 'vitest';
-import {
-    exportW3cVerifiableCredential,
-    exportOpenBadgesV3,
-    getLinkedInShareUrl,
-} from '../src/lib/standardsExport';
+import { buildStandardsExportDocument, getLinkedInShareUrl } from '../src/lib/standardsExport';
+import { buildAcrediaVerifiableCredential } from '../src/lib/verifiableCredential';
+import { CREDENTIAL_METADATA_SCHEMA_VERSION_V2 } from '../src/lib/credentialHash';
 
-describe('Standards Export Generators', () => {
-    const mockCredential = {
-        tokenId: '123',
-        studentName: 'Ada Lovelace',
-        studentWallet: 'GBSVJNVIAGQEAK3WAAVGXSMT7BMLI4SHAJWKKMRCMJIYG7XESR4ANDZD',
-        institutionName: 'Acredia Academy',
-        issuerWallet: 'GAcrediaIssuerWallet0000000000000000000000000000001',
-        degree: 'Bachelor of Science in Computer Science',
-        credentialType: 'diploma',
-        issueDate: '2024-01-15',
-        blockchainHash: 'e2e-tx-hash-123',
-    };
+describe('buildStandardsExportDocument', () => {
+    const explorerBaseUrl = 'https://stellar.expert/explorer/testnet';
 
-    it('generates a valid W3C Verifiable Credential structure', () => {
-        const vc = exportW3cVerifiableCredential(mockCredential);
-        expect(vc['@context']).toContain('https://www.w3.org/2018/credentials/v1');
-        expect(vc.type).toContain('VerifiableCredential');
-        expect((vc.issuer as { name: string }).name).toBe('Acredia Academy');
-        expect((vc.credentialSubject as { degree: string }).degree).toBe('Bachelor of Science in Computer Science');
-        expect((vc.proof as { proofValue: string }).proofValue).toBe('e2e-tx-hash-123');
+    it('re-serves the exact stored V2 metadata (byte-identical core) with a non-hashed on-chain anchor attached', async () => {
+        const storedMetadata = buildAcrediaVerifiableCredential(
+            {
+                studentName: 'Ada Lovelace',
+                studentWallet: 'GBSVJNVIAGQEAK3WAAVGXSMT7BMLI4SHAJWKKMRCMJIYG7XESR4ANDZD',
+                degree: 'Bachelor of Science in Computer Science',
+                issueDate: '2024-01-15',
+                credentialType: 'diploma',
+                institutionName: 'Acredia Academy',
+                institutionWallet: 'GAcrediaIssuerWallet0000000000000000000000000000001',
+            },
+            explorerBaseUrl,
+            'ipfs://evidence-cid',
+        );
+
+        const doc = await buildStandardsExportDocument({
+            tokenId: '123',
+            metadata: storedMetadata,
+            metadataSchemaVersion: CREDENTIAL_METADATA_SCHEMA_VERSION_V2,
+            hashAlgorithm: 'sha256:canonical-json:v2',
+            blockchainHash: 'e2e-tx-hash-123',
+        });
+
+        // The core VC fields are exactly what was stored/hashed — not a rebuild.
+        expect(doc.id).toBe(storedMetadata.id);
+        expect(doc.issuer).toEqual(storedMetadata.issuer);
+        expect(doc.credentialSubject).toEqual(storedMetadata.credentialSubject);
+
+        expect(doc.onChainAnchor.tokenId).toBe('123');
+        expect(doc.onChainAnchor.transactionHash).toBe('e2e-tx-hash-123');
+        expect(doc.onChainAnchor.hashCoversThisDocument).toBe(true);
+        expect(doc.onChainAnchor.credentialHash).toMatch(/^[0-9a-f]{64}$/);
+        expect(doc.credentialStatus.type).toBe('StellarSorobanRevocationStatus2024');
     });
 
-    it('generates a valid Open Badges v3 structure', () => {
-        const obv3 = exportOpenBadgesV3(mockCredential);
-        expect(obv3['@context']).toContain('https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.1.json');
-        expect(obv3.name).toBe('Bachelor of Science in Computer Science');
-        expect((obv3.issuer as { name: string }).name).toBe('Acredia Academy');
+    it('reconstructs a best-effort VC for legacy/curated rows and is honest that the hash does not cover it', async () => {
+        const doc = await buildStandardsExportDocument({
+            tokenId: '123',
+            studentName: 'Ada Lovelace',
+            studentWallet: 'GBSVJNVIAGQEAK3WAAVGXSMT7BMLI4SHAJWKKMRCMJIYG7XESR4ANDZD',
+            institutionName: 'Acredia Academy',
+            issuerWallet: 'GAcrediaIssuerWallet0000000000000000000000000000001',
+            degree: 'Bachelor of Science in Computer Science',
+            credentialType: 'diploma',
+            issueDate: '2024-01-15',
+            blockchainHash: 'e2e-tx-hash-123',
+        });
+
+        expect(doc.type).toContain('VerifiableCredential');
+        expect(doc.type).toContain('OpenBadgeCredential');
+        expect(doc.issuer.name).toBe('Acredia Academy');
+        expect(doc.credentialSubject.achievement.name).toBe('Bachelor of Science in Computer Science');
+        expect(doc.onChainAnchor.hashCoversThisDocument).toBe(false);
+        // No proof is fabricated — a real cryptographic proof type would be
+        // actively misleading here since no signature is actually verifiable.
+        expect((doc as unknown as Record<string, unknown>).proof).toBeUndefined();
+    });
+
+    it('trusts a caller-supplied on-chain hash (e.g. from the public verify API) over recomputing one', async () => {
+        const doc = await buildStandardsExportDocument({
+            tokenId: '123',
+            onChainHash: 'f'.repeat(64),
+            hashAlgorithm: 'sha256:canonical-json:v2',
+            degree: 'Bachelor of Science in Computer Science',
+            institutionName: 'Acredia Academy',
+        });
+
+        expect(doc.onChainAnchor.credentialHash).toBe('f'.repeat(64));
     });
 
     it('generates a properly formatted LinkedIn add certification URL', () => {
         const url = getLinkedInShareUrl({
-            title: mockCredential.degree,
-            institutionName: mockCredential.institutionName,
-            issueDate: mockCredential.issueDate,
-            tokenId: mockCredential.tokenId,
+            title: 'Bachelor of Science in Computer Science',
+            institutionName: 'Acredia Academy',
+            issueDate: '2024-01-15',
+            tokenId: '123',
             certUrl: 'https://acredia.test/credentials/123',
         });
 

--- a/frontend/tests/verifiableCredential.test.ts
+++ b/frontend/tests/verifiableCredential.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+    attachOnChainAnchor,
+    buildAcrediaVerifiableCredential,
+    OBV3_CONTEXT,
+    VC_CONTEXT_V1,
+    type BuildVerifiableCredentialInput,
+} from '../src/lib/verifiableCredential';
+import { validateVerifiableCredential } from '../src/lib/schemas';
+import { generateCanonicalCredentialHash } from '../src/lib/credentialHash';
+
+const explorerBaseUrl = 'https://stellar.expert/explorer/testnet';
+
+const baseInput: BuildVerifiableCredentialInput = {
+    studentName: 'Ada Lovelace',
+    studentWallet: 'GSTUDENTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    degree: 'BSc Computer Science',
+    major: 'Software Engineering',
+    gpa: '3.9',
+    issueDate: '2026-05-31',
+    credentialType: 'degree',
+    institutionName: 'Acredia Academy',
+    institutionWallet: 'GISSUERADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    subjects: [{ id: 'math-101', name: 'Mathematics', marks: '95', maxMarks: '100', grade: 'A' }],
+};
+
+describe('buildAcrediaVerifiableCredential', () => {
+    it('produces a document that validates as a VerifiableCredential / OpenBadgeCredential', () => {
+        const vc = buildAcrediaVerifiableCredential(baseInput, explorerBaseUrl, 'ipfs://evidence-cid');
+
+        expect(() => validateVerifiableCredential(vc)).not.toThrow();
+        expect(vc.type).toEqual(['VerifiableCredential', 'OpenBadgeCredential']);
+        expect(vc['@context']).toContain(VC_CONTEXT_V1);
+        expect(vc['@context']).toContain(OBV3_CONTEXT);
+    });
+
+    it('maps issuer, subject, achievement, issuance date, and evidence to standard VC/OBv3 fields', () => {
+        const vc = buildAcrediaVerifiableCredential(baseInput, explorerBaseUrl, 'ipfs://evidence-cid');
+
+        // issuer
+        expect(vc.issuer.name).toBe('Acredia Academy');
+        expect(vc.issuer.id).toBe(`${explorerBaseUrl}/account/${baseInput.institutionWallet}`);
+        expect(vc.issuer.type).toContain('Profile');
+
+        // subject
+        expect(vc.credentialSubject.name).toBe('Ada Lovelace');
+        expect(vc.credentialSubject.id).toBe(`${explorerBaseUrl}/account/${baseInput.studentWallet}`);
+        expect(vc.credentialSubject.type).toContain('AchievementSubject');
+
+        // achievement
+        expect(vc.credentialSubject.achievement.name).toBe('BSc Computer Science');
+        expect(vc.credentialSubject.achievement.achievementType).toBe('Degree');
+        expect(vc.credentialSubject.achievement.type).toContain('Achievement');
+
+        // issuance date: normalized to a full ISO 8601 datetime
+        expect(vc.issuanceDate).toBe(new Date('2026-05-31').toISOString());
+
+        // evidence
+        expect(vc.evidence).toHaveLength(1);
+        expect(vc.evidence[0].id).toBe('ipfs://evidence-cid');
+        expect(vc.evidence[0].type).toContain('Evidence');
+
+        // GPA surfaced as a standard `result` entry
+        expect(vc.credentialSubject.result).toEqual([
+            { type: ['Result'], resultDescription: 'GPA', value: '3.9' },
+        ]);
+    });
+
+    it('omits evidence when no source document was uploaded', () => {
+        const vc = buildAcrediaVerifiableCredential(baseInput, explorerBaseUrl, null);
+        expect(vc.evidence).toEqual([]);
+        expect(vc.image).toBeNull();
+    });
+
+    it('mints a fresh, unique id for every build', () => {
+        const first = buildAcrediaVerifiableCredential(baseInput, explorerBaseUrl, null);
+        const second = buildAcrediaVerifiableCredential(baseInput, explorerBaseUrl, null);
+        expect(first.id).not.toBe(second.id);
+        expect(first.id).toMatch(/^urn:uuid:/);
+    });
+
+    it('keeps the legacy credentialData extension for backward-compatible internal display', () => {
+        const vc = buildAcrediaVerifiableCredential(baseInput, explorerBaseUrl, null);
+        expect(vc.credentialData).toEqual({
+            studentName: 'Ada Lovelace',
+            studentWallet: baseInput.studentWallet,
+            degree: 'BSc Computer Science',
+            major: 'Software Engineering',
+            gpa: '3.9',
+            issueDate: '2026-05-31',
+            institutionName: 'Acredia Academy',
+            credentialType: 'degree',
+            subjects: baseInput.subjects,
+        });
+    });
+
+    it('is hashable end-to-end via the canonical V2 hasher', async () => {
+        const vc = buildAcrediaVerifiableCredential(baseInput, explorerBaseUrl, 'ipfs://evidence-cid');
+        const hash = await generateCanonicalCredentialHash(vc);
+        expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+});
+
+describe('attachOnChainAnchor', () => {
+    it('adds credentialStatus and onChainAnchor without mutating the original document', () => {
+        const vc = buildAcrediaVerifiableCredential(baseInput, explorerBaseUrl, null);
+        const anchored = attachOnChainAnchor(vc, {
+            network: 'testnet',
+            contractId: 'CCONTRACT',
+            tokenId: '1',
+            transactionHash: 'TXHASH',
+            credentialHash: 'a'.repeat(64),
+            hashAlgorithm: 'sha256:canonical-json:v2',
+            canonicalizationAlgorithm: 'sha256:canonical-json',
+            verifyUrl: 'https://acredia.app/verify?token=1',
+            hashCoversThisDocument: true,
+        });
+
+        expect((vc as unknown as Record<string, unknown>).onChainAnchor).toBeUndefined();
+        expect(anchored.onChainAnchor.tokenId).toBe('1');
+        expect(anchored.credentialStatus.id).toBe('https://acredia.app/verify?token=1');
+    });
+});


### PR DESCRIPTION
This pull request introduces major improvements to the handling, export, and documentation of verifiable credentials in the app. The most significant change is the adoption of the W3C Verifiable Credential / Open Badges 3.0 standard for credential metadata, with a new, detailed contributor and verifier guide. The export and download flows for credentials have been unified and simplified, and additional metadata fields are now surfaced throughout the API and UI to support better interoperability and verification.

**Verifiable Credentials & Standards Compliance**

* Added a comprehensive guide at `frontend/VERIFIABLE_CREDENTIALS.md` explaining the W3C VC / Open Badges 3.0 schema, field mapping, canonicalization, and third-party verification, and linked to it from the main `README.md`. [[1]](diffhunk://#diff-9347573e3bf6231517842fb70f88fab639c65e630259f58eb3991b016fdfc96dR1-R233) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L360-R363)
* Credential metadata is now modeled and exported as a standards-compliant W3C VC / OBv3 document, with legacy fields properly namespaced and documented.

**API & Data Model Enhancements**

* Added `metadata_schema_version` and `hash_algorithm` fields to credential API responses and database queries, ensuring all necessary data for standards-compliant exports and verification is available. [[1]](diffhunk://#diff-23479b9d99d3d8517fb841e806f898f9c1c8a22b62781236c9b8b8c96cf74989R25-R26) [[2]](diffhunk://#diff-23479b9d99d3d8517fb841e806f898f9c1c8a22b62781236c9b8b8c96cf74989L92-R95) [frontend/src/app/api/verify/[token]/route.tsR164](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R164), [frontend/src/app/api/verify/[token]/route.tsR267-R275](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R267-R275), [[3]](diffhunk://#diff-bfe64fc94569b23cbc34312ab2ac8bdb5cbe6c469ac98852a053914b8dcf881eR50-R51)

**UI/UX Improvements**

* Unified the credential export/download functionality in both the student dashboard and public credential page, replacing separate W3C VC and Open Badges v3 exports with a single standards-compliant export button. The download button now provides user feedback during preparation. [[1]](diffhunk://#diff-1a45eab603c72113efe8aa842a4386317b5b0a3158e5c50dd033b74890345708L21-R22) [[2]](diffhunk://#diff-1a45eab603c72113efe8aa842a4386317b5b0a3158e5c50dd033b74890345708R39-R41) [[3]](diffhunk://#diff-1a45eab603c72113efe8aa842a4386317b5b0a3158e5c50dd033b74890345708R51) [[4]](diffhunk://#diff-1a45eab603c72113efe8aa842a4386317b5b0a3158e5c50dd033b74890345708L88-R111) [[5]](diffhunk://#diff-1a45eab603c72113efe8aa842a4386317b5b0a3158e5c50dd033b74890345708L166-R184) [[6]](diffhunk://#diff-bfe64fc94569b23cbc34312ab2ac8bdb5cbe6c469ac98852a053914b8dcf881eR12) [[7]](diffhunk://#diff-bfe64fc94569b23cbc34312ab2ac8bdb5cbe6c469ac98852a053914b8dcf881eR27)
* Displayed additional metadata (e.g., on-chain hash, schema version, hash algorithm, wallet addresses) in the public credential card and page for transparency and easier verification. ([frontend/src/app/credentials/[token]/page.tsxR68-R79](diffhunk://#diff-a0bd14e6f824a914f8aa3794c94171473aa3d17bbf1bbf552337cce3f57828b5R68-R79), [frontend/src/components/student/PublicCredentialCard.tsxR39-R41](diffhunk://#diff-1a45eab603c72113efe8aa842a4386317b5b0a3158e5c50dd033b74890345708R39-R41))

These changes collectively bring the app's credentialing system up to modern interoperability standards and make it much easier for contributors and third parties to understand, verify, and use exported credentials.


close #162 