### PR TITLE
Implement verifiable credential generation and enhance hashing tests

### DIFF
--- a/frontend/VERIFIABLE_CREDENTIALS.md
+++ b/frontend/VERIFIABLE_CREDENTIALS.md
@@ -195,8 +195,14 @@ async function verify(document: unknown, onChainHashHex: string): Promise<boolea
 ```
 
 Or, more simply, trust this app's own `GET /api/verify/{token}` endpoint,
-which performs exactly this check server-side and returns
-`verification.onChainMatch` / `verification.verified`.
+which performs exactly steps 2–3 server-side (fetching the document from the
+CID the contract actually points to, not a cached copy) and returns the
+result as `verification.integrity.status` — `'match'`, `'mismatch'`, or
+`'unavailable'` if the CID couldn't be resolved just now. This is distinct
+from `verification.onChainMatch` / `verification.verified`, which check the
+*database's* cached metadata against the chain, not the live IPFS content —
+see `src/app/api/verify/[token]/route.ts`'s `checkIntegrity` and the "Document
+Integrity" card on `/verify`.
 
 ### Legacy (schema v1) credentials
 

--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -8,12 +8,20 @@ import {
     BlockchainUnavailableError,
 } from '@/lib/contractReads';
 import { deriveCredentialHash } from '@/lib/credentialHash';
+import { fetchJsonFromIpfs } from '@/lib/ipfsServer';
 import { enforceRateLimit } from '@/lib/rateLimit';
 import {
     writeVerificationAuditLog,
     type VerificationResultType,
 } from '@/lib/verificationAudit';
 import { captureException, recordMetric } from '@/lib/debug';
+
+export type IntegrityStatus = 'match' | 'mismatch' | 'unavailable';
+
+export interface IntegrityResult {
+    status: IntegrityStatus;
+    cidResolved: boolean;
+}
 
 export const dynamic = 'force-dynamic';
 
@@ -63,6 +71,47 @@ function getResultType(verified: boolean, revoked: boolean): VerificationResultT
     return 'mismatch';
 }
 
+/**
+ * Independently confirms that the CID the contract actually points to
+ * (`onChainUri`) resolves and that its content hashes to the same value as
+ * the on-chain `credential_hash`. This is deliberately separate from
+ * `checks.hashMatch` above, which only proves the *database's cached copy*
+ * of the metadata matches the chain — it says nothing about whether the
+ * document a real verifier would fetch from IPFS is the same bytes. See
+ * ACREDIA-STELLAR#163.
+ */
+async function checkIntegrity(
+    onChainUri: string | null | undefined,
+    onChainHash: string | null | undefined,
+    metadataSchemaVersion: number | null | undefined,
+    hashAlgorithm: string | null | undefined,
+): Promise<IntegrityResult> {
+    if (!onChainUri || !onChainHash) {
+        return { status: 'unavailable', cidResolved: false };
+    }
+
+    const fetched = await fetchJsonFromIpfs(onChainUri);
+    if (!fetched.ok) {
+        return { status: 'unavailable', cidResolved: false };
+    }
+
+    try {
+        const fetchedHash = await deriveCredentialHash(
+            fetched.content,
+            metadataSchemaVersion,
+            hashAlgorithm,
+        );
+        return {
+            status: fetchedHash === onChainHash ? 'match' : 'mismatch',
+            cidResolved: true,
+        };
+    } catch {
+        // Content resolved but isn't a canonicalizable document for the
+        // recorded schema version — can't be judged authentic or tampered.
+        return { status: 'unavailable', cidResolved: true };
+    }
+}
+
 async function logVerificationAttempt(
     supabase: ServiceRoleClient | null,
     request: NextRequest,
@@ -76,6 +125,7 @@ async function logVerificationAttempt(
             revoked?: boolean;
             match?: boolean;
         };
+        integrity?: IntegrityResult;
         mismatchReasons?: string[];
         errorCategory?: string;
     } = {},
@@ -85,6 +135,7 @@ async function logVerificationAttempt(
         statusCode,
         credentialId: options.credentialId,
         chain: options.chain,
+        integrityStatus: options.integrity?.status,
         errorCategory: options.errorCategory,
     });
 
@@ -99,6 +150,7 @@ async function logVerificationAttempt(
         statusCode,
         credentialId: options.credentialId,
         chain: options.chain,
+        integrity: options.integrity,
         mismatchReasons: options.mismatchReasons,
         errorCategory: options.errorCategory,
     });
@@ -236,6 +288,22 @@ export async function GET(
         const verified = onChain !== null && onChainMatch && !revoked;
         const resultType = getResultType(verified, revoked);
 
+        // Recompute the hash of the document actually fetched from IPFS (not
+        // the database's cached copy) and compare it to the on-chain hash —
+        // proves the CID resolves *and* that its content is what was
+        // anchored, independent of `checks.hashMatch` above.
+        const integrity = await checkIntegrity(
+            onChain?.uri,
+            onChain?.hash,
+            data.metadata_schema_version,
+            data.hash_algorithm,
+        );
+
+        const mismatchReasons = [
+            ...(resultType === 'mismatch' ? getMismatchReasons(checks) : []),
+            ...(integrity.status === 'mismatch' ? ['ipfs_integrity'] : []),
+        ];
+
         await logVerificationAttempt(supabase, request, token, resultType, 200, {
             credentialId,
             chain: {
@@ -243,7 +311,8 @@ export async function GET(
                 revoked,
                 match: onChainMatch,
             },
-            mismatchReasons: resultType === 'mismatch' ? getMismatchReasons(checks) : [],
+            integrity,
+            mismatchReasons,
         });
 
         const institution = Array.isArray(data.institution)
@@ -281,6 +350,11 @@ export async function GET(
                 onChainFound: onChain !== null,
                 issuerAuthorized,
                 issuerStatus: issuerAuthorized ? 'active' : 'revoked',
+                // Distinct from `revoked`/`onChainFound`: proves the actual
+                // IPFS-hosted document — not the DB's cached copy — hashes to
+                // the on-chain value. 'unavailable' means the CID couldn't be
+                // resolved/checked, not that anything is wrong.
+                integrity,
             },
         });
     } catch (err: unknown) {

--- a/frontend/src/app/verify/page.tsx
+++ b/frontend/src/app/verify/page.tsx
@@ -28,6 +28,7 @@ import {
 import Link from 'next/link';
 import { VerificationStateCard } from '@/components/verify/VerificationStateCard';
 import { VerificationSummary } from '@/components/verify/VerificationSummary';
+import { IntegrityStateCard } from '@/components/verify/IntegrityStateCard';
 import { useCredentialVerification } from '@/hooks/useCredentialVerification';
 import { SiteNavbar } from '@/components/marketing/SiteNavbar';
 
@@ -41,6 +42,7 @@ function VerifyContent() {
         credential,
         error,
         verificationStatus,
+        integrityStatus,
         manualToken,
         setManualToken,
         scanMode,
@@ -462,6 +464,14 @@ function VerifyContent() {
                             )}
                         </div>
                     </Card>
+
+                    {/* Document Integrity (CID ↔ on-chain hash) — a distinct
+                        signal from the revoked/not-found status above: it
+                        proves the document actually fetched from IPFS is the
+                        same bytes anchored on-chain. */}
+                    {integrityStatus && (
+                        <IntegrityStateCard status={integrityStatus} />
+                    )}
 
                     {/* Credential Details */}
                     <Card className="p-8 md:p-10 space-y-6 bg-card/90 backdrop-blur shadow-lg">

--- a/frontend/src/components/verify/IntegrityStateCard.tsx
+++ b/frontend/src/components/verify/IntegrityStateCard.tsx
@@ -1,0 +1,65 @@
+import { AlertTriangle, CheckCircle2, HelpCircle } from 'lucide-react';
+
+export type IntegrityStatus = 'match' | 'mismatch' | 'unavailable';
+
+interface IntegrityStateCardProps {
+    status: IntegrityStatus;
+}
+
+/**
+ * Surfaces the end-to-end CID ↔ on-chain-hash integrity result as its own,
+ * explicit state — deliberately separate from `VerificationStateCard`
+ * (valid/invalid/revoked). A credential can be a currently-authorized,
+ * non-revoked, on-chain match and *still* have its IPFS-hosted document
+ * fail this check if the pinned content was altered or is unreachable, so
+ * this is never folded into the main status card. See ACREDIA-STELLAR#163.
+ */
+export function IntegrityStateCard({ status }: IntegrityStateCardProps) {
+    const config = {
+        match: {
+            icon: CheckCircle2,
+            iconClassName: 'text-success',
+            wrapperClassName: 'border-success/25 bg-success/10',
+            title: 'Document Integrity: Authentic',
+            description:
+                'The credential document was fetched from IPFS and its content hash exactly matches the hash recorded on-chain. Nothing about this document has been altered since issuance.',
+        },
+        mismatch: {
+            icon: AlertTriangle,
+            iconClassName: 'text-destructive',
+            wrapperClassName: 'border-destructive/25 bg-destructive/10',
+            title: 'Document Integrity: Failed',
+            description:
+                'The document retrieved from the on-chain IPFS CID does not match the hash recorded on-chain. Do not rely on the details below — this document may have been tampered with or corrupted, independent of its revocation status.',
+        },
+        unavailable: {
+            icon: HelpCircle,
+            iconClassName: 'text-muted-foreground',
+            wrapperClassName: 'border-border bg-secondary/40',
+            title: 'Document Integrity: Unavailable',
+            description:
+                'The IPFS-hosted document could not be retrieved right now, so its content could not be independently checked against the on-chain hash. This does not mean the credential is invalid — please try again shortly.',
+        },
+    } as const;
+
+    const current = config[status];
+    const Icon = current.icon;
+
+    return (
+        <div
+            className={`rounded-2xl border p-6 shadow-sm ${current.wrapperClassName}`}
+            role="status"
+            aria-live="polite"
+        >
+            <div className="flex items-start gap-3">
+                <div className="rounded-full bg-white/80 p-2">
+                    <Icon className={`h-6 w-6 ${current.iconClassName}`} />
+                </div>
+                <div>
+                    <h3 className="text-lg font-semibold text-slate-900">{current.title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-slate-600">{current.description}</p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/hooks/useCredentialVerification.ts
+++ b/frontend/src/hooks/useCredentialVerification.ts
@@ -35,6 +35,8 @@ export interface CredentialData {
     issuer_status?: 'active' | 'revoked';
 }
 
+export type IntegrityStatus = 'match' | 'mismatch' | 'unavailable';
+
 export type ScanState =
     | 'idle'
     | 'requesting'
@@ -53,6 +55,7 @@ export function useCredentialVerification(tokenId: string | null) {
     const [credential, setCredential] = useState<CredentialData | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [verificationStatus, setVerificationStatus] = useState<'valid' | 'invalid' | 'revoked' | null>(null);
+    const [integrityStatus, setIntegrityStatus] = useState<IntegrityStatus | null>(null);
     const [manualToken, setManualToken] = useState('');
     const [scanMode, setScanMode] = useState(false);
     const [scanState, setScanState] = useState<ScanState>('idle');
@@ -122,9 +125,11 @@ export function useCredentialVerification(tokenId: string | null) {
 
             setCredential(transformedData);
             setVerificationStatus(safe.revoked ? 'revoked' : 'valid');
+            setIntegrityStatus(verification?.integrity?.status ?? null);
         } catch (err: unknown) {
             setError((err instanceof Error ? err.message : String(err)) || 'Failed to verify credential');
             setVerificationStatus('invalid');
+            setIntegrityStatus(null);
         } finally {
             setLoading(false);
         }
@@ -237,6 +242,7 @@ export function useCredentialVerification(tokenId: string | null) {
         credential,
         error,
         verificationStatus,
+        integrityStatus,
         manualToken,
         setManualToken,
         scanMode,

--- a/frontend/src/lib/ipfsServer.ts
+++ b/frontend/src/lib/ipfsServer.ts
@@ -1,10 +1,11 @@
-import { serverRuntimeConfig } from './runtimeConfig';
+import { runtimeConfig, serverRuntimeConfig } from './runtimeConfig';
 import { captureException, recordMetric } from './debug';
 
 const PINATA_API_BASE = 'https://api.pinata.cloud/pinning';
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const MAX_JSON_SIZE_BYTES = 1 * 1024 * 1024;
 const ALLOWED_FILE_TYPES = new Set(['application/pdf', 'image/jpeg', 'image/jpg', 'image/png']);
+const IPFS_FETCH_TIMEOUT_MS = 8_000;
 
 function requirePinataJwt(): string {
     const jwt = serverRuntimeConfig.ipfs.jwt;
@@ -154,6 +155,53 @@ export async function decryptBufferAESGCM(payload: EncryptedPayload, secretKeyHe
     const decryptedBuffer = await globalThis.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, cryptoKey, ciphertext as unknown as BufferSource);
 
     return new Uint8Array(decryptedBuffer);
+}
+
+export type IpfsFetchResult =
+    | { ok: true; content: unknown }
+    | { ok: false; reason: 'not_found' | 'gateway_error' | 'invalid_json' | 'timeout' | 'network_error' };
+
+function ipfsGatewayUrl(cidOrUri: string): string {
+    const path = cidOrUri.replace(/^ipfs:\/\//, '');
+    return `${runtimeConfig.ipfs.gatewayUrl}/ipfs/${path}`;
+}
+
+/**
+ * Fetches and parses the JSON document a CID/`ipfs://` URI resolves to, via
+ * the public IPFS gateway — used to independently confirm that a CID
+ * referenced on-chain actually resolves and to recompute its content hash
+ * (see `GET /api/verify/[token]`'s integrity check). Never throws: network
+ * failures, timeouts, and non-2xx responses all collapse to `{ ok: false }`
+ * so callers can report a clear "unavailable" state instead of a 500.
+ */
+export async function fetchJsonFromIpfs(cidOrUri: string): Promise<IpfsFetchResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), IPFS_FETCH_TIMEOUT_MS);
+
+    try {
+        const response = await fetch(ipfsGatewayUrl(cidOrUri), { signal: controller.signal });
+
+        if (response.status === 404) {
+            return { ok: false, reason: 'not_found' };
+        }
+
+        if (!response.ok) {
+            recordMetric('ipfs.fetch.error', 1, { status: response.status });
+            return { ok: false, reason: 'gateway_error' };
+        }
+
+        try {
+            return { ok: true, content: await response.json() };
+        } catch {
+            return { ok: false, reason: 'invalid_json' };
+        }
+    } catch (error) {
+        const isAbort = error instanceof Error && error.name === 'AbortError';
+        recordMetric('ipfs.fetch.error', 1, { reason: isAbort ? 'timeout' : 'network_error' });
+        return { ok: false, reason: isAbort ? 'timeout' : 'network_error' };
+    } finally {
+        clearTimeout(timeout);
+    }
 }
 
 /**

--- a/frontend/src/lib/queue.ts
+++ b/frontend/src/lib/queue.ts
@@ -4,7 +4,7 @@ import { SupabaseClient } from '@supabase/supabase-js';
 export interface Job {
     id: string;
     name: string;
-    payload: Record<string, unknown> | unknown;
+    payload: Record<string, unknown>;
     status: 'pending' | 'processing' | 'completed' | 'failed';
     attempts: number;
     max_attempts: number;
@@ -27,7 +27,7 @@ export type JobHandler = (payload: any) => Promise<void> | void;
 export async function enqueueJob(
     client: SupabaseClient,
     name: string,
-    payload: Record<string, unknown> | unknown,
+    payload: Record<string, unknown>,
     options?: {
         idempotencyKey?: string;
         runAt?: Date;

--- a/frontend/src/lib/rateLimit.ts
+++ b/frontend/src/lib/rateLimit.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { captureException } from './debug';
 
 type RateLimitOptions = {
     windowSeconds: number;
@@ -136,7 +137,7 @@ export function createUpstashRateLimitStore(): RateLimitStore | null {
                 // Degrade gracefully: log and fall back to per-instance memory store.
                 // This means limits may not be globally enforced during an outage, but
                 // legitimate traffic is never blocked by a Redis error.
-                console.error('[rateLimit] Upstash error, falling back to in-memory:', err);
+                captureException(err, { context: 'rateLimit.increment', fallback: 'in-memory' });
                 return fallback.increment(key, windowSeconds);
             }
         },
@@ -180,7 +181,7 @@ export function createUpstashRateLimitStore(): RateLimitStore | null {
                 // Also flush the local fallback store
                 fallback.reset?.();
             } catch (err) {
-                console.error('[rateLimit] Upstash reset error:', err);
+                captureException(err, { context: 'rateLimit.reset' });
                 fallback.reset?.();
             }
         },

--- a/frontend/src/lib/verificationAudit.ts
+++ b/frontend/src/lib/verificationAudit.ts
@@ -34,6 +34,17 @@ type VerificationAuditLog = {
         revoked?: boolean;
         match?: boolean;
     };
+    /**
+     * End-to-end CID/hash integrity result (ACREDIA-STELLAR#163): whether the
+     * document actually fetched from the on-chain IPFS CID hashes to the
+     * on-chain `credential_hash`. Already reduced to an enum + boolean before
+     * it gets here, so — like the rest of this log — it carries no document
+     * content or other identifying data.
+     */
+    integrity?: {
+        status: 'match' | 'mismatch' | 'unavailable';
+        cidResolved: boolean;
+    };
     mismatchReasons?: string[];
     errorCategory?: string;
 };
@@ -53,13 +64,14 @@ export function hashAuditValue(value: string | null | undefined): string | null 
 
 function buildVerificationResult(log: VerificationAuditLog) {
     return {
-        schema_version: 1,
+        schema_version: 2,
         result_type: log.resultType,
         status_code: log.statusCode,
         token_hash: hashAuditValue(log.token),
         ip_hash: hashAuditValue(getClientIp(log.request)),
         user_agent_hash: hashAuditValue(log.request.headers.get('user-agent')),
         chain: log.chain ?? null,
+        integrity: log.integrity ?? null,
         mismatch_reasons: log.mismatchReasons ?? [],
         error_category: log.errorCategory ?? null,
     };

--- a/frontend/tests/e2e.lifecycle.test.ts
+++ b/frontend/tests/e2e.lifecycle.test.ts
@@ -12,6 +12,7 @@ const {
     mockVerificationLogInsert,
     mockSupabaseMaybeSingle,
     mockRequireAdminRequest,
+    mockFetchJsonFromIpfs,
 } = vi.hoisted(() => ({
     mockIssueCredentialOnStellar: vi.fn(),
     mockGetServiceRoleClient: vi.fn(),
@@ -21,6 +22,7 @@ const {
     mockVerificationLogInsert: vi.fn(),
     mockSupabaseMaybeSingle: vi.fn(),
     mockRequireAdminRequest: vi.fn(),
+    mockFetchJsonFromIpfs: vi.fn(),
 }));
 
 // Mock IPFS methods
@@ -28,6 +30,14 @@ vi.mock('../src/lib/ipfs', () => ({
     uploadToIPFS: vi.fn(async () => 'mocked-file-cid'),
     uploadJSONToIPFS: vi.fn(async () => 'mocked-metadata-path'),
     getIPFSUrl: vi.fn((cid) => `ipfs://${cid}`),
+}));
+
+// Mock the server-side IPFS gateway fetch used by the verify route's
+// end-to-end integrity check (ACREDIA-STELLAR#163). Each verify-route test
+// below sets this to resolve with the same content it expects the CID to
+// hold, so the integrity check's outcome matches what that test is probing.
+vi.mock('../src/lib/ipfsServer', () => ({
+    fetchJsonFromIpfs: mockFetchJsonFromIpfs,
 }));
 
 // Mock Stellar/Freighter contracts
@@ -250,6 +260,7 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         });
 
         mockIsRevoked.mockResolvedValue(false);
+        mockFetchJsonFromIpfs.mockResolvedValue({ ok: true, content: dbMetadata });
 
         // Call verify route
         const req = new NextRequest('http://localhost:3000/api/verify/123');
@@ -260,6 +271,7 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         expect(payload.success).toBe(true);
         expect(payload.verification.verified).toBe(true);
         expect(payload.verification.onChainMatch).toBe(true);
+        expect(payload.verification.integrity).toEqual({ status: 'match', cidResolved: true });
         expectVerificationLog('verified', 'cred-001');
     });
 
@@ -303,6 +315,7 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
 
         // Revoked on-chain!
         mockIsRevoked.mockResolvedValue(true);
+        mockFetchJsonFromIpfs.mockResolvedValue({ ok: true, content: dbMetadata });
 
         const req = new NextRequest('http://localhost:3000/api/verify/123');
         const response = await GET(req, { params: Promise.resolve({ token: '123' }) });
@@ -312,6 +325,9 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         expect(payload.success).toBe(true);
         expect(payload.verification.verified).toBe(false); // Revoked credential is not verified
         expect(payload.verification.revoked).toBe(true);
+        // Revocation is orthogonal to document integrity: the document
+        // itself hasn't been tampered with, only invalidated by the issuer.
+        expect(payload.verification.integrity).toEqual({ status: 'match', cidResolved: true });
         expectVerificationLog('revoked', 'cred-001');
     });
 
@@ -370,6 +386,10 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         });
 
         mockIsRevoked.mockResolvedValue(false);
+        // The IPFS-hosted content is the real (untampered) metadata — but the
+        // on-chain hash itself was tampered/replaced, so recomputing from the
+        // fetched document still won't match it.
+        mockFetchJsonFromIpfs.mockResolvedValue({ ok: true, content: dbMetadata });
 
         const req = new NextRequest('http://localhost:3000/api/verify/123');
         const response = await GET(req, { params: Promise.resolve({ token: '123' }) });
@@ -379,15 +399,67 @@ describe('Academic Credential E2E Integration / Lifecycle', () => {
         expect(payload.success).toBe(true);
         expect(payload.verification.verified).toBe(false); // Tampered hash means not verified
         expect(payload.verification.onChainMatch).toBe(false);
+        expect(payload.verification.integrity).toEqual({ status: 'mismatch', cidResolved: true });
         expect(payload.verification).not.toHaveProperty('checks');
         expectVerificationLog('mismatch', 'cred-001');
         expect(mockVerificationLogInsert).toHaveBeenCalledWith(
             expect.objectContaining({
                 verification_result: expect.objectContaining({
-                    mismatch_reasons: expect.arrayContaining(['hash']),
+                    mismatch_reasons: expect.arrayContaining(['hash', 'ipfs_integrity']),
+                    integrity: { status: 'mismatch', cidResolved: true },
                 }),
             }),
         );
+    });
+
+    // ── 6b. VERIFICATION INTEGRITY UNAVAILABLE ────────────────────────────────
+    it('reports integrity as unavailable when the IPFS CID cannot be resolved', async () => {
+        const dbMetadata = {
+            credentialData: {
+                studentName: 'Alice Smith',
+                credentialType: 'diploma',
+            },
+        };
+
+        const expectedHash = await generateCanonicalCredentialHash(dbMetadata);
+
+        mockVerifyRouteClient({
+            data: {
+                id: 'cred-001',
+                token_id: '123',
+                issued_at: '2026-05-31T09:00:00Z',
+                revoked: false,
+                revoked_at: null,
+                metadata: dbMetadata,
+                metadata_schema_version: CREDENTIAL_METADATA_SCHEMA_VERSION,
+                hash_algorithm: CREDENTIAL_HASH_ALGORITHM,
+                ipfs_hash: 'mocked-metadata-path',
+                student_wallet_address: 'gstudentaddress123456789012345678901234567890123456789',
+                issuer_wallet_address: 'ginstitutionaddress12345678901234567890123456789',
+            },
+            error: null,
+        });
+
+        mockGetCredential.mockResolvedValue({
+            student: 'gstudentaddress123456789012345678901234567890123456789',
+            issuer: 'ginstitutionaddress12345678901234567890123456789',
+            hash: expectedHash,
+            uri: 'ipfs://mocked-metadata-path',
+            issued_at: 1717146000,
+        });
+        mockIsRevoked.mockResolvedValue(false);
+        // Gateway timeout / CID unreachable — a transient infra problem, not
+        // evidence of tampering, so this must not be reported as 'mismatch'.
+        mockFetchJsonFromIpfs.mockResolvedValue({ ok: false, reason: 'timeout' });
+
+        const req = new NextRequest('http://localhost:3000/api/verify/123');
+        const response = await GET(req, { params: Promise.resolve({ token: '123' }) });
+        const payload = await response.json();
+
+        expect(response.status).toBe(200);
+        // The on-chain/DB-based checks are unaffected by IPFS reachability.
+        expect(payload.verification.verified).toBe(true);
+        expect(payload.verification.integrity).toEqual({ status: 'unavailable', cidResolved: false });
     });
 
     // ── 7. ROLE-BASED ROUTE ACCESS ────────────────────────────────────────────

--- a/frontend/tests/institution-route-rate-limit.test.ts
+++ b/frontend/tests/institution-route-rate-limit.test.ts
@@ -45,15 +45,6 @@ function supabaseStub() {
         then: undefined as unknown,
     };
 
-    // Credentials route uses { count: 'exact' } select and awaits the query directly.
-    const countChain = {
-        ...chain,
-        // Vitest awaits the object via its promise interface if we add then().
-        // Instead we make the chain itself thenable so `await query` works.
-        // The route destructures { data, error, count } from the resolved value.
-        [Symbol.asyncIterator]: undefined,
-    };
-
     return {
         from: (table: string) => {
             if (table === 'institutions') {

--- a/frontend/tests/ipfsServer.test.ts
+++ b/frontend/tests/ipfsServer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { validatePinataFile, validatePinataJson } from '../src/lib/ipfsServer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchJsonFromIpfs, validatePinataFile, validatePinataJson } from '../src/lib/ipfsServer';
 
 describe('IPFS server validation', () => {
     it('accepts supported file types within the size limit', () => {
@@ -30,5 +30,106 @@ describe('IPFS server validation', () => {
 
         const hugePayload = { data: 'x'.repeat(1024 * 1024) };
         expect(validatePinataJson(hugePayload)).toContain('less than 1MB');
+    });
+});
+
+describe('fetchJsonFromIpfs', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        vi.restoreAllMocks();
+    });
+
+    it('resolves the parsed JSON content when the gateway responds 200', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ hello: 'world' }),
+        }) as unknown as typeof fetch;
+
+        const result = await fetchJsonFromIpfs('ipfs://some-cid');
+
+        expect(result).toEqual({ ok: true, content: { hello: 'world' } });
+    });
+
+    it('accepts a bare CID as well as an ipfs:// URI', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ ok: true }),
+        });
+        globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+        await fetchJsonFromIpfs('some-cid/metadata.json');
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringMatching(/\/ipfs\/some-cid\/metadata\.json$/),
+            expect.anything(),
+        );
+    });
+
+    it('reports not_found for a 404 response', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 }) as unknown as typeof fetch;
+
+        await expect(fetchJsonFromIpfs('ipfs://missing-cid')).resolves.toEqual({
+            ok: false,
+            reason: 'not_found',
+        });
+    });
+
+    it('reports gateway_error for other non-2xx responses', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 502 }) as unknown as typeof fetch;
+
+        await expect(fetchJsonFromIpfs('ipfs://some-cid')).resolves.toEqual({
+            ok: false,
+            reason: 'gateway_error',
+        });
+    });
+
+    it('reports invalid_json when the response body is not parseable JSON', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => {
+                throw new SyntaxError('Unexpected token');
+            },
+        }) as unknown as typeof fetch;
+
+        await expect(fetchJsonFromIpfs('ipfs://some-cid')).resolves.toEqual({
+            ok: false,
+            reason: 'invalid_json',
+        });
+    });
+
+    it('reports network_error when fetch itself throws', async () => {
+        globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+
+        await expect(fetchJsonFromIpfs('ipfs://some-cid')).resolves.toEqual({
+            ok: false,
+            reason: 'network_error',
+        });
+    });
+
+    it('reports timeout when the request is aborted', async () => {
+        vi.useFakeTimers();
+        try {
+            globalThis.fetch = vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+                return new Promise((_resolve, reject) => {
+                    init?.signal?.addEventListener('abort', () => {
+                        const abortError = new Error('The operation was aborted');
+                        abortError.name = 'AbortError';
+                        reject(abortError);
+                    });
+                });
+            }) as unknown as typeof fetch;
+
+            const resultPromise = fetchJsonFromIpfs('ipfs://slow-cid');
+            await vi.advanceTimersByTimeAsync(8_000);
+
+            await expect(resultPromise).resolves.toEqual({ ok: false, reason: 'timeout' });
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/frontend/tests/load-endpoints.test.ts
+++ b/frontend/tests/load-endpoints.test.ts
@@ -40,6 +40,10 @@ vi.mock('../src/lib/ipfsServer', () => ({
     pinJsonToPinata: mockPinJsonToPinata,
     validatePinataFile: vi.fn(() => null),
     validatePinataJson: vi.fn(() => null),
+    fetchJsonFromIpfs: vi.fn(async () => ({
+        ok: true,
+        content: { credentialData: { studentName: 'Ada Lovelace', credentialType: 'diploma' } },
+    })),
 }));
 
 vi.mock('../src/lib/contracts', () => ({

--- a/frontend/tests/playwright/a11y.spec.ts
+++ b/frontend/tests/playwright/a11y.spec.ts
@@ -11,7 +11,7 @@ async function runAxe(page: Page) {
     const axeSource = axeModule.source ?? axeModule.default.source;
     await page.addScriptTag({ content: axeSource });
     return page.evaluate(async () => {
-        const axe = (window as Window & { axe: { run: (node: Element, options: unknown) => Promise<{ violations: Array<{ id: string; impact?: string; help: string }> }> } }).axe;
+        const axe = (window as unknown as Window & { axe: { run: (node: Element, options: unknown) => Promise<{ violations: Array<{ id: string; impact?: string; help: string }> }> } }).axe;
         return axe.run(document.documentElement, {
             runOnly: {
                 type: 'tag',

--- a/frontend/tests/playwright/core.spec.ts
+++ b/frontend/tests/playwright/core.spec.ts
@@ -57,6 +57,9 @@ test('registers, issues, verifies, and revokes a credential', async ({ page }) =
     await expect(page.getByRole('heading', { name: 'Credential Verification Report' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Credential Verified ✓' })).toBeVisible();
     await expect(page.getByText('Blockchain Verified')).toBeVisible();
+    // Distinct end-to-end CID ↔ on-chain-hash integrity signal (ACREDIA-STELLAR#163) —
+    // separate from the revoked/verified status above.
+    await expect(page.getByText('Document Integrity: Authentic')).toBeVisible();
 
     await page.goto('/dashboard');
     await page.getByRole('tab', { name: 'View issued' }).click();
@@ -68,6 +71,9 @@ test('registers, issues, verifies, and revokes a credential', async ({ page }) =
     await page.goto('/verify?token=1');
     await expect(page.getByRole('heading', { name: 'Credential Revoked' })).toBeVisible();
     await expect(page.getByText('This credential has been revoked')).toBeVisible();
+    // Revocation and document integrity are independent signals: a revoked
+    // credential's original document can still be untampered.
+    await expect(page.getByText('Document Integrity: Authentic')).toBeVisible();
 });
 
 test('authorizes an issuer from the admin dashboard', async ({ page }) => {

--- a/frontend/tests/playwright/e2e-support.ts
+++ b/frontend/tests/playwright/e2e-support.ts
@@ -193,6 +193,9 @@ export async function installE2eRoutes(page: Page) {
                     onChainFound: true,
                     issuerAuthorized: true,
                     issuerStatus: credential.revoked ? 'revoked' : 'active',
+                    // E2E mode has no real IPFS/chain to fetch from — model
+                    // the common happy path (document matches on-chain hash).
+                    integrity: { status: 'match', cidResolved: true },
                 },
             }),
         });

--- a/frontend/tests/verify-route-error-handling.test.ts
+++ b/frontend/tests/verify-route-error-handling.test.ts
@@ -49,6 +49,10 @@ vi.mock('@/lib/credentialHash', () => ({
     deriveCredentialHash: async () => 'derived-hash',
 }));
 
+vi.mock('@/lib/ipfsServer', () => ({
+    fetchJsonFromIpfs: async () => ({ ok: true, content: {} }),
+}));
+
 describe('verify route error handling and payload checks', () => {
     beforeEach(() => {
         vi.clearAllMocks();

--- a/frontend/tests/verify-route-issuer-semantic.test.ts
+++ b/frontend/tests/verify-route-issuer-semantic.test.ts
@@ -50,6 +50,10 @@ vi.mock('@/lib/credentialHash', () => ({
     deriveCredentialHash: async () => 'derived-hash',
 }));
 
+vi.mock('@/lib/ipfsServer', () => ({
+    fetchJsonFromIpfs: async () => ({ ok: true, content: {} }),
+}));
+
 describe('verify route issuer semantics', () => {
     beforeEach(() => {
         resetRateLimitStore();

--- a/frontend/tests/verify-route-rate-limit.test.ts
+++ b/frontend/tests/verify-route-rate-limit.test.ts
@@ -50,6 +50,10 @@ vi.mock('@/lib/credentialHash', () => ({
     deriveCredentialHash: async () => 'derived-hash',
 }));
 
+vi.mock('@/lib/ipfsServer', () => ({
+    fetchJsonFromIpfs: async () => ({ ok: true, content: {} }),
+}));
+
 describe('verify route rate limiting', () => {
     beforeEach(() => {
         resetRateLimitStore();


### PR DESCRIPTION
This pull request adds a new, explicit end-to-end document integrity check for verifiable credentials, verifying that the IPFS-hosted document referenced on-chain actually matches the on-chain credential hash. The result of this check is surfaced as a distinct status ("match", "mismatch", or "unavailable") in both the API and the frontend UI, providing users with clear feedback if the IPFS document has been tampered with, is unavailable, or is authentic. Additional improvements include more robust error handling for IPFS fetches and rate limiting, and some minor type and logging updates.

**Document Integrity Verification**

* Added a new `checkIntegrity` function in `route.ts` that fetches the live IPFS document referenced on-chain, recomputes its hash, and compares it to the on-chain hash, returning a clear status: `'match'`, `'mismatch'`, or `'unavailable'`. This is reported separately from the cached database check. ([frontend/src/app/api/verify/[token]/route.tsR74-R114](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R74-R114))
* The result of the integrity check is now logged in the verification audit and returned from the `/api/verify/[token]` endpoint as `verification.integrity`. ([frontend/src/app/api/verify/[token]/route.tsR128](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R128), [frontend/src/app/api/verify/[token]/route.tsR138](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R138), [frontend/src/app/api/verify/[token]/route.tsR153](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R153), [frontend/src/lib/verificationAudit.tsR37-R47](diffhunk://#diff-f5971c1cd761c353378d4947471877d45d4560884d8a706d72cc0f3214fadd77R37-R47), [frontend/src/app/api/verify/[token]/route.tsR291-R315](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R291-R315), [frontend/src/app/api/verify/[token]/route.tsR353-R357](diffhunk://#diff-fded9dafd4039ac77f8a3b353c353fb97895732eae82f61a6dba6131ea6f4393R353-R357))

**Frontend UI Updates**

* Introduced the `IntegrityStateCard` component to display the document integrity status to users, with clear messaging for each possible state, and integrated it into the `/verify` page. [[1]](diffhunk://#diff-96ac6e35e785b244e37ab20b8eb3b8cf0b5bdfa5d4f4a157d55b64ff418aba8cR1-R65) [[2]](diffhunk://#diff-9c0da1a4163c4f7b07fb721a189e40471cc07a2cd932a220e6542a2e973806c0R31) [[3]](diffhunk://#diff-9c0da1a4163c4f7b07fb721a189e40471cc07a2cd932a220e6542a2e973806c0R45) [[4]](diffhunk://#diff-9c0da1a4163c4f7b07fb721a189e40471cc07a2cd932a220e6542a2e973806c0R468-R475)
* Updated the `useCredentialVerification` hook to track and expose the integrity status, ensuring the UI reflects the latest check results. [[1]](diffhunk://#diff-b9c03fa8780a470dfeafcaddf9ea8ad2e75986430753259ce254807878495decR38-R39) [[2]](diffhunk://#diff-b9c03fa8780a470dfeafcaddf9ea8ad2e75986430753259ce254807878495decR58) [[3]](diffhunk://#diff-b9c03fa8780a470dfeafcaddf9ea8ad2e75986430753259ce254807878495decR128-R132) [[4]](diffhunk://#diff-b9c03fa8780a470dfeafcaddf9ea8ad2e75986430753259ce254807878495decR245)

**IPFS Fetching and Error Handling**

* Added a robust `fetchJsonFromIpfs` utility that fetches and parses JSON documents from IPFS, with timeout and error handling, ensuring that network or gateway issues result in a clear `'unavailable'` state rather than a server error. [[1]](diffhunk://#diff-07551274a0c5cb8368529a0c3eedd82e1c7afa393dca267db473338feb410a39L1-R8) [[2]](diffhunk://#diff-07551274a0c5cb8368529a0c3eedd82e1c7afa393dca267db473338feb410a39R160-R206)

**Rate Limiting and Logging**

* Improved error logging in the rate limiting logic to use `captureException` for better observability and fallback handling. [[1]](diffhunk://#diff-92d3c9a03e79c8b085aac4219e1a053ab5bc6b48e5b67c230b05c3a3b408f683R2) [[2]](diffhunk://#diff-92d3c9a03e79c8b085aac4219e1a053ab5bc6b48e5b67c230b05c3a3b408f683L139-R140) [[3]](diffhunk://#diff-92d3c9a03e79c8b085aac4219e1a053ab5bc6b48e5b67c230b05c3a3b408f683L183-R184)

**Type and Minor Code Updates**

* Updated types for job queue payloads to ensure they are always records, improving type safety. [[1]](diffhunk://#diff-2054a384760f553c200bb82b25b2f24df284cfc18e02d487bb1e584b3a071207L7-R7) [[2]](diffhunk://#diff-2054a384760f553c200bb82b25b2f24df284cfc18e02d487bb1e584b3a071207L30-R30)
* Clarified documentation in `VERIFIABLE_CREDENTIALS.md` to explain the distinction between database and live IPFS integrity checks.

close #163 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added document integrity verification by checking the live IPFS document against its on-chain hash.
  - Verification results now report integrity as **match**, **mismatch**, or **unavailable**.
  - Added a dedicated Document Integrity status display, separate from credential validity or revocation status.

- **Documentation**
  - Updated verification guidance to explain live IPFS integrity checks and cached metadata comparisons.

- **Bug Fixes**
  - Improved handling and reporting of IPFS gateway failures and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->