### PR TITLE
fix: remove unsafe-inline and unsafe-eval from CSP script-src

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
+import { headers } from 'next/headers';
 import './globals.css';
 import { Providers } from '@/components/providers';
 import { Toaster } from '@/components/ui/sonner';
@@ -69,11 +70,17 @@ export const viewport: Viewport = {
     initialScale: 1,
 };
 
-export default function RootLayout({
+export default async function RootLayout({
     children,
 }: Readonly<{
     children: React.ReactNode;
 }>) {
+    // Reading headers() here opts this layout into dynamic rendering, which is
+    // what lets Next.js discover the per-request nonce (see src/middleware.ts)
+    // and automatically add it to the inline scripts Next.js itself injects for
+    // hydration — without this, script-src's 'nonce-...' would block them.
+    await headers();
+
     return (
         <html lang="en" className={inter.variable} suppressHydrationWarning>
             <body className="font-sans antialiased" suppressHydrationWarning>

--- a/frontend/src/lib/securityHeaders.ts
+++ b/frontend/src/lib/securityHeaders.ts
@@ -11,6 +11,14 @@ export interface SecurityHeader {
 // X-Content-Type-Options, Referrer-Policy, and Permissions-Policy for a
 // wallet-connected credential app.
 //
+// Resolves Issue #236 — script-src uses a per-request nonce + 'strict-dynamic'
+// instead of 'unsafe-inline'/'unsafe-eval'. The nonce is generated per request
+// in src/middleware.ts (build-time next.config.ts headers() cannot produce a
+// fresh nonce per request), so the CSP header itself is emitted by middleware,
+// not by buildSecurityHeaders() below. 'unsafe-eval' is kept ONLY in
+// development, because Next.js's dev-mode HMR/react-refresh runtime relies on
+// eval(); it is never present in the production policy.
+//
 // When adding a new external integration (image CDN, API endpoint, IPFS gateway,
 // wallet provider, etc.):
 //
@@ -27,37 +35,43 @@ export interface SecurityHeader {
 // 3. Run `npm test` to confirm the header definitions are valid.
 // 4. Rebuild and verify with: curl -sI https://your-deployment.url | grep -i 'content-security-policy'
 //
-// To harden script-src with nonces in the future:
-//   - Remove 'unsafe-inline' from script-src
-//   - Generate a per-request nonce in middleware (src/middleware.ts)
-//   - Pass the nonce to the layout via request headers or React context
-//   - The nonce will appear in CSP as: script-src 'nonce-{random}' 'strict-dynamic'
+// style-src keeps 'unsafe-inline': Next.js and Tailwind emit inline `style`
+// attributes/`<style>` tags that a nonce cannot easily cover without breaking
+// styling. Per the issue's own remediation guidance, this is materially lower
+// risk than 'unsafe-inline'/'unsafe-eval' on script-src (no code execution),
+// so it is accepted rather than nonce'd.
 // ──────────────────────────────────────────────────────────────────────────────
 
-export const CSP_DIRECTIVES: Record<string, string> = {
-    'default-src': "'self'",
-    'script-src': "'self' 'unsafe-eval' 'unsafe-inline'",
-    'style-src': "'self' 'unsafe-inline'",
-    'img-src':
-        "'self' data: blob: "
-        + 'tse1.mm.bing.net tse3.mm.bing.net tse4.mm.bing.net '
-        + 'www.scholarshipregion.com '
-        + 'gateway.pinata.cloud ipfs.io *.ipfs.dweb.link res.cloudinary.com',
-    'media-src': "'self' gateway.pinata.cloud ipfs.io *.ipfs.dweb.link res.cloudinary.com",
-    'connect-src':
-        "'self' "
-        + '*.supabase.co '
-        + 'https://horizon-testnet.stellar.org https://soroban-testnet.stellar.org '
-        + 'https://horizon.stellar.org https://soroban-mainnet.stellar.org '
-        + 'https://gateway.pinata.cloud https://ipfs.io https://api.pinata.cloud',
-    'frame-ancestors': "'none'",
-    'form-action': "'self'",
-    'base-uri': "'self'",
-};
+export function buildCspDirectives(nonce: string, isProduction: boolean): Record<string, string> {
+    return {
+        'default-src': "'self'",
+        'script-src':
+            `'self' 'nonce-${nonce}' 'strict-dynamic'`
+            + (isProduction ? '' : " 'unsafe-eval'"),
+        'style-src': "'self' 'unsafe-inline'",
+        'img-src':
+            "'self' data: blob: "
+            + 'tse1.mm.bing.net tse3.mm.bing.net tse4.mm.bing.net '
+            + 'www.scholarshipregion.com '
+            + 'gateway.pinata.cloud ipfs.io *.ipfs.dweb.link res.cloudinary.com',
+        'media-src': "'self' gateway.pinata.cloud ipfs.io *.ipfs.dweb.link res.cloudinary.com",
+        'connect-src':
+            "'self' "
+            + '*.supabase.co '
+            + 'https://horizon-testnet.stellar.org https://soroban-testnet.stellar.org '
+            + 'https://horizon.stellar.org https://soroban-mainnet.stellar.org '
+            + 'https://gateway.pinata.cloud https://ipfs.io https://api.pinata.cloud',
+        'frame-ancestors': "'none'",
+        'form-action': "'self'",
+        'base-uri': "'self'",
+        'object-src': "'none'",
+        'upgrade-insecure-requests': '',
+    };
+}
 
-export function buildCspString(): string {
-    return Object.entries(CSP_DIRECTIVES)
-        .map(([directive, value]) => `${directive} ${value}`)
+export function buildCspString(nonce: string, isProduction: boolean): string {
+    return Object.entries(buildCspDirectives(nonce, isProduction))
+        .map(([directive, value]) => (value ? `${directive} ${value}` : directive))
         .join('; ');
 }
 
@@ -76,9 +90,11 @@ export interface HeaderGroup {
     headers: SecurityHeader[];
 }
 
+// Static (non-nonce) security headers, applied via next.config.ts headers().
+// Content-Security-Policy is NOT included here: it needs a fresh per-request
+// nonce and is applied by src/middleware.ts instead. See buildCspString above.
 export function buildSecurityHeaders(isProduction: boolean): HeaderGroup[] {
     const headers: SecurityHeader[] = [
-        { key: 'Content-Security-Policy', value: buildCspString() },
         { key: 'X-Frame-Options', value: 'DENY' },
         { key: 'X-Content-Type-Options', value: 'nosniff' },
         { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,12 +1,22 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { buildCspString } from './lib/securityHeaders';
 
 export function middleware(request: NextRequest) {
     const requestId = crypto.randomUUID();
 
-    // Attach request ID to request headers
+    // Per-request nonce for the Content-Security-Policy script-src directive.
+    // Generated here (not in next.config.ts headers(), which is static/build-time)
+    // so every response gets a fresh, unguessable nonce. See src/lib/securityHeaders.ts.
+    const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+    const csp = buildCspString(nonce, process.env.NODE_ENV === 'production');
+
+    // Attach request ID + nonce to request headers so Server Components can
+    // read them via `headers()` (e.g. to add `nonce={nonce}` to a manual <script>).
     const requestHeaders = new Headers(request.headers);
     requestHeaders.set('x-request-id', requestId);
+    requestHeaders.set('x-nonce', nonce);
+    requestHeaders.set('Content-Security-Policy', csp);
 
     const response = NextResponse.next({
         request: {
@@ -16,9 +26,15 @@ export function middleware(request: NextRequest) {
 
     // Also attach to response headers
     response.headers.set('x-request-id', requestId);
+    response.headers.set('Content-Security-Policy', csp);
     return response;
 }
 
 export const config = {
-    matcher: '/api/:path*',
+    matcher: [
+        // Run on everything except static assets and Next's internal image
+        // optimizer, so page navigations get a fresh CSP nonce. API routes are
+        // included too, so the x-request-id behavior below is unchanged.
+        '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)',
+    ],
 };

--- a/frontend/tests/security-headers.test.ts
+++ b/frontend/tests/security-headers.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
-    CSP_DIRECTIVES,
+    buildCspDirectives,
     buildCspString,
     buildPermissionsPolicy,
     buildSecurityHeaders,
 } from '../src/lib/securityHeaders';
+
+const NONCE = 'test-nonce-value';
 
 const REQUIRED_DIRECTIVES = [
     'default-src',
@@ -16,6 +18,8 @@ const REQUIRED_DIRECTIVES = [
     'frame-ancestors',
     'form-action',
     'base-uri',
+    'object-src',
+    'upgrade-insecure-requests',
 ] as const;
 
 const STELLAR_ENDPOINTS = [
@@ -43,21 +47,23 @@ const IPFS_DOMAINS = [
 
 describe('CSP directives', () => {
     it('includes all required directives', () => {
+        const directives = buildCspDirectives(NONCE, true);
         for (const directive of REQUIRED_DIRECTIVES) {
-            expect(CSP_DIRECTIVES).toHaveProperty(directive);
+            expect(directives).toHaveProperty(directive);
         }
     });
 
     it('has no unknown directives (typo guard)', () => {
+        const directives = buildCspDirectives(NONCE, true);
         const known = new Set(REQUIRED_DIRECTIVES);
-        for (const key of Object.keys(CSP_DIRECTIVES)) {
+        for (const key of Object.keys(directives)) {
             expect(known.has(key as typeof REQUIRED_DIRECTIVES[number])).toBe(true);
         }
     });
 
     it('uses single-quoted keywords correctly', () => {
-        for (const value of Object.values(CSP_DIRECTIVES)) {
-            for (const keyword of ['self', 'none', 'unsafe-inline', 'unsafe-eval']) {
+        for (const value of Object.values(buildCspDirectives(NONCE, false))) {
+            for (const keyword of ['self', 'none', 'unsafe-inline', 'unsafe-eval', 'strict-dynamic']) {
                 if (value.includes(keyword)) {
                     expect(value).toContain(`'${keyword}'`);
                 }
@@ -67,31 +73,70 @@ describe('CSP directives', () => {
 });
 
 describe('script-src', () => {
-    it('allows self, unsafe-eval, and unsafe-inline (practical baseline)', () => {
-        const value = CSP_DIRECTIVES['script-src'];
+    it('allows self, the request nonce, and strict-dynamic', () => {
+        const value = buildCspDirectives(NONCE, true)['script-src'];
         expect(value).toContain("'self'");
-        expect(value).toContain("'unsafe-eval'");
-        expect(value).toContain("'unsafe-inline'");
+        expect(value).toContain(`'nonce-${NONCE}'`);
+        expect(value).toContain("'strict-dynamic'");
+    });
+
+    it('never contains unsafe-inline', () => {
+        expect(buildCspDirectives(NONCE, true)['script-src']).not.toContain('unsafe-inline');
+        expect(buildCspDirectives(NONCE, false)['script-src']).not.toContain('unsafe-inline');
+    });
+
+    it('excludes unsafe-eval in production', () => {
+        expect(buildCspDirectives(NONCE, true)['script-src']).not.toContain('unsafe-eval');
+    });
+
+    it('allows unsafe-eval only in development, for Next.js HMR', () => {
+        expect(buildCspDirectives(NONCE, false)['script-src']).toContain("'unsafe-eval'");
+    });
+
+    it('changes the nonce per invocation', () => {
+        const a = buildCspDirectives('nonce-a', true)['script-src'];
+        const b = buildCspDirectives('nonce-b', true)['script-src'];
+        expect(a).not.toBe(b);
+    });
+});
+
+describe('object-src', () => {
+    it('blocks plugin content entirely', () => {
+        expect(buildCspDirectives(NONCE, true)['object-src']).toBe("'none'");
+    });
+});
+
+describe('upgrade-insecure-requests', () => {
+    it('is present as a valueless directive', () => {
+        const directives = buildCspDirectives(NONCE, true);
+        expect(directives).toHaveProperty('upgrade-insecure-requests');
+        expect(directives['upgrade-insecure-requests']).toBe('');
+    });
+
+    it('renders without a trailing value in the header string', () => {
+        const csp = buildCspString(NONCE, true);
+        const parts = csp.split('; ');
+        expect(parts).toContain('upgrade-insecure-requests');
     });
 });
 
 describe('img-src', () => {
     it('allows self, data:, and blob:', () => {
-        const value = CSP_DIRECTIVES['img-src'];
+        const value = buildCspDirectives(NONCE, true)['img-src'];
         expect(value).toContain("'self'");
         expect(value).toContain('data:');
         expect(value).toContain('blob:');
     });
 
     it('allows all known image CDNs', () => {
-        const value = CSP_DIRECTIVES['img-src'];
+        const value = buildCspDirectives(NONCE, true)['img-src'];
         for (const domain of IMAGE_DOMAINS) {
             expect(value).toContain(domain);
         }
     });
 
     it('allows IPFS gateways', () => {
-        const value = CSP_DIRECTIVES['img-src'];
+        const value = buildCspDirectives(NONCE, true)['img-src'];
         for (const domain of IPFS_DOMAINS) {
             expect(value).toContain(domain);
         }
@@ -100,7 +145,7 @@ describe('img-src', () => {
 
 describe('media-src', () => {
     it('allows self and IPFS gateways', () => {
-        const value = CSP_DIRECTIVES['media-src'];
+        const value = buildCspDirectives(NONCE, true)['media-src'];
         expect(value).toContain("'self'");
         for (const domain of IPFS_DOMAINS) {
             expect(value).toContain(domain);
@@ -108,26 +153,26 @@ describe('media-src', () => {
     });
 
     it('allows res.cloudinary.com for hero video', () => {
-        expect(CSP_DIRECTIVES['media-src']).toContain('res.cloudinary.com');
+        expect(buildCspDirectives(NONCE, true)['media-src']).toContain('res.cloudinary.com');
     });
 });
 
 describe('connect-src', () => {
     it('allows self and Supabase', () => {
-        const value = CSP_DIRECTIVES['connect-src'];
+        const value = buildCspDirectives(NONCE, true)['connect-src'];
         expect(value).toContain("'self'");
         expect(value).toContain('*.supabase.co');
     });
 
     it('allows all Stellar endpoints', () => {
-        const value = CSP_DIRECTIVES['connect-src'];
+        const value = buildCspDirectives(NONCE, true)['connect-src'];
         for (const endpoint of STELLAR_ENDPOINTS) {
             expect(value).toContain(endpoint);
         }
     });
 
     it('allows IPFS gateways and Pinata API', () => {
-        const value = CSP_DIRECTIVES['connect-src'];
+        const value = buildCspDirectives(NONCE, true)['connect-src'];
         // *.ipfs.dweb.link is for media/img, not connect; only explicit gateway domains go here.
         for (const domain of ['gateway.pinata.cloud', 'ipfs.io', 'api.pinata.cloud']) {
             expect(value).toContain(domain);
@@ -137,44 +182,49 @@ describe('connect-src', () => {
 
 describe('frame-ancestors', () => {
     it('blocks all framing', () => {
-        expect(CSP_DIRECTIVES['frame-ancestors']).toBe("'none'");
+        expect(buildCspDirectives(NONCE, true)['frame-ancestors']).toBe("'none'");
     });
 });
 
 describe('form-action', () => {
     it('restricts to self', () => {
-        expect(CSP_DIRECTIVES['form-action']).toBe("'self'");
+        expect(buildCspDirectives(NONCE, true)['form-action']).toBe("'self'");
     });
 });
 
 describe('base-uri', () => {
     it('restricts to self', () => {
-        expect(CSP_DIRECTIVES['base-uri']).toBe("'self'");
+        expect(buildCspDirectives(NONCE, true)['base-uri']).toBe("'self'");
     });
 });
 
 describe('buildCspString', () => {
     it('produces a valid CSP header string', () => {
-        const csp = buildCspString();
+        const csp = buildCspString(NONCE, true);
         expect(csp).toBeTruthy();
 
         // Each directive should be separated by "; "
         const parts = csp.split('; ');
-        expect(parts.length).toBe(Object.keys(CSP_DIRECTIVES).length);
+        expect(parts.length).toBe(Object.keys(buildCspDirectives(NONCE, true)).length);
 
-        // Each part should be "directive value"
+        // Each part should start with a lowercase directive name.
         for (const part of parts) {
-            expect(part).toMatch(/^[a-z-]+ .+/);
+            expect(part).toMatch(/^[a-z-]+(?: .+)?$/);
         }
     });
 
     it('round-trips directives correctly', () => {
-        const csp = buildCspString();
+        const csp = buildCspString(NONCE, true);
+        const directives = buildCspDirectives(NONCE, true);
         const parts = csp.split('; ');
         for (const part of parts) {
-            const [directive] = part.split(' ');
-            expect(CSP_DIRECTIVES[directive]).toBe(part.slice(directive.length + 1));
+            const [directive, ...rest] = part.split(' ');
+            expect(directives[directive]).toBe(rest.join(' '));
         }
+    });
+
+    it('embeds the given nonce', () => {
+        expect(buildCspString('abc123', true)).toContain("'nonce-abc123'");
     });
 });
 
@@ -198,16 +248,21 @@ describe('buildPermissionsPolicy', () => {
 });
 
 describe('buildSecurityHeaders', () => {
-    it('includes all required headers in development', () => {
+    it('includes all required static headers in development', () => {
         const groups = buildSecurityHeaders(false);
         const headers = groups[0].headers;
         const keys = headers.map((h) => h.key);
 
-        expect(keys).toContain('Content-Security-Policy');
         expect(keys).toContain('X-Frame-Options');
         expect(keys).toContain('X-Content-Type-Options');
         expect(keys).toContain('Referrer-Policy');
         expect(keys).toContain('Permissions-Policy');
+    });
+
+    it('does not include Content-Security-Policy (set per-request by middleware instead)', () => {
+        const groups = buildSecurityHeaders(false);
+        const keys = groups[0].headers.map((h) => h.key);
+        expect(keys).not.toContain('Content-Security-Policy');
     });
 
     it('excludes HSTS in development', () => {


### PR DESCRIPTION
Closes #236 

## Summary
- What changed?
- Why is this needed?

## Testing
- [ ] Lint
- [ ] Unit tests
- [ ] Build
- [ ] Coverage check

## Notes
- Any follow-up items or risks?
