### PR TITLE
feat(verify): add shared verification cache — Issue #228

### DIFF
--- a/frontend/src/app/api/verify/[token]/route.ts
+++ b/frontend/src/app/api/verify/[token]/route.ts
@@ -16,6 +16,13 @@ import {
 } from '@/lib/verificationAudit';
 import { captureException, recordMetric } from '@/lib/debug';
 import { hashApiKey } from '@/lib/apiKey';
+import {
+    getCachedImmutableData,
+    setCachedImmutableData,
+    getCachedRevocationStatus,
+    setCachedRevocationStatus,
+    RESPONSE_CACHE_MAX_AGE_SECONDS,
+} from '@/lib/verificationCache';
 
 export type IntegrityStatus = 'match' | 'mismatch' | 'unavailable';
 
@@ -24,6 +31,8 @@ export interface IntegrityResult {
     cidResolved: boolean;
 }
 
+// Dynamic rendering is required because we read request headers (IP, API key).
+// The response Cache-Control header allows CDN/browser caching of the payload.
 export const dynamic = 'force-dynamic';
 
 const MAX_TOKEN_LENGTH = 128;
@@ -292,13 +301,61 @@ export async function GET(
 
         credentialId = data.id;
 
-        const [onChain, onChainRevoked, issuerAuthorized] = await Promise.all([
-            getCredential(data.token_id),
-            isRevoked(data.token_id),
+        // ------------------------------------------------------------------
+        // Cache layer — Issue #228
+        // Immutable data (on-chain credential + IPFS integrity) is cached with
+        // a long TTL. Revocation status uses a short TTL so that a revocation
+        // event propagates to verifiers within its documented window.
+        // All cache helpers return `null` on a miss or Redis unavailability
+        // so we fall through to the live chain/IPFS path transparently.
+        // ------------------------------------------------------------------
+        const tokenId = data.token_id;
+
+        // 1. Try the immutable cache (skips RPC + IPFS fetch on a hit).
+        const cachedImmutable = await getCachedImmutableData(tokenId);
+        let onChain = cachedImmutable?.onChain ?? null;
+        let integrity = cachedImmutable?.integrity ?? null;
+        const immutableCacheHit = cachedImmutable !== null;
+
+        // 2. Revocation is always re-checked with its own short TTL.
+        let cachedRevoked = await getCachedRevocationStatus(tokenId);
+        const revocationCacheHit = cachedRevoked !== null;
+
+        // 3. On an immutable cache miss, do the real chain + IPFS work.
+        if (!immutableCacheHit) {
+            onChain = await getCredential(tokenId);
+            integrity = await checkIntegrity(
+                onChain?.uri,
+                onChain?.hash,
+                data.metadata_schema_version,
+                data.hash_algorithm,
+            );
+            // Write immutable results to cache in the background — don't block.
+            void setCachedImmutableData(tokenId, {
+                onChain,
+                integrity: integrity ?? { status: 'unavailable', cidResolved: false },
+            });
+        }
+
+        // 4. On a revocation cache miss, fetch live and cache the result.
+        if (!revocationCacheHit) {
+            cachedRevoked = await isRevoked(tokenId);
+            void setCachedRevocationStatus(tokenId, cachedRevoked);
+        }
+        const onChainRevoked = cachedRevoked ?? false;
+
+        // issuerAuthorized is not cached — it's a cheap single Supabase lookup
+        // and is not on the hot path of repeated public verification.
+        const issuerAuthorized =
             data.issuer_wallet_address && typeof isAuthorizedIssuer === 'function'
-                ? isAuthorizedIssuer(data.issuer_wallet_address)
-                : Promise.resolve(false),
-        ]);
+                ? await isAuthorizedIssuer(data.issuer_wallet_address)
+                : false;
+
+        recordMetric('verification.cache.status', 1, {
+            immutableHit: immutableCacheHit,
+            revocationHit: revocationCacheHit,
+            tokenId,
+        });
 
         const dbHash = data.metadata
             ? await deriveCredentialHash(
@@ -330,26 +387,21 @@ export async function GET(
             checks.hashMatch === true &&
             checks.uriMatch === true;
 
+        // integrity is guaranteed non-null here: either from cache or from
+        // the live checkIntegrity() call above. Fall back defensively.
+        const safeIntegrity: IntegrityResult = integrity ?? { status: 'unavailable', cidResolved: false };
+
         const revoked = Boolean(onChainRevoked || data.revoked);
         const verified = onChain !== null && onChainMatch && !revoked;
         const resultType = getResultType(verified, revoked);
 
-        // Recompute the hash of the document actually fetched from IPFS (not
-        // the database's cached copy) and compare it to the on-chain hash —
-        // proves the CID resolves *and* that its content is what was
-        // anchored, independent of `checks.hashMatch` above.
-        const integrity = await checkIntegrity(
-            onChain?.uri,
-            onChain?.hash,
-            data.metadata_schema_version,
-            data.hash_algorithm,
-        );
-
         const mismatchReasons = [
             ...(resultType === 'mismatch' ? getMismatchReasons(checks) : []),
-            ...(integrity.status === 'mismatch' ? ['ipfs_integrity'] : []),
+            ...(safeIntegrity.status === 'mismatch' ? ['ipfs_integrity'] : []),
         ];
 
+        // Audit log is unconditional — every attempt is recorded whether the
+        // result came from cache or from live chain/IPFS reads.
         await logVerificationAttempt(supabase, request, token, resultType, 200, {
             credentialId,
             chain: {
@@ -357,7 +409,7 @@ export async function GET(
                 revoked,
                 match: onChainMatch,
             },
-            integrity,
+            integrity: safeIntegrity,
             mismatchReasons,
             apiKeyContext,
         });
@@ -368,42 +420,54 @@ export async function GET(
 
         const credentialData = data.metadata?.credentialData ?? {};
 
-        return NextResponse.json({
-            success: true,
-            credential: {
-                tokenId: data.token_id,
-                issuedAt: data.issued_at,
-                revoked,
-                revokedAt: data.revoked_at,
-                institutionName: institution?.name ?? credentialData.institutionName ?? null,
-                credentialType: credentialData.credentialType ?? null,
-                degree: credentialData.degree ?? null,
-                major: credentialData.major ?? null,
-                issueDate: credentialData.issueDate ?? null,
-                // Stellar account addresses, not sensitive: already readable
-                // on-chain by anyone who queries this token_id directly.
-                studentWallet: onChain?.student ?? data.student_wallet_address ?? null,
-                institutionWallet: onChain?.issuer ?? data.issuer_wallet_address ?? null,
-                metadataSchemaVersion: data.metadata_schema_version ?? null,
-                hashAlgorithm: data.hash_algorithm ?? null,
-                onChainHash: onChain?.hash ?? null,
-                blockchainHash: data.blockchain_hash ?? null,
-                ipfsHash: data.ipfs_hash ?? null,
+        // HTTP Cache-Control: CDN/browsers may cache this public response for the
+        // same duration as the revocation TTL — ensuring a revocation event
+        // propagates to all cached copies within the documented window.
+        // stale-while-revalidate lets CDNs serve the old response while they
+        // refresh it in the background, preventing latency spikes on expiry.
+        const cacheControl = `public, s-maxage=${RESPONSE_CACHE_MAX_AGE_SECONDS}, stale-while-revalidate=30`;
+
+        return NextResponse.json(
+            {
+                success: true,
+                credential: {
+                    tokenId: data.token_id,
+                    issuedAt: data.issued_at,
+                    revoked,
+                    revokedAt: data.revoked_at,
+                    institutionName: institution?.name ?? credentialData.institutionName ?? null,
+                    credentialType: credentialData.credentialType ?? null,
+                    degree: credentialData.degree ?? null,
+                    major: credentialData.major ?? null,
+                    issueDate: credentialData.issueDate ?? null,
+                    // Stellar account addresses, not sensitive: already readable
+                    // on-chain by anyone who queries this token_id directly.
+                    studentWallet: onChain?.student ?? data.student_wallet_address ?? null,
+                    institutionWallet: onChain?.issuer ?? data.issuer_wallet_address ?? null,
+                    metadataSchemaVersion: data.metadata_schema_version ?? null,
+                    hashAlgorithm: data.hash_algorithm ?? null,
+                    onChainHash: onChain?.hash ?? null,
+                    blockchainHash: data.blockchain_hash ?? null,
+                    ipfsHash: data.ipfs_hash ?? null,
+                },
+                verification: {
+                    verified,
+                    revoked,
+                    onChainMatch,
+                    onChainFound: onChain !== null,
+                    issuerAuthorized,
+                    issuerStatus: issuerAuthorized ? 'active' : 'revoked',
+                    // Distinct from `revoked`/`onChainFound`: proves the actual
+                    // IPFS-hosted document — not the DB's cached copy — hashes to
+                    // the on-chain value. 'unavailable' means the CID couldn't be
+                    // resolved/checked, not that anything is wrong.
+                    integrity: safeIntegrity,
+                },
             },
-            verification: {
-                verified,
-                revoked,
-                onChainMatch,
-                onChainFound: onChain !== null,
-                issuerAuthorized,
-                issuerStatus: issuerAuthorized ? 'active' : 'revoked',
-                // Distinct from `revoked`/`onChainFound`: proves the actual
-                // IPFS-hosted document — not the DB's cached copy — hashes to
-                // the on-chain value. 'unavailable' means the CID couldn't be
-                // resolved/checked, not that anything is wrong.
-                integrity,
+            {
+                headers: { 'Cache-Control': cacheControl },
             },
-        });
+        );
     } catch (err: unknown) {
         if (err instanceof ContractConfigurationError) {
             captureException(err, { requestId, context: 'GET /api/verify/[token]' });

--- a/frontend/src/lib/verificationCache.ts
+++ b/frontend/src/lib/verificationCache.ts
@@ -1,0 +1,171 @@
+﻿/**
+ * Shared verification result cache — Issue #228.
+ *
+ * Caches the two expensive, immutable parts of credential verification:
+ *   1. The on-chain credential record (hash + URI + wallets)
+ *   2. The IPFS integrity result (fetched document hash comparison)
+ *
+ * Revocation status is stored with a much shorter TTL so that a revocation
+ * event propagates to verifiers within its documented window.
+ *
+ * The cache is backed by the same Upstash Redis instance used for rate
+ * limiting (pure REST — no new npm dependency). If Upstash is not configured
+ * or is temporarily unreachable every function returns `null`, which callers
+ * treat as a cache miss and fall back to the live chain/IPFS path.
+ */
+
+import { captureException, recordMetric } from './debug';
+import type { OnChainCredential } from './contractReads';
+import type { IntegrityResult } from '@/app/api/verify/[token]/route';
+
+// ---------------------------------------------------------------------------
+// TTLs
+// ---------------------------------------------------------------------------
+
+/** On-chain credential data and IPFS integrity are immutable once written. */
+const IMMUTABLE_TTL_SECONDS = 4 * 60 * 60; // 4 hours
+
+/** Revocation can change — keep the stale window short. */
+const REVOCATION_TTL_SECONDS = 45;
+
+// ---------------------------------------------------------------------------
+// Upstash REST helpers (mirrors the pattern in rateLimit.ts)
+// ---------------------------------------------------------------------------
+
+function getUpstashConfig(): { url: string; token: string } | null {
+    const url = process.env.UPSTASH_REDIS_REST_URL?.replace(/\/$/, '');
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) return null;
+    return { url, token };
+}
+
+async function redisGet(key: string): Promise<string | null> {
+    const cfg = getUpstashConfig();
+    if (!cfg) return null;
+
+    try {
+        const res = await fetch(`${cfg.url}/get/${encodeURIComponent(key)}`, {
+            headers: { Authorization: `Bearer ${cfg.token}` },
+            signal: AbortSignal.timeout(3_000),
+        });
+        if (!res.ok) return null;
+        const body = (await res.json()) as { result?: string | null };
+        return body.result ?? null;
+    } catch (err) {
+        captureException(err, { context: 'verificationCache.redisGet', key });
+        return null;
+    }
+}
+
+async function redisSet(key: string, value: string, ttlSeconds: number): Promise<void> {
+    const cfg = getUpstashConfig();
+    if (!cfg) return;
+
+    try {
+        await fetch(`${cfg.url}/set/${encodeURIComponent(key)}`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${cfg.token}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify([value, 'EX', ttlSeconds]),
+            signal: AbortSignal.timeout(3_000),
+        });
+    } catch (err) {
+        // Fire-and-forget: a write failure just means a future cache miss.
+        captureException(err, { context: 'verificationCache.redisSet', key });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cache key builders
+// ---------------------------------------------------------------------------
+
+function immutableKey(tokenId: string): string {
+    return `verify:immutable:${tokenId}`;
+}
+
+function revocationKey(tokenId: string): string {
+    return `verify:revoked:${tokenId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Immutable verification data (on-chain credential + IPFS integrity)
+// ---------------------------------------------------------------------------
+
+export interface CachedImmutableData {
+    onChain: OnChainCredential | null;
+    integrity: IntegrityResult;
+}
+
+/**
+ * Returns the cached immutable verification data for `tokenId`, or `null` on
+ * a miss / parse error / Redis unavailability.
+ */
+export async function getCachedImmutableData(
+    tokenId: string,
+): Promise<CachedImmutableData | null> {
+    const raw = await redisGet(immutableKey(tokenId));
+    if (!raw) return null;
+
+    try {
+        const parsed = JSON.parse(raw) as CachedImmutableData;
+        recordMetric('verification.cache.hit', 1, { kind: 'immutable', tokenId });
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Stores the immutable verification data for `tokenId` with a long TTL.
+ * Never throws — a write failure is silently ignored.
+ */
+export async function setCachedImmutableData(
+    tokenId: string,
+    data: CachedImmutableData,
+): Promise<void> {
+    await redisSet(immutableKey(tokenId), JSON.stringify(data), IMMUTABLE_TTL_SECONDS);
+    recordMetric('verification.cache.write', 1, { kind: 'immutable', tokenId });
+}
+
+// ---------------------------------------------------------------------------
+// Revocation status (short TTL — must not serve stale revocations too long)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the cached revocation flag, or `null` if not cached.
+ * `null` means: re-fetch from the live source.
+ */
+export async function getCachedRevocationStatus(
+    tokenId: string,
+): Promise<boolean | null> {
+    const raw = await redisGet(revocationKey(tokenId));
+    if (raw === null) return null;
+
+    // Stored as the string "1" (revoked) or "0" (not revoked).
+    const value = raw === '1' ? true : raw === '0' ? false : null;
+    if (value !== null) {
+        recordMetric('verification.cache.hit', 1, { kind: 'revocation', tokenId });
+    }
+    return value;
+}
+
+/**
+ * Stores the revocation flag with a short TTL.
+ * Never throws.
+ */
+export async function setCachedRevocationStatus(
+    tokenId: string,
+    revoked: boolean,
+): Promise<void> {
+    await redisSet(revocationKey(tokenId), revoked ? '1' : '0', REVOCATION_TTL_SECONDS);
+    recordMetric('verification.cache.write', 1, { kind: 'revocation', tokenId });
+}
+
+// ---------------------------------------------------------------------------
+// Documented TTLs (for HTTP Cache-Control header in the route)
+// ---------------------------------------------------------------------------
+
+/** Maximum seconds a CDN/browser may cache a verification response. */
+export const RESPONSE_CACHE_MAX_AGE_SECONDS = REVOCATION_TTL_SECONDS;


### PR DESCRIPTION
- Add frontend/src/lib/verificationCache.ts: Upstash REST-based cache helper (no new npm dependency) with two cache buckets:
    * verify:immutable:<token_id>  — 4-hour TTL for on-chain credential struct and IPFS integrity result (both immutable once written)
    * verify:revoked:<token_id>    — 45-second TTL for revocation flag
      so a revocation propagates to verifiers within the documented window

- All cache helpers return null on Redis unavailability / miss, so the endpoint degrades transparently to the live chain/IPFS path with no error surface change.

- Update GET /api/verify/[token]/route.ts:
    * Wrap getCredential() + checkIntegrity() with getCachedImmutableData() — on a hit, the Soroban RPC round-trip and IPFS download are skipped
    * Wrap isRevoked() with getCachedRevocationStatus() (short TTL)
    * Cache writes are fire-and-forget (void) — never block the response
    * Audit log (writeVerificationAuditLog) fires unconditionally on every request whether served from cache or live reads
    * Add verification.cache.status metric with immutableHit / revocationHit flags for observability
    * Add Cache-Control: public, s-maxage=45, stale-while-revalidate=30 response header so CDN/browsers can cache the public response up to the revocation TTL

Closes #228

## Summary
- What changed?
- Why is this needed?

## Testing
- [ ] Lint
- [ ] Unit tests
- [ ] Build
- [ ] Coverage check

## Notes
- Any follow-up items or risks?
