### PR TITLE
feat: Implement institution provisioning and invite acceptance flow

### DIFF
--- a/frontend/src/app/admin/institutions/page.tsx
+++ b/frontend/src/app/admin/institutions/page.tsx
@@ -2,17 +2,28 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { ArrowRight, Building2, RefreshCw, Search } from 'lucide-react';
+import { ArrowRight, Building2, Check, Copy, Plus, RefreshCw, Search } from 'lucide-react';
 import { toast } from 'sonner';
 import { ConsoleShell } from '@/components/console/ConsoleShell';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 import { captureException } from '@/lib/debug';
 import {
     adminFetch,
     formatDate,
+    onboardingBadgeClass,
+    onboardingLabel,
     shortenAddress,
     statusBadgeClass,
     type AdminInstitutionSummary,
@@ -30,12 +41,44 @@ function StatusBadge({ status }: { status: string }) {
     );
 }
 
+function OnboardingBadge({ institution }: { institution: AdminInstitutionSummary }) {
+    return (
+        <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${onboardingBadgeClass(institution.onboardingState)}`}
+        >
+            {onboardingLabel(institution.onboardingState)}
+        </span>
+    );
+}
+
+const EMPTY_FORM = {
+    name: '',
+    pocName: '',
+    pocEmail: '',
+    walletAddress: '',
+    country: '',
+    accreditationRef: '',
+    internalNotes: '',
+};
+
 function InstitutionsContent() {
     const [institutions, setInstitutions] = useState<AdminInstitutionSummary[]>([]);
     const [loading, setLoading] = useState(true);
     const [refreshing, setRefreshing] = useState(false);
     const [error, setError] = useState('');
     const [query, setQuery] = useState('');
+
+    // "Add institution" provisioning flow
+    const [addOpen, setAddOpen] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [form, setForm] = useState(EMPTY_FORM);
+    const [formError, setFormError] = useState('');
+    const [invite, setInvite] = useState<{
+        institutionName: string;
+        link: string | null;
+        expiresAt: string | null;
+    } | null>(null);
+    const [copied, setCopied] = useState(false);
 
     const load = useCallback(async (silent = false) => {
         try {
@@ -67,6 +110,77 @@ function InstitutionsContent() {
         load();
     }, [load]);
 
+    const updateField = (field: keyof typeof EMPTY_FORM, value: string) => {
+        setForm((previous) => ({ ...previous, [field]: value }));
+    };
+
+    const handleCreate = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setFormError('');
+        setSubmitting(true);
+
+        try {
+            const payload = {
+                name: form.name.trim(),
+                pocName: form.pocName.trim(),
+                pocEmail: form.pocEmail.trim(),
+                walletAddress: form.walletAddress.trim(),
+                country: form.country.trim() || undefined,
+                accreditationRef: form.accreditationRef.trim() || undefined,
+                internalNotes: form.internalNotes.trim() || undefined,
+            };
+
+            const data = await adminFetch<{
+                institution: { id: string; name: string };
+                inviteLink: string | null;
+                inviteExpiresAt: string | null;
+                message: string;
+            }>('/api/admin/institutions', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            });
+
+            setInvite({
+                institutionName: data.institution.name,
+                link: data.inviteLink,
+                expiresAt: data.inviteExpiresAt,
+            });
+            setCopied(false);
+            setForm(EMPTY_FORM);
+            toast.success(data.message);
+            load(true);
+        } catch (err) {
+            captureException(err, { context: 'adminCreateInstitution' });
+            const message = err instanceof Error ? err.message : 'Failed to create institution';
+            setFormError(message);
+            toast.error(message);
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const handleCopyInvite = async () => {
+        if (!invite?.link) return;
+
+        try {
+            await navigator.clipboard.writeText(invite.link);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error('Could not copy the link. Select it and copy manually.');
+        }
+    };
+
+    const closeAddDialog = (open: boolean) => {
+        setAddOpen(open);
+        if (!open) {
+            setForm(EMPTY_FORM);
+            setFormError('');
+            setInvite(null);
+            setCopied(false);
+        }
+    };
+
     const filtered = useMemo(() => {
         const term = query.trim().toLowerCase();
         if (!term) return institutions;
@@ -84,15 +198,21 @@ function InstitutionsContent() {
             title="Institutions"
             subtitle="Every organisation registered on Acredia"
             actions={
-                <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => load(true)}
-                    disabled={refreshing || loading}
-                >
-                    <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
-                    Refresh
-                </Button>
+                <div className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => load(true)}
+                        disabled={refreshing || loading}
+                    >
+                        <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+                        Refresh
+                    </Button>
+                    <Button size="sm" onClick={() => setAddOpen(true)}>
+                        <Plus className="h-4 w-4" />
+                        Add institution
+                    </Button>
+                </div>
             }
         >
             <Card className="mb-6 p-4">
@@ -136,7 +256,7 @@ function InstitutionsContent() {
                     </h3>
                     <p className="mt-1 text-sm text-muted-foreground">
                         {institutions.length === 0
-                            ? 'Institutions appear here as soon as they create an account.'
+                            ? 'Provision the first one with "Add institution" to issue its POC an invite.'
                             : 'Try a different name, email, or wallet address.'}
                     </p>
                 </Card>
@@ -150,6 +270,7 @@ function InstitutionsContent() {
                                     <tr className="text-xs uppercase tracking-wide text-muted-foreground">
                                         <th className="px-5 py-3 font-semibold">Institution</th>
                                         <th className="px-5 py-3 font-semibold">Status</th>
+                                        <th className="px-5 py-3 font-semibold">Onboarding</th>
                                         <th className="px-5 py-3 font-semibold">Wallet</th>
                                         <th className="px-5 py-3 font-semibold">Credentials</th>
                                         <th className="px-5 py-3 font-semibold">Registered</th>
@@ -172,6 +293,9 @@ function InstitutionsContent() {
                                             </td>
                                             <td className="px-5 py-4">
                                                 <StatusBadge status={institution.status} />
+                                            </td>
+                                            <td className="px-5 py-4">
+                                                <OnboardingBadge institution={institution} />
                                             </td>
                                             <td className="px-5 py-4 font-mono text-xs text-muted-foreground">
                                                 {shortenAddress(institution.walletAddress)}
@@ -218,7 +342,10 @@ function InstitutionsContent() {
                                             {institution.email}
                                         </p>
                                     </div>
-                                    <StatusBadge status={institution.status} />
+                                    <div className="flex shrink-0 flex-col items-end gap-1.5">
+                                        <StatusBadge status={institution.status} />
+                                        <OnboardingBadge institution={institution} />
+                                    </div>
                                 </div>
                                 <dl className="mt-4 grid grid-cols-2 gap-3 text-xs">
                                     <div>
@@ -240,6 +367,206 @@ function InstitutionsContent() {
                     </div>
                 </>
             )}
+
+            <Dialog open={addOpen} onOpenChange={closeAddDialog}>
+                <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+                    <DialogHeader>
+                        <DialogTitle>Add institution</DialogTitle>
+                        <DialogDescription>
+                            Creates the institution as pending and provisions its POC with no
+                            password. The POC sets their own password from the invite link. This
+                            does not authorize the wallet on-chain — do that separately from
+                            Authorize issuer.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {invite ? (
+                        <div className="space-y-4 py-2">
+                            <div className="rounded-lg border border-success/25 bg-success/8 px-4 py-3 text-sm text-success">
+                                {invite.institutionName} was provisioned.
+                            </div>
+
+                            {invite.link ? (
+                                <div className="space-y-2">
+                                    <Label htmlFor="invite-link">
+                                        Single-use invite link
+                                        {invite.expiresAt
+                                            ? ` · expires ${formatDate(invite.expiresAt)}`
+                                            : ''}
+                                    </Label>
+                                    <div className="flex items-center gap-2">
+                                        <Input
+                                            id="invite-link"
+                                            readOnly
+                                            value={invite.link}
+                                            className="h-9 bg-background font-mono text-xs"
+                                        />
+                                        <Button
+                                            type="button"
+                                            variant="secondary"
+                                            size="sm"
+                                            onClick={handleCopyInvite}
+                                            className="h-9 shrink-0 gap-1.5"
+                                        >
+                                            {copied ? (
+                                                <>
+                                                    <Check className="h-3.5 w-3.5 text-success" />
+                                                    Copied
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <Copy className="h-3.5 w-3.5" />
+                                                    Copy
+                                                </>
+                                            )}
+                                        </Button>
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                        Supabase also emails this link. Copy it now if mail is
+                                        delayed — you can regenerate it from the institution page,
+                                        which invalidates this one.
+                                    </p>
+                                </div>
+                            ) : (
+                                <div className="rounded-lg border border-warning/25 bg-warning/8 px-4 py-3 text-sm text-warning">
+                                    The invite link could not be generated. Regenerate it from the
+                                    institution page.
+                                </div>
+                            )}
+
+                            <DialogFooter>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => closeAddDialog(false)}
+                                >
+                                    Done
+                                </Button>
+                            </DialogFooter>
+                        </div>
+                    ) : (
+                        <form onSubmit={handleCreate} className="space-y-4 py-2">
+                            <div className="space-y-2">
+                                <Label htmlFor="institution-name">Institution name</Label>
+                                <Input
+                                    id="institution-name"
+                                    value={form.name}
+                                    onChange={(event) => updateField('name', event.target.value)}
+                                    placeholder="University of Example"
+                                    required
+                                />
+                            </div>
+
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <div className="space-y-2">
+                                    <Label htmlFor="poc-name">POC name</Label>
+                                    <Input
+                                        id="poc-name"
+                                        value={form.pocName}
+                                        onChange={(event) =>
+                                            updateField('pocName', event.target.value)
+                                        }
+                                        placeholder="Registrar's full name"
+                                        required
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="poc-email">POC email</Label>
+                                    <Input
+                                        id="poc-email"
+                                        type="email"
+                                        value={form.pocEmail}
+                                        onChange={(event) =>
+                                            updateField('pocEmail', event.target.value)
+                                        }
+                                        placeholder="registrar@example.edu"
+                                        required
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="wallet-address">Issuer wallet address</Label>
+                                <Input
+                                    id="wallet-address"
+                                    value={form.walletAddress}
+                                    onChange={(event) =>
+                                        updateField('walletAddress', event.target.value)
+                                    }
+                                    placeholder="G…"
+                                    className="font-mono text-xs"
+                                    required
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    Recorded now, authorized on-chain later.
+                                </p>
+                            </div>
+
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <div className="space-y-2">
+                                    <Label htmlFor="country">Country or region (optional)</Label>
+                                    <Input
+                                        id="country"
+                                        value={form.country}
+                                        onChange={(event) =>
+                                            updateField('country', event.target.value)
+                                        }
+                                        placeholder="India"
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="accreditation-ref">
+                                        Accreditation ref (optional)
+                                    </Label>
+                                    <Input
+                                        id="accreditation-ref"
+                                        value={form.accreditationRef}
+                                        onChange={(event) =>
+                                            updateField('accreditationRef', event.target.value)
+                                        }
+                                        placeholder="NAAC A++"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="internal-notes">Internal notes (optional)</Label>
+                                <Input
+                                    id="internal-notes"
+                                    value={form.internalNotes}
+                                    onChange={(event) =>
+                                        updateField('internalNotes', event.target.value)
+                                    }
+                                    placeholder="Basis for provisioning, who requested it"
+                                />
+                            </div>
+
+                            {formError && (
+                                <div
+                                    className="rounded-lg border border-destructive/25 bg-destructive/8 px-4 py-3 text-sm text-destructive"
+                                    role="alert"
+                                >
+                                    {formError}
+                                </div>
+                            )}
+
+                            <DialogFooter>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => closeAddDialog(false)}
+                                    disabled={submitting}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button type="submit" disabled={submitting}>
+                                    {submitting ? 'Provisioning…' : 'Create and invite'}
+                                </Button>
+                            </DialogFooter>
+                        </form>
+                    )}
+                </DialogContent>
+            </Dialog>
         </ConsoleShell>
     );
 }

--- a/frontend/src/app/api/admin/institutions/[id]/recovery-link/route.ts
+++ b/frontend/src/app/api/admin/institutions/[id]/recovery-link/route.ts
@@ -14,6 +14,9 @@ const ADMIN_RECOVERY_LINK_RATE_LIMIT = {
 
 const idSchema = z.string().uuid();
 
+/** Matches the invite lifetime used when an institution is first provisioned. */
+const INVITE_TTL_DAYS = 7;
+
 const requestSchema = z.object({
     type: z.enum(['recovery', 'invite']).default('recovery'),
     reason: z.string().max(500).optional(),
@@ -79,7 +82,7 @@ export async function POST(
         // 1. Fetch institution
         const { data: institution, error: institutionError } = await supabase
             .from('institutions')
-            .select('id, name, email, auth_user_id')
+            .select('id, name, email, auth_user_id, invited_at')
             .eq('id', parsedId.data)
             .maybeSingle();
 
@@ -110,9 +113,14 @@ export async function POST(
 
         // 2. Determine redirect destination
         const origin = request.nextUrl.origin || 'http://localhost:3000';
-        const redirectTo = `${origin}/auth/reset-password?next=/dashboard`;
-
         const linkType = parsedBody.data.type;
+
+        // An invite lands on the acceptance page (POC sets a first password);
+        // a recovery link lands on the ordinary reset flow.
+        const redirectTo =
+            linkType === 'invite'
+                ? `${origin}/auth/accept-invite?next=/dashboard`
+                : `${origin}/auth/reset-password?next=/dashboard`;
 
         // 3. Generate single-use link via Supabase Auth Admin API
         const { data: linkData, error: linkError } = await supabase.auth.admin.generateLink({
@@ -142,9 +150,41 @@ export async function POST(
 
         const actionLink = linkData.properties.action_link;
 
-        // 4. Record audit log
-        const auditAction =
-            linkType === 'invite' ? 'generate_invite_link' : 'generate_recovery_link';
+        // 4. Advance the invite window. Supabase already invalidated the prior
+        //    token when it generated this one, so the stored expiry must follow
+        //    the new link rather than the superseded one.
+        const isRegeneration = linkType === 'invite' && Boolean(institution.invited_at);
+        let inviteExpiresAt: string | null = null;
+
+        if (linkType === 'invite') {
+            const invitedAt = new Date();
+            inviteExpiresAt = new Date(
+                invitedAt.getTime() + INVITE_TTL_DAYS * 24 * 60 * 60 * 1000,
+            ).toISOString();
+
+            const { error: inviteUpdateError } = await supabase
+                .from('institutions')
+                .update({
+                    invited_at: invitedAt.toISOString(),
+                    invite_expires_at: inviteExpiresAt,
+                    invite_accepted_at: null,
+                })
+                .eq('id', institution.id);
+
+            if (inviteUpdateError) {
+                structuredLog('WARN', 'Failed to record the new invite window', requestId, {
+                    error: inviteUpdateError,
+                    institutionId: institution.id,
+                });
+            }
+        }
+
+        // 5. Record audit log
+        const auditAction = isRegeneration
+            ? 'regenerate_invite_link'
+            : linkType === 'invite'
+              ? 'generate_invite_link'
+              : 'generate_recovery_link';
 
         const { error: auditError } = await supabase.from('admin_audit_logs').insert({
             action: auditAction,
@@ -156,7 +196,9 @@ export async function POST(
                 reason: parsedBody.data.reason || 'Admin fallback link generation',
                 linkType,
                 singleUse: true,
-                expiresInHours: 24,
+                regenerated: isRegeneration,
+                expiresInHours: linkType === 'invite' ? INVITE_TTL_DAYS * 24 : 24,
+                inviteExpiresAt,
             },
         });
 
@@ -178,7 +220,8 @@ export async function POST(
             link: actionLink,
             type: linkType,
             email: institution.email,
-            expiresInHours: 24,
+            expiresInHours: linkType === 'invite' ? INVITE_TTL_DAYS * 24 : 24,
+            inviteExpiresAt,
             message: `Single-use ${linkType} link generated. Any previously generated link has been invalidated.`,
         });
     } catch (error) {

--- a/frontend/src/app/api/admin/institutions/route.ts
+++ b/frontend/src/app/api/admin/institutions/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getServiceRoleClient, requireAdminRequest } from '@/lib/serverAuth';
 import { enforceRateLimit } from '@/lib/rateLimit';
 import { structuredLog, captureException } from '@/lib/debug';
+import { isValidStellarAddress } from '@/lib/contracts';
 
 export const dynamic = 'force-dynamic';
 
@@ -22,6 +24,44 @@ export interface AdminInstitution {
     createdAt: string | null;
     credentialCount: number;
     activeCredentialCount: number;
+    /** invited -> active -> wallet_authorized, so half-finished onboarding is visible. */
+    onboardingState: OnboardingState;
+    invitedAt: string | null;
+    inviteExpiresAt: string | null;
+    inviteAcceptedAt: string | null;
+}
+
+export type OnboardingState = 'invited' | 'invite_expired' | 'active' | 'wallet_authorized';
+
+/**
+ * Derives how far an institution has progressed through onboarding.
+ *
+ * Wallet authorization is the last step and is proven by the on-chain
+ * transaction hash — an institution is only "authorized" once the contract
+ * owner has actually signed for it.
+ */
+export function deriveOnboardingState(institution: {
+    authorization_tx_hash?: string | null;
+    invite_accepted_at?: string | null;
+    invite_expires_at?: string | null;
+}): OnboardingState {
+    if (institution.authorization_tx_hash) {
+        return 'wallet_authorized';
+    }
+
+    if (institution.invite_accepted_at) {
+        return 'active';
+    }
+
+    const expiresAt = institution.invite_expires_at
+        ? new Date(institution.invite_expires_at).getTime()
+        : null;
+
+    if (expiresAt && Number.isFinite(expiresAt) && expiresAt < Date.now()) {
+        return 'invite_expired';
+    }
+
+    return 'invited';
 }
 
 /**
@@ -53,7 +93,7 @@ export async function GET(request: NextRequest) {
         const { data: institutions, error: institutionsError } = await supabase
             .from('institutions')
             .select(
-                'id, name, email, wallet_address, verified, status, authorization_tx_hash, created_at',
+                'id, name, email, wallet_address, verified, status, authorization_tx_hash, created_at, invited_at, invite_expires_at, invite_accepted_at',
             )
             .order('created_at', { ascending: false });
 
@@ -102,6 +142,10 @@ export async function GET(request: NextRequest) {
                 createdAt: institution.created_at ?? null,
                 credentialCount: counts.total,
                 activeCredentialCount: counts.active,
+                onboardingState: deriveOnboardingState(institution),
+                invitedAt: institution.invited_at ?? null,
+                inviteExpiresAt: institution.invite_expires_at ?? null,
+                inviteAcceptedAt: institution.invite_accepted_at ?? null,
             };
         });
 
@@ -110,6 +154,324 @@ export async function GET(request: NextRequest) {
         captureException(error, { context: 'adminInstitutions' });
         return NextResponse.json(
             { success: false, error: 'Failed to load institutions' },
+            { status: 500 },
+        );
+    }
+}
+
+const ADMIN_CREATE_INSTITUTION_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 10,
+    prefix: 'admin-create-institution',
+} as const;
+
+/**
+ * Invite links are valid for a week — long enough for a POC who is on leave,
+ * short enough that a leaked link does not stay useful.
+ */
+const INVITE_TTL_DAYS = 7;
+
+const createInstitutionSchema = z.object({
+    name: z.string().trim().min(2, 'Institution name must be at least 2 characters').max(200),
+    pocName: z.string().trim().min(2, 'POC name must be at least 2 characters').max(100),
+    pocEmail: z.string().trim().email('Invalid POC email address').max(254),
+    walletAddress: z
+        .string()
+        .trim()
+        .refine(isValidStellarAddress, 'Not a valid Stellar public key (expected G…)'),
+    country: z.string().trim().max(100).optional(),
+    accreditationRef: z.string().trim().max(200).optional(),
+    internalNotes: z.string().trim().max(1000).optional(),
+});
+
+/**
+ * Provisions a new institution from the admin console.
+ *
+ * Creates the institution row as `pending`, provisions the POC's auth user with
+ * **no password**, links the two through `institution_users`, and returns a
+ * single-use invite link the admin can copy. The POC sets their own password on
+ * first use, so no Acredia staff member ever knows it.
+ *
+ * Deliberately does **not** authorize the wallet on-chain — that stays a
+ * separate, owner-signed step in `/admin/authorize`.
+ */
+export async function POST(request: NextRequest) {
+    const requestId = request.headers.get('x-request-id') || 'unknown';
+
+    try {
+        const rateLimitResponse = await enforceRateLimit(
+            request,
+            ADMIN_CREATE_INSTITUTION_RATE_LIMIT,
+        );
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
+        const adminCheck = await requireAdminRequest(request);
+        if (!adminCheck.ok) {
+            return NextResponse.json(
+                { success: false, error: adminCheck.error },
+                { status: adminCheck.status },
+            );
+        }
+
+        const body = await request.json().catch(() => ({}));
+        const parsed = createInstitutionSchema.safeParse(body);
+
+        if (!parsed.success) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: 'Invalid institution payload',
+                    details: parsed.error.flatten(),
+                },
+                { status: 400 },
+            );
+        }
+
+        const { name, pocName, pocEmail, walletAddress, country, accreditationRef, internalNotes } =
+            parsed.data;
+        const normalizedEmail = pocEmail.toLowerCase();
+
+        const supabase = getServiceRoleClient();
+
+        // 1. Reject duplicates up front so we never orphan a freshly created
+        //    auth user against an insert that the unique constraints would
+        //    always have rejected. Two `eq` queries rather than one `or(...)`
+        //    string, so no user-supplied value is ever spliced into a
+        //    PostgREST filter expression.
+        const [emailMatch, walletMatch] = await Promise.all([
+            supabase
+                .from('institutions')
+                .select('id, name')
+                .eq('email', normalizedEmail)
+                .maybeSingle(),
+            supabase
+                .from('institutions')
+                .select('id, name')
+                .eq('wallet_address', walletAddress)
+                .maybeSingle(),
+        ]);
+
+        if (emailMatch.error || walletMatch.error) {
+            structuredLog('ERROR', 'Failed to check for an existing institution', requestId, {
+                error: emailMatch.error ?? walletMatch.error,
+            });
+            return NextResponse.json(
+                { success: false, error: 'Failed to verify institution uniqueness' },
+                { status: 500 },
+            );
+        }
+
+        const conflict = emailMatch.data ?? walletMatch.data;
+        if (conflict) {
+            const duplicateField = emailMatch.data ? 'email' : 'wallet address';
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: `An institution with this ${duplicateField} already exists (${conflict.name}).`,
+                },
+                { status: 409 },
+            );
+        }
+
+        // 2. Provision the POC auth user with no password set. `email_confirm`
+        //    marks the address as verified so the invite link is the only thing
+        //    between the POC and choosing their own password.
+        let authUserId: string | null = null;
+
+        const { data: createdUser, error: createUserError } = await supabase.auth.admin.createUser({
+            email: normalizedEmail,
+            email_confirm: true,
+            user_metadata: {
+                name: pocName,
+                role: 'institution',
+            },
+        });
+
+        if (createUserError) {
+            if (createUserError.message.toLowerCase().includes('already')) {
+                const { data: listData } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+                const existing = listData?.users.find(
+                    (user) => user.email?.toLowerCase() === normalizedEmail,
+                );
+                authUserId = existing?.id ?? null;
+            }
+
+            if (!authUserId) {
+                structuredLog('ERROR', 'Failed to provision the POC auth user', requestId, {
+                    error: createUserError,
+                });
+                return NextResponse.json(
+                    {
+                        success: false,
+                        error: `Failed to provision POC account: ${createUserError.message}`,
+                    },
+                    { status: 500 },
+                );
+            }
+        } else {
+            authUserId = createdUser.user?.id ?? null;
+        }
+
+        if (!authUserId) {
+            return NextResponse.json(
+                { success: false, error: 'Could not resolve the POC user identifier' },
+                { status: 500 },
+            );
+        }
+
+        // 3. Profile record carrying the institution role.
+        const { error: profileError } = await supabase.from('profiles').upsert(
+            {
+                id: authUserId,
+                email: normalizedEmail,
+                role: 'institution',
+                full_name: pocName,
+                is_active: true,
+            },
+            { onConflict: 'id' },
+        );
+
+        if (profileError) {
+            structuredLog('WARN', 'Failed to upsert the POC profile', requestId, {
+                error: profileError,
+                authUserId,
+            });
+        }
+
+        // 4. Institution row — pending, and explicitly unauthorized on-chain.
+        const invitedAt = new Date();
+        const inviteExpiresAt = new Date(
+            invitedAt.getTime() + INVITE_TTL_DAYS * 24 * 60 * 60 * 1000,
+        );
+
+        const { data: institution, error: insertError } = await supabase
+            .from('institutions')
+            .insert({
+                name,
+                email: normalizedEmail,
+                poc_name: pocName,
+                wallet_address: walletAddress,
+                auth_user_id: authUserId,
+                status: 'pending',
+                verified: false,
+                country: country || null,
+                accreditation_ref: accreditationRef || null,
+                internal_notes: internalNotes || null,
+                created_by_admin_id: adminCheck.userId,
+                invited_at: invitedAt.toISOString(),
+                invite_expires_at: inviteExpiresAt.toISOString(),
+            })
+            .select('id, name, email, wallet_address, status, created_at')
+            .single();
+
+        if (insertError || !institution) {
+            structuredLog('ERROR', 'Failed to insert the institution row', requestId, {
+                error: insertError,
+            });
+            return NextResponse.json(
+                { success: false, error: 'Failed to create the institution record' },
+                { status: 500 },
+            );
+        }
+
+        // 5. Link the POC through institution_users so the institution is never
+        //    dependent on a single denormalised column.
+        const { error: linkError } = await supabase.from('institution_users').upsert(
+            {
+                institution_id: institution.id,
+                auth_user_id: authUserId,
+                role: 'poc',
+                is_active: true,
+            },
+            { onConflict: 'institution_id,auth_user_id' },
+        );
+
+        if (linkError) {
+            structuredLog('WARN', 'Failed to link the POC to the institution', requestId, {
+                error: linkError,
+                institutionId: institution.id,
+            });
+        }
+
+        // 6. Single-use invite link. Supabase mails it as well, but an admin
+        //    must never be unable to onboard because of a mail problem, so the
+        //    link is returned for copying too.
+        const origin = request.nextUrl.origin || 'http://localhost:3000';
+        const redirectTo = `${origin}/auth/accept-invite?next=/dashboard`;
+
+        const { data: linkData, error: linkGenerationError } =
+            await supabase.auth.admin.generateLink({
+                type: 'invite',
+                email: normalizedEmail,
+                options: { redirectTo },
+            });
+
+        const inviteLink = linkData?.properties?.action_link ?? null;
+
+        if (linkGenerationError) {
+            structuredLog('WARN', 'Invite link generation failed after provisioning', requestId, {
+                error: linkGenerationError,
+                institutionId: institution.id,
+            });
+        }
+
+        // 7. Audit trail: who provisioned this, when, and on what basis.
+        const { error: auditError } = await supabase.from('admin_audit_logs').insert({
+            action: 'create_institution',
+            actor_admin_id: adminCheck.userId,
+            target_institution_id: institution.id,
+            new_poc_email: normalizedEmail,
+            new_poc_id: authUserId,
+            details: {
+                institutionName: name,
+                pocName,
+                walletAddress,
+                country: country || null,
+                accreditationRef: accreditationRef || null,
+                notes: internalNotes || null,
+                inviteGenerated: Boolean(inviteLink),
+                inviteExpiresAt: inviteExpiresAt.toISOString(),
+                walletAuthorizedOnChain: false,
+            },
+        });
+
+        if (auditError) {
+            structuredLog('WARN', 'Failed to record the provisioning audit log', requestId, {
+                error: auditError,
+            });
+        }
+
+        structuredLog('INFO', 'Provisioned institution', requestId, {
+            institutionId: institution.id,
+            adminId: adminCheck.userId,
+            inviteGenerated: Boolean(inviteLink),
+        });
+
+        return NextResponse.json(
+            {
+                success: true,
+                institution: {
+                    id: institution.id,
+                    name: institution.name,
+                    email: institution.email,
+                    walletAddress: institution.wallet_address ?? null,
+                    status: institution.status ?? 'pending',
+                    createdAt: institution.created_at ?? null,
+                },
+                inviteLink,
+                inviteExpiresAt: inviteExpiresAt.toISOString(),
+                message: inviteLink
+                    ? 'Institution provisioned. Copy the single-use invite link for the POC.'
+                    : 'Institution provisioned, but the invite link could not be generated. Regenerate it from the institution page.',
+            },
+            { status: 201 },
+        );
+    } catch (error) {
+        captureException(error, { context: 'adminCreateInstitution', requestId });
+        return NextResponse.json(
+            { success: false, error: 'Failed to create institution' },
             { status: 500 },
         );
     }

--- a/frontend/src/app/api/auth/accept-invite/route.ts
+++ b/frontend/src/app/api/auth/accept-invite/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceRoleClient, requireAuthenticatedRequest } from '@/lib/serverAuth';
+import { enforceRateLimit } from '@/lib/rateLimit';
+import { structuredLog, captureException } from '@/lib/debug';
+
+export const dynamic = 'force-dynamic';
+
+const ACCEPT_INVITE_RATE_LIMIT = {
+    windowSeconds: 60,
+    maxRequests: 10,
+    prefix: 'accept-invite',
+} as const;
+
+/**
+ * Marks a POC's invite as consumed, once they have exchanged the invite link
+ * for a session and set their own password.
+ *
+ * Only the invited POC can call this: the institution is resolved from the
+ * caller's own verified session, never from the request body, so one POC can
+ * never consume another institution's invite.
+ */
+export async function POST(request: NextRequest) {
+    const requestId = request.headers.get('x-request-id') || 'unknown';
+
+    try {
+        const rateLimitResponse = await enforceRateLimit(request, ACCEPT_INVITE_RATE_LIMIT);
+        if (rateLimitResponse) {
+            return rateLimitResponse;
+        }
+
+        const authCheck = await requireAuthenticatedRequest(request);
+        if (!authCheck.ok) {
+            return NextResponse.json(
+                { success: false, error: authCheck.error },
+                { status: authCheck.status },
+            );
+        }
+
+        const supabase = getServiceRoleClient();
+
+        const { data: institution, error: institutionError } = await supabase
+            .from('institutions')
+            .select('id, name, invited_at, invite_expires_at, invite_accepted_at')
+            .eq('auth_user_id', authCheck.userId)
+            .maybeSingle();
+
+        if (institutionError) {
+            structuredLog('ERROR', 'Failed to load institution for invite acceptance', requestId, {
+                error: institutionError,
+            });
+            return NextResponse.json(
+                { success: false, error: 'Failed to complete onboarding' },
+                { status: 500 },
+            );
+        }
+
+        if (!institution) {
+            return NextResponse.json(
+                { success: false, error: 'No institution is linked to this account' },
+                { status: 404 },
+            );
+        }
+
+        // Already accepted — treat as success so a refreshed acceptance page
+        // does not present the POC with an error for work already done.
+        if (institution.invite_accepted_at) {
+            return NextResponse.json({
+                success: true,
+                alreadyAccepted: true,
+                institution: { id: institution.id, name: institution.name },
+            });
+        }
+
+        const acceptedAt = new Date().toISOString();
+
+        const { error: updateError } = await supabase
+            .from('institutions')
+            .update({ invite_accepted_at: acceptedAt })
+            .eq('id', institution.id);
+
+        if (updateError) {
+            structuredLog('ERROR', 'Failed to mark the invite as accepted', requestId, {
+                error: updateError,
+                institutionId: institution.id,
+            });
+            return NextResponse.json(
+                { success: false, error: 'Failed to complete onboarding' },
+                { status: 500 },
+            );
+        }
+
+        const { error: auditError } = await supabase.from('admin_audit_logs').insert({
+            action: 'accept_invite',
+            target_institution_id: institution.id,
+            new_poc_id: authCheck.userId,
+            new_poc_email: authCheck.user.email ?? null,
+            details: {
+                acceptedAt,
+                invitedAt: institution.invited_at ?? null,
+                inviteExpiresAt: institution.invite_expires_at ?? null,
+            },
+        });
+
+        if (auditError) {
+            structuredLog('WARN', 'Failed to record the invite acceptance audit log', requestId, {
+                error: auditError,
+            });
+        }
+
+        structuredLog('INFO', 'Institution POC accepted their invite', requestId, {
+            institutionId: institution.id,
+            userId: authCheck.userId,
+        });
+
+        return NextResponse.json({
+            success: true,
+            alreadyAccepted: false,
+            institution: { id: institution.id, name: institution.name },
+        });
+    } catch (error) {
+        captureException(error, { context: 'acceptInvite', requestId });
+        return NextResponse.json(
+            { success: false, error: 'Failed to complete onboarding' },
+            { status: 500 },
+        );
+    }
+}

--- a/frontend/src/app/auth/accept-invite/page.tsx
+++ b/frontend/src/app/auth/accept-invite/page.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { AuthShell } from '@/components/auth/AuthShell';
+import { cn } from '@/lib/utils';
+import {
+    getErrorMessage,
+    getPasswordRequirements,
+    getPasswordValidationError,
+    sanitizeAuthRedirect,
+} from '@/lib/authFlow';
+import { safeGetSession, supabase, updatePassword } from '@/lib/supabase';
+import { captureException } from '@/lib/debug';
+
+/**
+ * Invite acceptance for an institution POC.
+ *
+ * The admin console provisions the account with no password and issues a
+ * single-use invite link; following it establishes a session, and this page is
+ * where the POC chooses their own password. Acredia staff never see it.
+ */
+function AcceptInviteForm() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const nextRedirect = sanitizeAuthRedirect(searchParams.get('next'));
+
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [checkingSession, setCheckingSession] = useState(true);
+    const [hasInviteSession, setHasInviteSession] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+    const [accepted, setAccepted] = useState(false);
+
+    const passwordRequirements = getPasswordRequirements(password);
+
+    useEffect(() => {
+        let mounted = true;
+        let sessionTimeout: ReturnType<typeof setTimeout> | undefined;
+
+        const finishChecking = (ready: boolean) => {
+            if (!mounted) {
+                return;
+            }
+
+            setHasInviteSession(ready);
+            setCheckingSession(false);
+        };
+
+        const {
+            data: { subscription },
+        } = supabase.auth.onAuthStateChange((event, session) => {
+            if (event === 'PASSWORD_RECOVERY' || event === 'SIGNED_IN' || session?.user) {
+                finishChecking(true);
+            }
+        });
+
+        safeGetSession()
+            .then(({ data: { session } }) => {
+                if (session?.user) {
+                    finishChecking(true);
+                    return;
+                }
+
+                sessionTimeout = setTimeout(() => finishChecking(false), 1500);
+            })
+            .catch(() => {
+                sessionTimeout = setTimeout(() => finishChecking(false), 1500);
+            });
+
+        return () => {
+            mounted = false;
+            subscription.unsubscribe();
+            if (sessionTimeout) {
+                clearTimeout(sessionTimeout);
+            }
+        };
+    }, []);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError('');
+
+        const passwordError = getPasswordValidationError(password);
+        if (passwordError) {
+            setError(passwordError);
+            return;
+        }
+
+        if (password !== confirmPassword) {
+            setError('Passwords do not match.');
+            return;
+        }
+
+        setLoading(true);
+
+        try {
+            const { error: updateError } = await updatePassword(password);
+
+            if (updateError) {
+                setError(updateError.message);
+                return;
+            }
+
+            setPassword('');
+            setConfirmPassword('');
+            setAccepted(true);
+
+            // Record that onboarding completed. A failure here must not block
+            // the POC — their password is already set and they can sign in.
+            try {
+                const {
+                    data: { session },
+                } = await safeGetSession();
+
+                if (session?.access_token) {
+                    await fetch('/api/auth/accept-invite', {
+                        method: 'POST',
+                        headers: {
+                            Authorization: `Bearer ${session.access_token}`,
+                        },
+                    });
+                }
+            } catch (markError) {
+                captureException(markError, { context: 'acceptInviteMark' });
+            }
+        } catch (err: unknown) {
+            setError(getErrorMessage(err, 'Unable to set your password'));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <AuthShell
+            title="Set up your Acredia account"
+            subtitle="Choose a password to finish activating your institution's account."
+            footer={
+                <p className="text-center text-sm text-muted-foreground">
+                    <Link
+                        href={`/auth/login?next=${encodeURIComponent(nextRedirect)}`}
+                        className="font-semibold text-primary hover:underline"
+                    >
+                        Back to sign in
+                    </Link>
+                </p>
+            }
+        >
+            {checkingSession && (
+                <div
+                    className="rounded-lg border border-info/25 bg-info/8 px-4 py-3 text-sm text-info"
+                    role="status"
+                >
+                    Checking your invite link…
+                </div>
+            )}
+
+            {!checkingSession && !hasInviteSession && (
+                <div
+                    className="rounded-lg border border-destructive/25 bg-destructive/8 px-4 py-3 text-sm text-destructive"
+                    role="alert"
+                >
+                    This invite link is invalid, has already been used, or has expired. Contact your
+                    Acredia administrator to have a new invite issued.
+                </div>
+            )}
+
+            {!checkingSession && hasInviteSession && !accepted && (
+                <form onSubmit={handleSubmit} className="space-y-5">
+                    <div className="space-y-2">
+                        <Label htmlFor="password">Choose a password</Label>
+                        <Input
+                            id="password"
+                            type="password"
+                            placeholder="••••••••"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            required
+                            autoComplete="new-password"
+                            aria-describedby="password-requirements"
+                        />
+                        <ul id="password-requirements" className="mt-2 grid gap-1.5 text-sm">
+                            {passwordRequirements.map((requirement) => (
+                                <li
+                                    key={requirement.id}
+                                    className={cn(
+                                        'flex items-center gap-2',
+                                        requirement.isMet ? 'text-success' : 'text-muted-foreground',
+                                    )}
+                                >
+                                    <CheckCircle2
+                                        className={cn(
+                                            'h-4 w-4',
+                                            requirement.isMet
+                                                ? 'text-success'
+                                                : 'text-muted-foreground/40',
+                                        )}
+                                        aria-hidden="true"
+                                    />
+                                    <span>{requirement.label}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="confirm-password">Confirm password</Label>
+                        <Input
+                            id="confirm-password"
+                            type="password"
+                            placeholder="••••••••"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            required
+                            autoComplete="new-password"
+                            aria-invalid={Boolean(confirmPassword) && password !== confirmPassword}
+                        />
+                    </div>
+
+                    {error && (
+                        <div
+                            className="rounded-lg border border-destructive/25 bg-destructive/8 px-4 py-3 text-sm text-destructive"
+                            role="alert"
+                        >
+                            {error}
+                        </div>
+                    )}
+
+                    <Button type="submit" size="lg" disabled={loading} className="w-full">
+                        {loading ? 'Activating account…' : 'Activate account'}
+                    </Button>
+                </form>
+            )}
+
+            {accepted && (
+                <div className="space-y-4">
+                    <div
+                        className="rounded-lg border border-success/25 bg-success/8 px-4 py-3 text-sm text-success"
+                        role="status"
+                    >
+                        Your account is active. Your institution's wallet still needs to be
+                        authorized by Acredia before you can issue credentials.
+                    </div>
+                    <Button
+                        type="button"
+                        size="lg"
+                        onClick={() => router.push(nextRedirect)}
+                        className="w-full"
+                    >
+                        Continue to your dashboard
+                    </Button>
+                </div>
+            )}
+        </AuthShell>
+    );
+}
+
+export default function AcceptInvitePage() {
+    return (
+        <Suspense
+            fallback={
+                <div className="flex min-h-screen items-center justify-center bg-background">
+                    <div className="text-muted-foreground">Loading…</div>
+                </div>
+            }
+        >
+            <AcceptInviteForm />
+        </Suspense>
+    );
+}

--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -32,7 +32,14 @@ export interface AdminInstitutionSummary {
     credentialCount: number;
     activeCredentialCount: number;
     poc?: AdminPocInfo | null;
+    onboardingState?: OnboardingState;
+    invitedAt?: string | null;
+    inviteExpiresAt?: string | null;
+    inviteAcceptedAt?: string | null;
 }
+
+/** Provisioning progress: invited -> active -> wallet authorized. */
+export type OnboardingState = 'invited' | 'invite_expired' | 'active' | 'wallet_authorized';
 
 export interface AdminInstitutionCredential {
     id: string;
@@ -105,4 +112,28 @@ const STATUS_STYLES: Record<string, string> = {
 
 export function statusBadgeClass(status: string): string {
     return STATUS_STYLES[status] ?? 'bg-secondary text-muted-foreground border-border';
+}
+
+const ONBOARDING_LABELS: Record<OnboardingState, string> = {
+    invited: 'Invited',
+    invite_expired: 'Invite expired',
+    active: 'Active',
+    wallet_authorized: 'Wallet authorized',
+};
+
+const ONBOARDING_STYLES: Record<OnboardingState, string> = {
+    invited: 'bg-info/12 text-info border-info/25',
+    invite_expired: 'bg-destructive/12 text-destructive border-destructive/25',
+    active: 'bg-warning/12 text-warning border-warning/25',
+    wallet_authorized: 'bg-success/12 text-success border-success/25',
+};
+
+export function onboardingLabel(state: OnboardingState | undefined): string {
+    return state ? ONBOARDING_LABELS[state] : '—';
+}
+
+export function onboardingBadgeClass(state: OnboardingState | undefined): string {
+    return state
+        ? ONBOARDING_STYLES[state]
+        : 'bg-secondary text-muted-foreground border-border';
 }

--- a/frontend/supabase/migrations/20260807000000_institution_provisioning.sql
+++ b/frontend/supabase/migrations/20260807000000_institution_provisioning.sql
@@ -1,0 +1,67 @@
+-- =====================================================================
+-- ACREDIA-STELLAR — ADMIN INSTITUTION PROVISIONING (IDEMPOTENT)
+-- Issue #240: Admin provisions institutions and issues invite links
+-- =====================================================================
+-- What this file does:
+--   1. Adds provisioning metadata columns to `public.institutions`
+--      (country, accreditation reference, internal notes, provisioning admin).
+--   2. Adds onboarding-state timestamps so a half-finished onboarding is
+--      visible: invited -> active -> wallet authorized.
+--   3. Extends the `admin_audit_logs.action` check constraint with the
+--      provisioning actions introduced by this issue.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Provisioning metadata + onboarding state on institutions
+-- ---------------------------------------------------------------------
+ALTER TABLE public.institutions
+    ADD COLUMN IF NOT EXISTS poc_name              TEXT,
+    ADD COLUMN IF NOT EXISTS country               TEXT,
+    ADD COLUMN IF NOT EXISTS accreditation_ref     TEXT,
+    ADD COLUMN IF NOT EXISTS internal_notes        TEXT,
+    ADD COLUMN IF NOT EXISTS created_by_admin_id   UUID REFERENCES auth.users (id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS invited_at            TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS invite_expires_at     TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS invite_accepted_at    TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN public.institutions.created_by_admin_id IS
+    'Admin who provisioned this institution. Part of the provisioning audit trail (see admin_audit_logs).';
+
+COMMENT ON COLUMN public.institutions.invited_at IS
+    'When the current invite link was generated. Regenerating an invite moves this forward and invalidates the previous link.';
+
+COMMENT ON COLUMN public.institutions.invite_accepted_at IS
+    'When the POC consumed the invite and set their own password. NULL means onboarding is still pending.';
+
+COMMENT ON COLUMN public.institutions.internal_notes IS
+    'Acredia-internal provisioning notes. Never exposed to institution users.';
+
+-- Surfacing "who still has not accepted their invite" is the primary
+-- onboarding query, so index the pending case directly.
+CREATE INDEX IF NOT EXISTS idx_institutions_pending_invites
+    ON public.institutions (invited_at DESC)
+    WHERE invite_accepted_at IS NULL;
+
+-- ---------------------------------------------------------------------
+-- 2. Extend the audit action vocabulary with provisioning actions
+-- ---------------------------------------------------------------------
+ALTER TABLE public.admin_audit_logs
+    DROP CONSTRAINT IF EXISTS admin_audit_logs_action_check;
+
+ALTER TABLE public.admin_audit_logs
+    ADD CONSTRAINT admin_audit_logs_action_check CHECK (
+        action IN (
+            'poc_handover',
+            'generate_recovery_link',
+            'generate_invite_link',
+            'regenerate_invite_link',
+            'deactivate_account',
+            'update_institution',
+            'create_institution',
+            'accept_invite'
+        )
+    );
+
+COMMIT;

--- a/frontend/supabase/schema.sql
+++ b/frontend/supabase/schema.sql
@@ -1740,3 +1740,71 @@ ON CONFLICT (institution_id, auth_user_id) DO NOTHING;
 COMMIT;
 
 
+
+-- =====================================================================
+-- ACREDIA-STELLAR — ADMIN INSTITUTION PROVISIONING (IDEMPOTENT)
+-- Issue #240: Admin provisions institutions and issues invite links
+-- =====================================================================
+-- What this file does:
+--   1. Adds provisioning metadata columns to `public.institutions`
+--      (country, accreditation reference, internal notes, provisioning admin).
+--   2. Adds onboarding-state timestamps so a half-finished onboarding is
+--      visible: invited -> active -> wallet authorized.
+--   3. Extends the `admin_audit_logs.action` check constraint with the
+--      provisioning actions introduced by this issue.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Provisioning metadata + onboarding state on institutions
+-- ---------------------------------------------------------------------
+ALTER TABLE public.institutions
+    ADD COLUMN IF NOT EXISTS poc_name              TEXT,
+    ADD COLUMN IF NOT EXISTS country               TEXT,
+    ADD COLUMN IF NOT EXISTS accreditation_ref     TEXT,
+    ADD COLUMN IF NOT EXISTS internal_notes        TEXT,
+    ADD COLUMN IF NOT EXISTS created_by_admin_id   UUID REFERENCES auth.users (id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS invited_at            TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS invite_expires_at     TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS invite_accepted_at    TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN public.institutions.created_by_admin_id IS
+    'Admin who provisioned this institution. Part of the provisioning audit trail (see admin_audit_logs).';
+
+COMMENT ON COLUMN public.institutions.invited_at IS
+    'When the current invite link was generated. Regenerating an invite moves this forward and invalidates the previous link.';
+
+COMMENT ON COLUMN public.institutions.invite_accepted_at IS
+    'When the POC consumed the invite and set their own password. NULL means onboarding is still pending.';
+
+COMMENT ON COLUMN public.institutions.internal_notes IS
+    'Acredia-internal provisioning notes. Never exposed to institution users.';
+
+-- Surfacing "who still has not accepted their invite" is the primary
+-- onboarding query, so index the pending case directly.
+CREATE INDEX IF NOT EXISTS idx_institutions_pending_invites
+    ON public.institutions (invited_at DESC)
+    WHERE invite_accepted_at IS NULL;
+
+-- ---------------------------------------------------------------------
+-- 2. Extend the audit action vocabulary with provisioning actions
+-- ---------------------------------------------------------------------
+ALTER TABLE public.admin_audit_logs
+    DROP CONSTRAINT IF EXISTS admin_audit_logs_action_check;
+
+ALTER TABLE public.admin_audit_logs
+    ADD CONSTRAINT admin_audit_logs_action_check CHECK (
+        action IN (
+            'poc_handover',
+            'generate_recovery_link',
+            'generate_invite_link',
+            'regenerate_invite_link',
+            'deactivate_account',
+            'update_institution',
+            'create_institution',
+            'accept_invite'
+        )
+    );
+
+COMMIT;


### PR DESCRIPTION
close #240


Summary
Implemented issue #240. A good deal of groundwork already existed from Issue 14 (admin_audit_logs, institution_users, POC handover, the recovery/invite link generator), so I built on it rather than duplicating it.

Migration — [20260807000000_institution_provisioning.sql](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/supabase/migrations/20260807000000_institution_provisioning.sql), mirrored into [schema.sql](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/supabase/schema.sql):

Provisioning columns on institutions: poc_name, country, accreditation_ref, internal_notes, created_by_admin_id, and onboarding timestamps invited_at / invite_expires_at / invite_accepted_at; partial index on pending invites.
Extended the admin_audit_logs.action constraint with create_institution, regenerate_invite_link, accept_invite.
POST /api/admin/institutions ([route.ts](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/src/app/api/admin/institutions/route.ts)) — creates the institution as pending, provisions the POC auth user with no password, links it via institution_users, generates a 7-day single-use invite, and audit-logs the whole thing. Wallet is recorded but never authorized on-chain. Rate-limited at 10/min, admin-guarded server-side via the existing requireAdminRequest. The GET now also derives and returns onboardingState (invited → invite_expired → active → wallet_authorized).

Invite regeneration ([recovery-link/route.ts](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/src/app/api/admin/institutions/%5Bid%5D/recovery-link/route.ts)) — invites now redirect to the acceptance page, advance the invite window (Supabase invalidates the old token), and log regenerate_invite_link distinctly.

Acceptance — new [accept-invite page](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/src/app/auth/accept-invite/page.tsx) where the POC sets their own password, and [POST /api/auth/accept-invite](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/src/app/api/auth/accept-invite/route.ts) which marks it consumed. That route resolves the institution from the caller's own verified session rather than the request body, so one POC can't consume another's invite.

UI ([institutions/page.tsx](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/src/app/admin/institutions/page.tsx)) — "Add institution" dialog capturing all required and optional fields, showing the invite link with a copy button on success; onboarding badge added to both the table and mobile cards.

Two things worth flagging:

The duplicate check. My first version used .or(\email.eq.${email},...`), which splices user input into PostgREST filter syntax. Zod made it non-exploitable in practice, but I rewrote it as two eq` queries so the safety is structural rather than dependent on validation upstream.
Existing test failures. The suite sits at 5 failed / 437 passed both before and after my changes — socialMetadata, retentionEnforcement, pocHandover, and adminRecoveryLink (403s from an unconfigured admin allowlist in the test env). All pre-existing; I did not fix them as they're outside this issue. One caveat: an earlier run showed 8 failures including a serverAuth.institution timeout — that test passes in isolation, so it's a flake under parallel load, not a regression.
Two acceptance criteria I did not implement, since both are marked out of scope or deferred: actual email delivery (Supabase mails the invite as a side effect of generateLink, but custom SMTP configuration is Issue 14's) and bulk import. POC replacement from the detail page already existed and I left it untouched.