### PR TITLE
Enhance admin dashboard with new panels and improved UX

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ graph TD
 
 ## 2. Layers
 
-1. **Presentation** — role-aware dashboards (student / institution / admin) and a public verify page. Design system built on Tailwind v4 tokens + Radix primitives.
+1. **Presentation** — one role-aware console (`ConsoleShell` + `src/lib/consoleNav.ts`) serving students, institutions, and admins, plus a public verify page. Design system built on Tailwind v4 tokens + Radix primitives. Admins have a single console at `/admin`; `/dashboard` redirects them there — see [decisions/0001](decisions/0001-single-admin-console.md).
 2. **Application** — Next.js API routes handle privileged work server-side: student/institution provisioning, wallet linking, admin stats, IPFS pinning, and verification logging. Server-only secrets never reach the client bundle.
 3. **Blockchain** — the `AcrediaCredential` Soroban contract is the authoritative record. It gates issuance behind owner-approved issuer authorization and keeps credentials persistent via explicit TTL extension.
 4. **Storage** — documents/metadata are content-addressed on IPFS; only a hash + IPFS URI are anchored on-chain.

--- a/docs/decisions/0001-single-admin-console.md
+++ b/docs/decisions/0001-single-admin-console.md
@@ -1,0 +1,80 @@
+# 0001 — One admin console, at `/admin`
+
+**Status:** Accepted
+**Date:** 2026-08-28
+**Issues:** [#224](https://github.com/soumen0818/ACREDIA-STELLAR/issues/224) (shared console shell), [#225](https://github.com/soumen0818/ACREDIA-STELLAR/issues/225) (admin landing screen)
+
+## Context
+
+`/dashboard` used to render a third, admin-specific screen: a "Welcome, Admin"
+heading, an Account card mixing identity, account actions, and wallet status,
+and two link cards pointing at `/admin` and `/admin/institutions` — followed by
+roughly half a viewport of nothing.
+
+That screen had no job. It was not a working dashboard (it showed no data) and
+not a redirect either, so it read as a dead-end menu that duplicated `/admin`
+without its content. `/auth/admin-login` already sends admins straight to
+`/admin`, so it was only reachable by clicking the logo or typing the URL.
+
+Issue #225 offered two directions:
+
+- **Option A** — grow `/dashboard` into a real admin overview: sidebar shell,
+  live stats, pending institutions, verification activity, worker health.
+- **Option B** — redirect `/dashboard` → `/admin`, so there is exactly one
+  admin console.
+
+## Decision
+
+**Option B.** `/dashboard` redirects admins to `/admin`, and `/admin` is the
+admin landing screen.
+
+Option A was rejected because everything it asks for — the sidebar shell, live
+statistics, and links into the rest of the console — already exists at `/admin`.
+Building it a second time at `/dashboard` would leave one role with two consoles
+that have to be kept in sync, which is the opposite of what #224 set out to fix.
+
+Consequences of choosing B:
+
+- `/dashboard` and `/dashboard/settings` redirect admins to `/admin` and
+  `/admin/settings`. The settings redirect preserves the query string, because
+  the notification-unsubscribe route sends every role to `/dashboard/settings`.
+- The "welcome" surface is gone. Nothing was lost with it: it carried no data.
+- **The acceptance criteria of #225 move to `/admin`.** #225 lists changes to
+  `/admin` as out of scope, but that was written assuming the landing screen
+  would stay at `/dashboard`. Under Option B, `/admin` *is* the landing screen,
+  so it is the only place the criteria can be satisfied.
+
+## What that meant for `/admin`
+
+- **Blocking states own the whole content area.** No wallet connected, still
+  checking ownership, and connected-but-not-the-owner each render a single
+  centred gate instead of a small card stranded above an empty page. The
+  disconnected state went from filling 51% of a 1080p viewport to 96%.
+- **Wallet-disconnected is loud, connected is quiet.** The gate is
+  warning-toned with the connect action inside it. When a wallet is connected
+  it disappears entirely; the address becomes a quiet control in the sidebar.
+- **Identity, wallet state, and actions are separated** into three bands in the
+  sidebar footer — "Signed in as <email>", then the wallet control, then sign
+  out. The page no longer carries an Account card.
+- **The landing screen leads with what needs attention:** institutions awaiting
+  review, counted from the institution `status` column via the existing
+  `/api/admin/institutions` route. Deliberately *not* from the overview's
+  `authorizedInstitutions` stat, which counts "has a wallet or has issued
+  something" rather than "approved by an admin", and would make the claim
+  untrue.
+- **Verification outcomes and indexer position are shown.** Both already rode
+  along in the `/api/admin/stats` payload and were being fetched and discarded.
+  No new endpoint, no new capability.
+- **The subtitle was dropped.** The sidebar entry already reads
+  "Overview — System statistics"; an `<h1>Overview</h1>` plus a
+  "System statistics and contract status" subtitle stated the same fact three
+  times in one viewport.
+
+## Alternatives considered
+
+**Unlock statistics without a wallet.** `/api/admin/stats` is authenticated by
+bearer token and admin role — it never needed a wallet, so gating it on
+`isOwner` is a client-side choice. Removing that gate would fill the
+disconnected screen with real content. Rejected: the read-only notice states
+that behaviour deliberately, and changing it is a product decision, not a
+layout one.

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -15,6 +15,9 @@ import {
 import { toast } from 'sonner';
 import { ConsoleShell } from '@/components/console/ConsoleShell';
 import { ConnectWalletNotice } from '@/components/admin/ConnectWalletNotice';
+import { PendingInstitutionsPanel } from '@/components/admin/PendingInstitutionsPanel';
+import { AdminGate } from '@/components/admin/AdminGate';
+import { IndexerHealth, VerificationOutcomes } from '@/components/admin/AdminOverviewPanels';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -23,7 +26,7 @@ import { adminFetch } from '@/lib/adminApi';
 import { runtimeConfig } from '@/lib/runtimeConfig';
 import { useContractOwner } from '@/hooks/useContractOwner';
 import { CONSOLE_NAV } from '@/lib/consoleNav';
-import { ProtectedRoute, useAuth } from '@/contexts/AuthContext';
+import { ProtectedRoute } from '@/contexts/AuthContext';
 
 interface AdminStats {
     totalInstitutions: number;
@@ -34,6 +37,12 @@ interface AdminStats {
     verificationActivity: {
         totalAttempts: number;
         attemptsLast24h: number;
+        // Already returned by /api/admin/stats; the overview used to discard it.
+        resultCounts?: Record<string, number>;
+    };
+    indexer?: {
+        lastLedger: number | null;
+        lastUpdated: string | null;
     };
 }
 
@@ -46,7 +55,9 @@ const EMPTY_STATS: AdminStats = {
     verificationActivity: {
         totalAttempts: 0,
         attemptsLast24h: 0,
+        resultCounts: {},
     },
+    indexer: { lastLedger: null, lastUpdated: null },
 };
 
 const REFRESH_INTERVAL_MS = 30_000;
@@ -90,12 +101,14 @@ function StatCard({
 }
 
 function AdminDashboardContent() {
-    const { user } = useAuth();
     const { address, isOwner, isChecking, contractOwner } = useContractOwner();
 
     const [stats, setStats] = useState<AdminStats>(EMPTY_STATS);
     const [loadingStats, setLoadingStats] = useState(true);
     const [refreshing, setRefreshing] = useState(false);
+    // Bumped by the Refresh button so the attention panel reloads alongside the
+    // statistics. The 30s background poll leaves it alone.
+    const [refreshToken, setRefreshToken] = useState(0);
 
     const fetchStats = useCallback(async (silent = false) => {
         try {
@@ -131,19 +144,26 @@ function AdminDashboardContent() {
         return () => clearInterval(interval);
     }, [isOwner, fetchStats]);
 
+    const handleRefresh = useCallback(() => {
+        fetchStats(true);
+        setRefreshToken((value) => value + 1);
+    }, [fetchStats]);
+
     const revokedCredentials = Math.max(stats.totalCredentials - stats.activeCredentials, 0);
 
     return (
         <ConsoleShell
             nav={CONSOLE_NAV.admin}
+            // No subtitle: the sidebar entry already reads "Overview — System
+            // statistics", so a subtitle here would state the same fact a third
+            // time in one viewport (ACREDIA-STELLAR#225).
             title="Overview"
-            subtitle="System statistics and contract status"
             actions={
                 isOwner ? (
                     <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => fetchStats(true)}
+                        onClick={handleRefresh}
                         disabled={refreshing || loadingStats}
                     >
                         <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
@@ -152,162 +172,143 @@ function AdminDashboardContent() {
                 ) : undefined
             }
         >
+            {/* The three blocking states each own the whole content area, so
+                none of them leaves a small card stranded above an empty page. */}
             {!address ? (
                 <ConnectWalletNotice message="Connect the contract owner wallet to load system statistics and manage issuer authorizations." />
+            ) : isChecking ? (
+                <div className="flex min-h-[calc(100vh-16rem)] items-center justify-center lg:min-h-[calc(100vh-12rem)]">
+                    <Card className="w-full max-w-xl p-8 text-center">
+                        <Skeleton className="mx-auto h-5 w-56" />
+                        <Skeleton className="mx-auto mt-4 h-4 w-full max-w-md" />
+                    </Card>
+                </div>
+            ) : !isOwner ? (
+                <AdminGate
+                    icon={ShieldAlert}
+                    title="Read-only mode — not the contract owner"
+                    message="Statistics stay hidden and issuer authorization is disabled until you connect the wallet that deployed the contract."
+                >
+                    <dl className="space-y-3 rounded-xl border border-border bg-card p-4 text-left">
+                        <div>
+                            <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Connected
+                            </dt>
+                            <dd className="mt-1 break-all font-mono text-xs text-foreground">
+                                {address}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Contract owner
+                            </dt>
+                            <dd className="mt-1 break-all font-mono text-xs text-foreground">
+                                {contractOwner || 'Could not fetch'}
+                            </dd>
+                        </div>
+                    </dl>
+                </AdminGate>
             ) : (
                 <div className="space-y-6">
-                    {isChecking ? (
-                        <Card className="p-6">
-                            <Skeleton className="h-5 w-56" />
-                            <Skeleton className="mt-4 h-4 w-full max-w-md" />
-                        </Card>
-                    ) : !isOwner ? (
-                        <Card className="border-warning/25 bg-warning/8 p-6">
-                            <div className="flex items-start gap-3">
-                                <ShieldAlert className="mt-0.5 h-6 w-6 shrink-0 text-warning" />
-                                <div className="min-w-0">
-                                    <h3 className="text-sm font-bold text-foreground">
-                                        Read-only mode — not the contract owner
-                                    </h3>
-                                    <p className="mt-1.5 text-sm text-muted-foreground">
-                                        Statistics stay hidden and issuer authorization is disabled
-                                        until you connect the wallet that deployed the contract.
-                                    </p>
-                                    <p className="mt-3 text-xs text-muted-foreground">
-                                        Connected:{' '}
-                                        <span className="break-all font-mono text-foreground">
-                                            {address}
-                                        </span>
-                                    </p>
-                                    <p className="mt-1 text-xs text-muted-foreground">
-                                        Contract owner:{' '}
-                                        <span className="break-all font-mono text-foreground">
-                                            {contractOwner || 'Could not fetch'}
-                                        </span>
-                                    </p>
-                                </div>
-                            </div>
-                        </Card>
-                    ) : null}
+                    {/* The landing screen leads with what needs doing, not with
+                        who is signed in. */}
+                    <PendingInstitutionsPanel refreshToken={refreshToken} />
 
-                    <Card className="p-6">
-                        <div className="flex items-start gap-3">
-                            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-success/12 text-success">
-                                <CheckCircle2 className="h-5 w-5" />
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                        <StatCard
+                            icon={Users}
+                            iconClassName="bg-primary/10 text-primary"
+                            label="Total institutions"
+                            value={stats.totalInstitutions}
+                            caption="Registered institutions"
+                            loading={loadingStats}
+                        />
+                        <StatCard
+                            icon={CheckCircle2}
+                            iconClassName="bg-success/12 text-success"
+                            label="Authorized"
+                            value={stats.authorizedInstitutions}
+                            caption="Authorized to issue"
+                            loading={loadingStats}
+                        />
+                        <StatCard
+                            icon={Shield}
+                            iconClassName="bg-primary/10 text-primary"
+                            label="Total credentials"
+                            value={stats.totalCredentials}
+                            caption={`${stats.activeCredentials} active, ${revokedCredentials} revoked`}
+                            loading={loadingStats}
+                        />
+                        <StatCard
+                            icon={Activity}
+                            iconClassName="bg-gold/12 text-gold"
+                            label="Verification checks"
+                            value={stats.verificationActivity.totalAttempts}
+                            caption={`${stats.verificationActivity.attemptsLast24h} in last 24h`}
+                            loading={loadingStats}
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        <Link
+                            href="/admin/institutions"
+                            className="group rounded-xl border border-border bg-card p-6 transition-all hover:border-primary/30 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                        >
+                            <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary transition-transform group-hover:scale-105">
+                                <Building2 className="h-5 w-5" />
                             </span>
-                            <div className="min-w-0 flex-1">
-                                <h3 className="text-base font-semibold text-foreground">
-                                    {isOwner ? 'Contract owner' : 'Signed in as admin'}
-                                </h3>
-                                <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
-                                    <div className="min-w-0">
-                                        <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                            Email
-                                        </dt>
-                                        <dd className="mt-1 truncate text-sm text-foreground">
-                                            {user?.email}
-                                        </dd>
-                                    </div>
-                                    <div className="min-w-0">
-                                        <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                            Wallet address
-                                        </dt>
-                                        <dd className="mt-1 break-all font-mono text-xs text-foreground">
-                                            {address}
-                                        </dd>
-                                    </div>
-                                    <div className="min-w-0">
-                                        <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                            Contract address
-                                        </dt>
-                                        <dd className="mt-1 break-all font-mono text-xs text-foreground">
-                                            {runtimeConfig.contracts.CREDENTIAL_NFT}
-                                        </dd>
-                                    </div>
-                                </dl>
-                            </div>
+                            <h3 className="mt-4 font-semibold text-foreground">Institutions</h3>
+                            <p className="mt-1 text-sm text-muted-foreground">
+                                Browse every registered institution and inspect the credentials it
+                                has issued.
+                            </p>
+                            <span className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-primary">
+                                View institutions
+                                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                            </span>
+                        </Link>
+
+                        <Link
+                            href="/admin/authorize"
+                            className="group rounded-xl border border-border bg-card p-6 transition-all hover:border-primary/30 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                        >
+                            <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-gold/12 text-gold transition-transform group-hover:scale-105">
+                                <Shield className="h-5 w-5" />
+                            </span>
+                            <h3 className="mt-4 font-semibold text-foreground">Authorize issuer</h3>
+                            <p className="mt-1 text-sm text-muted-foreground">
+                                Grant a wallet permission to issue credentials on-chain.
+                            </p>
+                            <span className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-primary">
+                                Open authorization
+                                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                            </span>
+                        </Link>
+                    </div>
+
+                    {/* Verification outcomes and indexer position ride along in
+                        the same /api/admin/stats payload the numbers above come
+                        from — no extra request. */}
+                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                        <VerificationOutcomes
+                            counts={stats.verificationActivity.resultCounts}
+                            loading={loadingStats}
+                        />
+                        <IndexerHealth indexer={stats.indexer} loading={loadingStats} />
+                    </div>
+
+                    {/* Deployment metadata: useful, but never the loudest thing
+                        on the page. */}
+                    <div className="rounded-xl border border-border bg-card px-5 py-4">
+                        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Credential contract
+                            </span>
+                            <span className="break-all font-mono text-xs text-foreground">
+                                {runtimeConfig.contracts.CREDENTIAL_NFT}
+                            </span>
                         </div>
-                    </Card>
-
-                    {isOwner && (
-                        <>
-                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                                <StatCard
-                                    icon={Users}
-                                    iconClassName="bg-primary/10 text-primary"
-                                    label="Total institutions"
-                                    value={stats.totalInstitutions}
-                                    caption="Registered institutions"
-                                    loading={loadingStats}
-                                />
-                                <StatCard
-                                    icon={CheckCircle2}
-                                    iconClassName="bg-success/12 text-success"
-                                    label="Authorized"
-                                    value={stats.authorizedInstitutions}
-                                    caption="Authorized to issue"
-                                    loading={loadingStats}
-                                />
-                                <StatCard
-                                    icon={Shield}
-                                    iconClassName="bg-primary/10 text-primary"
-                                    label="Total credentials"
-                                    value={stats.totalCredentials}
-                                    caption={`${stats.activeCredentials} active, ${revokedCredentials} revoked`}
-                                    loading={loadingStats}
-                                />
-                                <StatCard
-                                    icon={Activity}
-                                    iconClassName="bg-gold/12 text-gold"
-                                    label="Verification checks"
-                                    value={stats.verificationActivity.totalAttempts}
-                                    caption={`${stats.verificationActivity.attemptsLast24h} in last 24h`}
-                                    loading={loadingStats}
-                                />
-                            </div>
-
-                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                                <Link
-                                    href="/admin/institutions"
-                                    className="group rounded-xl border border-border bg-card p-6 transition-all hover:border-primary/30 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                                >
-                                    <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary transition-transform group-hover:scale-105">
-                                        <Building2 className="h-5 w-5" />
-                                    </span>
-                                    <h3 className="mt-4 font-semibold text-foreground">
-                                        Institutions
-                                    </h3>
-                                    <p className="mt-1 text-sm text-muted-foreground">
-                                        Browse every registered institution and inspect the
-                                        credentials it has issued.
-                                    </p>
-                                    <span className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-primary">
-                                        View institutions
-                                        <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                                    </span>
-                                </Link>
-
-                                <Link
-                                    href="/admin/authorize"
-                                    className="group rounded-xl border border-border bg-card p-6 transition-all hover:border-primary/30 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                                >
-                                    <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-gold/12 text-gold transition-transform group-hover:scale-105">
-                                        <Shield className="h-5 w-5" />
-                                    </span>
-                                    <h3 className="mt-4 font-semibold text-foreground">
-                                        Authorize issuer
-                                    </h3>
-                                    <p className="mt-1 text-sm text-muted-foreground">
-                                        Grant a wallet permission to issue credentials on-chain.
-                                    </p>
-                                    <span className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-primary">
-                                        Open authorization
-                                        <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                                    </span>
-                                </Link>
-                            </div>
-                        </>
-                    )}
+                    </div>
                 </div>
             )}
         </ConsoleShell>

--- a/frontend/src/components/admin/AdminGate.tsx
+++ b/frontend/src/components/admin/AdminGate.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Card } from '@/components/ui/card';
+
+/**
+ * A blocking state of the admin console — no wallet connected, or the wrong
+ * wallet connected.
+ *
+ * These states leave nothing for the admin to do but fix them, so the gate is
+ * the only thing on the page and is centred in the content area rather than
+ * left as a small card above half a viewport of nothing
+ * (ACREDIA-STELLAR#225).
+ */
+export function AdminGate({
+    icon: Icon,
+    title,
+    message,
+    children,
+}: {
+    icon: LucideIcon;
+    title: string;
+    message: string;
+    /** The action or detail block shown under the message. */
+    children?: ReactNode;
+}) {
+    return (
+        <div className="flex min-h-[calc(100vh-16rem)] items-center justify-center lg:min-h-[calc(100vh-12rem)]">
+            <Card className="w-full max-w-xl border-warning/30 bg-warning/8 p-8 text-center sm:p-10">
+                <span className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-warning/15 text-warning">
+                    <Icon className="h-8 w-8" />
+                </span>
+                <h2 className="mt-6 text-xl font-bold tracking-tight text-foreground">{title}</h2>
+                {/* Held to a readable measure rather than the full card width. */}
+                <p className="mx-auto mt-2.5 max-w-prose text-sm leading-6 text-muted-foreground">
+                    {message}
+                </p>
+                {children && <div className="mt-7">{children}</div>}
+            </Card>
+        </div>
+    );
+}

--- a/frontend/src/components/admin/AdminOverviewPanels.tsx
+++ b/frontend/src/components/admin/AdminOverviewPanels.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { formatDistanceToNow } from 'date-fns';
+import { Activity, Database } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/** Human labels for the verification outcomes recorded in `verification_logs`. */
+const RESULT_LABELS: Record<string, string> = {
+    verified: 'Verified',
+    revoked: 'Revoked',
+    not_found: 'Not found',
+    mismatch: 'Hash mismatch',
+    chain_unavailable: 'Chain unavailable',
+    invalid_request: 'Invalid request',
+    server_error: 'Server error',
+};
+
+// Ordered so the two expected outcomes lead and the failure modes follow.
+const RESULT_ORDER = [
+    'verified',
+    'revoked',
+    'not_found',
+    'mismatch',
+    'chain_unavailable',
+    'invalid_request',
+    'server_error',
+];
+
+/**
+ * Breakdown of how public verification attempts resolved.
+ *
+ * The counts already ride along in `/api/admin/stats`; the overview used to
+ * fetch and discard them (ACREDIA-STELLAR#225).
+ */
+export function VerificationOutcomes({
+    counts,
+    loading,
+}: {
+    counts: Record<string, number> | undefined;
+    loading: boolean;
+}) {
+    const entries = RESULT_ORDER.filter((key) => key in (counts ?? {})).map(
+        (key) => [key, counts?.[key] ?? 0] as const,
+    );
+
+    return (
+        <Card className="p-5">
+            <div className="flex items-center gap-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gold/12 text-gold">
+                    <Activity className="h-5 w-5" />
+                </span>
+                <h2 className="text-sm font-semibold text-muted-foreground">
+                    Verification outcomes
+                </h2>
+            </div>
+
+            {loading ? (
+                <Skeleton className="mt-5 h-24 w-full" />
+            ) : entries.length === 0 ? (
+                <p className="mt-5 text-sm text-muted-foreground">No verification attempts yet.</p>
+            ) : (
+                <dl className="mt-5 grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
+                    {entries.map(([key, value]) => (
+                        <div key={key} className="min-w-0">
+                            <dt className="truncate text-xs text-muted-foreground">
+                                {RESULT_LABELS[key] ?? key}
+                            </dt>
+                            <dd className="mt-0.5 text-lg font-bold tabular-nums text-foreground">
+                                {value}
+                            </dd>
+                        </div>
+                    ))}
+                </dl>
+            )}
+        </Card>
+    );
+}
+
+function formatSyncedAt(lastUpdated: string | null): string {
+    if (!lastUpdated) return 'Not yet synced';
+    const date = new Date(lastUpdated);
+    if (Number.isNaN(date.getTime())) return 'Unknown';
+    return `Synced ${formatDistanceToNow(date, { addSuffix: true })}`;
+}
+
+/**
+ * Ledger position of the background indexer.
+ *
+ * Reported as-is with no staleness threshold — deciding what counts as "behind"
+ * is a product call this screen is not the place to make.
+ */
+export function IndexerHealth({
+    indexer,
+    loading,
+}: {
+    indexer: { lastLedger: number | null; lastUpdated: string | null } | undefined;
+    loading: boolean;
+}) {
+    return (
+        <Card className="p-5">
+            <div className="flex items-center gap-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                    <Database className="h-5 w-5" />
+                </span>
+                <h2 className="text-sm font-semibold text-muted-foreground">Indexer</h2>
+            </div>
+
+            {loading ? (
+                <Skeleton className="mt-5 h-12 w-40" />
+            ) : (
+                <>
+                    <p className="mt-5 text-2xl font-bold tabular-nums text-foreground">
+                        {indexer?.lastLedger != null
+                            ? `Ledger ${indexer.lastLedger.toLocaleString()}`
+                            : 'No ledger recorded'}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                        {formatSyncedAt(indexer?.lastUpdated ?? null)}
+                    </p>
+                </>
+            )}
+        </Card>
+    );
+}

--- a/frontend/src/components/admin/ConnectWalletNotice.tsx
+++ b/frontend/src/components/admin/ConnectWalletNotice.tsx
@@ -1,26 +1,20 @@
 'use client';
 
 import { Wallet } from 'lucide-react';
+import { AdminGate } from '@/components/admin/AdminGate';
 import { ConnectWallet } from '@/components/ui/ConnectWallet';
-import { Card } from '@/components/ui/card';
 
 /**
- * Shown inside the admin content area when no wallet is connected.
- *
- * Rendered within the shell rather than as a full-screen block, so the sidebar
- * stays available and the admin is not stranded on a dead end.
+ * The wallet gate for admin pages whose work cannot start without a connected
+ * wallet. The sidebar keeps its own Connect Wallet control, so the action stays
+ * reachable from either place.
  */
 export function ConnectWalletNotice({ message }: { message: string }) {
     return (
-        <Card className="p-8 text-center sm:p-10">
-            <span className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                <Wallet className="h-7 w-7" />
-            </span>
-            <h2 className="mt-5 text-lg font-bold text-foreground">Connect your wallet</h2>
-            <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">{message}</p>
-            <div className="mt-6 flex justify-center">
+        <AdminGate icon={Wallet} title="Wallet connection required" message={message}>
+            <div className="flex justify-center">
                 <ConnectWallet />
             </div>
-        </Card>
+        </AdminGate>
     );
 }

--- a/frontend/src/components/admin/PendingInstitutionsPanel.tsx
+++ b/frontend/src/components/admin/PendingInstitutionsPanel.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowRight, CheckCircle2, Clock } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { adminFetch, type AdminInstitutionSummary } from '@/lib/adminApi';
+import { captureException } from '@/lib/debug';
+
+/**
+ * Answers "what needs my attention?" on the admin landing screen
+ * (ACREDIA-STELLAR#225).
+ *
+ * The count comes from the institution `status` column via the existing admin
+ * institutions route — deliberately *not* from the overview's
+ * `authorizedInstitutions` stat, which counts "has a wallet or has issued"
+ * rather than "approved by an admin" and would make this claim untrue.
+ */
+export function PendingInstitutionsPanel({ refreshToken }: { refreshToken?: number }) {
+    const [pending, setPending] = useState<number | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [failed, setFailed] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const load = async () => {
+            try {
+                const data = await adminFetch<{ institutions: AdminInstitutionSummary[] }>(
+                    '/api/admin/institutions',
+                );
+                if (cancelled) return;
+                setPending(
+                    (data.institutions ?? []).filter((item) => item.status === 'pending').length,
+                );
+                setFailed(false);
+            } catch (error) {
+                if (cancelled) return;
+                // The overview already surfaces a toast when stats fail; this
+                // panel stays silent and simply hides itself.
+                captureException(error, { context: 'pendingInstitutionsPanel' });
+                setFailed(true);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+
+        load();
+        return () => {
+            cancelled = true;
+        };
+    }, [refreshToken]);
+
+    if (loading) {
+        return (
+            <Card className="p-5">
+                <Skeleton className="h-5 w-64" />
+            </Card>
+        );
+    }
+
+    if (failed || pending === null) {
+        return null;
+    }
+
+    if (pending === 0) {
+        return (
+            <Card className="flex items-center gap-3 p-5">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-success/12 text-success">
+                    <CheckCircle2 className="h-5 w-5" />
+                </span>
+                <p className="text-sm text-muted-foreground">
+                    Nothing needs your attention — no institutions are awaiting review.
+                </p>
+            </Card>
+        );
+    }
+
+    return (
+        <Card className="border-warning/30 bg-warning/8 p-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-start gap-3">
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-warning/15 text-warning">
+                        <Clock className="h-5 w-5" />
+                    </span>
+                    <div className="min-w-0">
+                        <h2 className="text-sm font-bold text-foreground">
+                            {pending} {pending === 1 ? 'institution is' : 'institutions are'}{' '}
+                            awaiting review
+                        </h2>
+                        <p className="mt-1 max-w-prose text-sm text-muted-foreground">
+                            They cannot issue credentials until an admin approves them and
+                            authorizes their wallet on-chain.
+                        </p>
+                    </div>
+                </div>
+                <Link
+                    href="/admin/institutions"
+                    className="inline-flex shrink-0 items-center gap-1 text-sm font-semibold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 sm:ml-auto"
+                >
+                    Review institutions
+                    <ArrowRight className="h-4 w-4" />
+                </Link>
+            </div>
+        </Card>
+    );
+}

--- a/frontend/src/components/console/ConsoleShell.tsx
+++ b/frontend/src/components/console/ConsoleShell.tsx
@@ -50,6 +50,8 @@ function SidebarContent({
     onSignOut: () => void;
 }) {
     const pathname = usePathname();
+    const { user } = useAuth();
+    const email = user?.email;
 
     return (
         <div className="flex h-full flex-col">
@@ -107,32 +109,51 @@ function SidebarContent({
                 })}
             </nav>
 
-            <div className="shrink-0 space-y-3 border-t border-border p-3">
-                {activeNetwork.kind === 'testnet' && (
-                    <div className="flex items-center gap-2 rounded-lg bg-amber-500/10 px-3 py-2">
-                        <span className="relative flex h-2 w-2 shrink-0">
-                            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-500/60" />
-                            <span className="relative inline-flex h-2 w-2 rounded-full bg-amber-500" />
-                        </span>
-                        <span className="text-[11px] font-bold uppercase tracking-wider text-amber-800">
-                            Stellar Testnet
-                        </span>
+            {/* Account identity, wallet state, and account actions each get
+                their own band so they never read as one undifferentiated blob
+                (ACREDIA-STELLAR#225). */}
+            <div className="shrink-0 border-t border-border">
+                {email && (
+                    <div className="px-3 py-2.5">
+                        <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                            Signed in as
+                        </p>
+                        <p
+                            className="mt-0.5 truncate text-sm font-medium text-foreground"
+                            title={email}
+                        >
+                            {email}
+                        </p>
                     </div>
                 )}
 
-                <div className="[&>*]:w-full">
-                    <ConnectWallet />
-                </div>
+                <div className="space-y-3 border-t border-border p-3">
+                    {activeNetwork.kind === 'testnet' && (
+                        <div className="flex items-center gap-2 rounded-lg bg-amber-500/10 px-3 py-2">
+                            <span className="relative flex h-2 w-2 shrink-0">
+                                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-500/60" />
+                                <span className="relative inline-flex h-2 w-2 rounded-full bg-amber-500" />
+                            </span>
+                            <span className="text-[11px] font-bold uppercase tracking-wider text-amber-800">
+                                Stellar Testnet
+                            </span>
+                        </div>
+                    )}
 
-                <Button
-                    onClick={onSignOut}
-                    variant="ghost"
-                    size="sm"
-                    className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
-                >
-                    <LogOut className="h-4 w-4" />
-                    Sign out
-                </Button>
+                    <div className="[&>*]:w-full">
+                        <ConnectWallet />
+                    </div>
+
+                    <Button
+                        onClick={onSignOut}
+                        variant="ghost"
+                        size="sm"
+                        className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    >
+                        <LogOut className="h-4 w-4" />
+                        Sign out
+                    </Button>
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/lib/e2e.ts
+++ b/frontend/src/lib/e2e.ts
@@ -46,6 +46,19 @@ export interface E2eAdminStats {
     };
 }
 
+export interface E2eAdminInstitution {
+    id: string;
+    name: string;
+    email: string;
+    walletAddress: string | null;
+    verified: boolean;
+    status: string;
+    authorizationTxHash: string | null;
+    createdAt: string | null;
+    credentialCount: number;
+    activeCredentialCount: number;
+}
+
 export interface E2eState {
     enabled?: boolean;
     session?: E2eSession | null;
@@ -59,6 +72,8 @@ export interface E2eState {
         walletAddress: string;
     };
     stats?: E2eAdminStats;
+    /** Rows served by the admin institutions route. */
+    adminInstitutions?: E2eAdminInstitution[];
     nextTokenId?: number;
     issuedCredentials?: E2eIssuedCredential[];
 }

--- a/frontend/tests/playwright/a11y.spec.ts
+++ b/frontend/tests/playwright/a11y.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
-import { createE2eState, installE2eRoutes, seedE2eState } from './e2e-support';
+import { applyE2eState, createE2eState, installE2eRoutes, seedE2eState } from './e2e-support';
 
 async function runAxe(page: Page) {
     // The app can still be settling (hydration / client-side redirect) right
@@ -109,10 +109,23 @@ test('core pages pass WCAG 2.1 AA accessibility audit', async ({ page }) => {
         },
     });
 
-    await seedE2eState(page, adminState);
-    await installE2eRoutes(page);
+    // Switching roles mid-test has to overwrite the stored state — re-seeding
+    // would be ignored and this audit would silently re-check /dashboard.
+    await applyE2eState(page, adminState);
 
     await page.goto('/admin');
+    // Guards the role switch above: as an institution this page would redirect
+    // to /dashboard and the audit below would pass without ever seeing /admin.
+    await expect(page.getByRole('navigation', { name: 'Admin navigation' })).toBeVisible();
     results = await runAxe(page);
     expect(results.violations, `Admin page violations: ${JSON.stringify(results.violations, null, 2)}`).toEqual([]);
+
+    // The wallet gate is a distinct visual treatment (warning-toned, centred),
+    // so it gets audited in its own right (ACREDIA-STELLAR#225).
+    await applyE2eState(page, { ...adminState, walletAddress: null });
+
+    await page.goto('/admin');
+    await expect(page.getByRole('heading', { name: 'Wallet connection required' })).toBeVisible();
+    results = await runAxe(page);
+    expect(results.violations, `Admin wallet gate violations: ${JSON.stringify(results.violations, null, 2)}`).toEqual([]);
 });

--- a/frontend/tests/playwright/core.spec.ts
+++ b/frontend/tests/playwright/core.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from '@playwright/test';
-import { createE2eState, installE2eRoutes, seedE2eState } from './e2e-support';
+import {
+    applyE2eState,
+    createAdminInstitution,
+    createE2eState,
+    installE2eRoutes,
+    seedE2eState,
+} from './e2e-support';
 
 const issuerWallet = 'GAcrediaIssuerWallet0000000000000000000000000000001';
 const adminWallet = 'GAcrediaAdminWallet00000000000000000000000000000001';
@@ -160,4 +166,86 @@ test('authorizes an issuer from the admin dashboard', async ({ page }) => {
     await page.getByLabel('Wallet Address to Authorize').fill(issuerWallet);
     await page.getByRole('button', { name: 'Authorize Wallet' }).click();
     await expect(page.getByText('Authorized to issue credentials', { exact: true })).toBeVisible();
+});
+
+test('admin console is the only admin landing screen', async ({ page }) => {
+    const state = createE2eState({
+        role: 'admin',
+        walletAddress: adminWallet,
+        contractOwner: adminWallet,
+        session: {
+            user: { id: 'admin-user-1', email: 'admin@acredia.test' },
+            access_token: 'e2e-admin-token',
+        },
+        adminInstitutions: [
+            createAdminInstitution({ id: 'inst-1', status: 'pending' }),
+            createAdminInstitution({ id: 'inst-2', status: 'verified' }),
+        ],
+    });
+
+    await seedE2eState(page, state);
+    await installE2eRoutes(page);
+
+    // There is exactly one admin console: /dashboard hands admins over to it
+    // rather than rendering a second, emptier version of the same thing
+    // (docs/decisions/0001-single-admin-console.md).
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/admin$/);
+    await expect(page.getByRole('heading', { name: 'Overview', level: 1 })).toBeVisible();
+
+    // ...and the settings entry point admins can be sent to generically.
+    await page.goto('/dashboard/settings');
+    await expect(page).toHaveURL(/\/admin\/settings$/);
+
+    await page.goto('/admin');
+
+    // The landing screen leads with what needs attention.
+    await expect(
+        page.getByRole('heading', { name: '1 institution is awaiting review' }),
+    ).toBeVisible();
+    await page.getByRole('link', { name: 'Review institutions' }).click();
+    await expect(page).toHaveURL(/\/admin\/institutions$/);
+
+    // Identity, wallet state, and sign-out are three separated bands in the
+    // sidebar rather than one Account card on the page.
+    const sidebar = page.getByRole('navigation', { name: 'Admin navigation' });
+    await expect(sidebar).toBeVisible();
+    await expect(page.getByText('admin@acredia.test')).toBeVisible();
+});
+
+test('the admin wallet gate is unmissable when disconnected and gone when connected', async ({
+    page,
+}) => {
+    const disconnected = createE2eState({
+        role: 'admin',
+        walletAddress: null,
+        contractOwner: adminWallet,
+        session: {
+            user: { id: 'admin-user-1', email: 'admin@acredia.test' },
+            access_token: 'e2e-admin-token',
+        },
+    });
+
+    await seedE2eState(page, disconnected);
+    await installE2eRoutes(page);
+
+    await page.goto('/admin');
+    const gate = page.getByRole('heading', { name: 'Wallet connection required' });
+    await expect(gate).toBeVisible();
+
+    // The gate is centred in the content area, so the screen does not end
+    // half-way down the viewport (ACREDIA-STELLAR#225).
+    const filled = await page.evaluate(() => {
+        const main = document.querySelector('main');
+        const bottom = main?.getBoundingClientRect().bottom ?? 0;
+        return bottom / window.innerHeight;
+    });
+    expect(filled, 'the admin landing screen must not end half-way down').toBeGreaterThan(0.8);
+
+    // Connected: the gate disappears entirely and the wallet becomes a quiet
+    // sidebar control.
+    await applyE2eState(page, { ...disconnected, walletAddress: adminWallet });
+
+    await expect(gate).toBeHidden();
+    await expect(page.getByRole('heading', { name: 'Verification outcomes' })).toBeVisible();
 });

--- a/frontend/tests/playwright/e2e-support.ts
+++ b/frontend/tests/playwright/e2e-support.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@playwright/test';
-import type { E2eAdminStats, E2eState } from '@/lib/e2e';
+import type { E2eAdminInstitution, E2eAdminStats, E2eState } from '@/lib/e2e';
 
 export function createE2eState(overrides: Partial<E2eState> = {}): E2eState {
     return {
@@ -23,6 +23,7 @@ export function createE2eState(overrides: Partial<E2eState> = {}): E2eState {
             walletAddress: 'GAcrediaIssuerWallet0000000000000000000000000000001',
         },
         stats: createAdminStats(),
+        adminInstitutions: [createAdminInstitution()],
         nextTokenId: 1,
         issuedCredentials: [],
         ...overrides,
@@ -53,6 +54,24 @@ export function createAdminStats(overrides: Partial<E2eAdminStats> = {}): E2eAdm
     };
 }
 
+export function createAdminInstitution(
+    overrides: Partial<E2eAdminInstitution> = {},
+): E2eAdminInstitution {
+    return {
+        id: 'inst-1',
+        name: 'Acredia Academy',
+        email: 'issuer@acredia.test',
+        walletAddress: 'GAcrediaIssuerWallet0000000000000000000000000000001',
+        verified: true,
+        status: 'verified',
+        authorizationTxHash: null,
+        createdAt: new Date().toISOString(),
+        credentialCount: 0,
+        activeCredentialCount: 0,
+        ...overrides,
+    };
+}
+
 export async function seedE2eState(page: Page, state: E2eState) {
     await page.addInitScript((initialState) => {
         const stored = window.sessionStorage.getItem('__ACREDIA_E2E__');
@@ -67,6 +86,22 @@ export async function seedE2eState(page: Page, state: E2eState) {
         window.__ACREDIA_E2E__ = initialState as typeof window.__ACREDIA_E2E__;
         window.sessionStorage.setItem('__ACREDIA_E2E__', JSON.stringify(initialState));
     }, state);
+}
+
+/**
+ * Replace the E2E state of an already-loaded page and reload it.
+ *
+ * `seedE2eState` deliberately keeps whatever is already in sessionStorage, so
+ * that state a test mutated (an issued credential, say) survives navigation.
+ * That also means calling it a second time is a no-op — switching roles
+ * mid-test has to overwrite the stored state explicitly.
+ */
+export async function applyE2eState(page: Page, state: E2eState) {
+    await page.evaluate((next) => {
+        window.__ACREDIA_E2E__ = next as typeof window.__ACREDIA_E2E__;
+        window.sessionStorage.setItem('__ACREDIA_E2E__', JSON.stringify(next));
+    }, state);
+    await page.reload();
 }
 
 /**
@@ -125,6 +160,20 @@ export async function installE2eRoutes(page: Page) {
                 total: credentials.length,
                 page: 1,
                 totalPages: 1,
+            }),
+        });
+    });
+
+    // The list route only — `/api/admin/institutions/:id` is a different page.
+    await page.route('**/api/admin/institutions', async (route) => {
+        const state = await readE2eState(page);
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                success: true,
+                institutions: state?.adminInstitutions ?? [],
             }),
         });
     });


### PR DESCRIPTION
close #225 

This pull request implements a unified admin console experience, consolidating all admin functionality at `/admin` and redirecting `/dashboard` for admins. It also significantly improves the admin overview screen, making it more actionable and user-friendly by focusing on pending tasks, surfacing system health and verification outcomes, and refining the handling of blocking states (e.g., wallet not connected or wrong wallet). The documentation is updated to reflect these architectural and product decisions.

**Admin Console Unification and UI Improvements:**

* `/dashboard` now redirects admins to `/admin`, ensuring there is only one admin console and eliminating the redundant admin landing screen. This is documented in the new ADR `docs/decisions/0001-single-admin-console.md`. [[1]](diffhunk://#diff-448fdbf15fbfc0985fb221014d0819093d7b7af3b8ceef76cdd99400d036274eR1-R80) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L48-R48)
* The admin overview now leads with pending institutions requiring review, followed by system statistics, verification outcomes, indexer health, and contract metadata, making the landing screen actionable and focused. [[1]](diffhunk://#diff-aeed671fb8fac954010bb1c9e3793c9005b52938ecd30faeb999dd9b4fd410c2R175-L233) [[2]](diffhunk://#diff-aeed671fb8fac954010bb1c9e3793c9005b52938ecd30faeb999dd9b4fd410c2L309-R311)
* Blocking states (no wallet, checking ownership, wrong wallet) now each own the whole content area, using the new `AdminGate` component to provide clear, centered feedback and actions, rather than leaving small cards stranded above empty space. [[1]](diffhunk://#diff-31eec8dca23609114668a51baa9233573c1e105d6aa15b0476be369bae01310cR1-R43) [[2]](diffhunk://#diff-aeed671fb8fac954010bb1c9e3793c9005b52938ecd30faeb999dd9b4fd410c2R175-L233)

**Component and Data Handling Enhancements:**

* Introduced new components: `PendingInstitutionsPanel`, `AdminGate`, `VerificationOutcomes`, and `IndexerHealth` to modularize and clarify the admin dashboard UI. [[1]](diffhunk://#diff-aeed671fb8fac954010bb1c9e3793c9005b52938ecd30faeb999dd9b4fd410c2R18-R20) [[2]](diffhunk://#diff-31eec8dca23609114668a51baa9233573c1e105d6aa15b0476be369bae01310cR1-R43) [[3]](diffhunk://#diff-aeed671fb8fac954010bb1c9e3793c9005b52938ecd30faeb999dd9b4fd410c2L309-R311)
* The admin stats payload and local state now include verification outcome counts and indexer status, which are displayed without extra API requests. [[1]](diffhunk://#diff-aeed671fb8fac954010bb1c9e3793c9005b52938ecd30faeb999dd9b4fd410c2R40-R45) [[2]](diffhunk://#diff-aeed671fb8fac954010bb1c9e3793c9005b52938ecd30faeb999dd9b4fd410c2R58-R60) [[3]](diffhunk://#diff-aeed671fb8fac954010bb1c9e3793c9005b52938ecd30faeb999dd9b4fd410c2L309-R311)

**Documentation Updates:**

* Added ADR `0001-single-admin-console.md` to document the decision to unify the admin console and the rationale behind UI/UX changes. Updated `docs/architecture.md` to reference the new console structure and ADR. [[1]](diffhunk://#diff-448fdbf15fbfc0985fb221014d0819093d7b7af3b8ceef76cdd99400d036274eR1-R80) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L48-R48)