### PR TITLE
Sanitize filenames and secure IPFS upload endpoints

### DIFF
--- a/frontend/src/lib/ipfsServer.ts
+++ b/frontend/src/lib/ipfsServer.ts
@@ -37,6 +37,16 @@ function parsePinataCid(payload: unknown): string {
     return cid.trim();
 }
 
+export function sanitizePinataFilename(name: string): string {
+    // Strip CRLF, non-printable control chars, quotes, and path separators to prevent CRLF injection & header manipulation
+    const sanitized = name
+        .replace(/[\r\n\t\x00-\x1f\x7f-\x9f"/\\]/g, '_')
+        .replace(/^\.+/, '')
+        .trim();
+
+    return sanitized.slice(0, 255) || 'credential_file';
+}
+
 export function validatePinataFile(file: File): string | null {
     if (!ALLOWED_FILE_TYPES.has(file.type)) {
         return 'Invalid file type. Please upload PDF, JPG, or PNG files only.';
@@ -74,9 +84,10 @@ export function validatePinataJson(content: unknown): string | null {
 export async function pinFileToPinata(file: File): Promise<string> {
     const jwt = requirePinataJwt();
     const startedAt = Date.now();
+    const safeFilename = sanitizePinataFilename(file.name);
     const formData = new FormData();
-    formData.append('file', file, file.name);
-    formData.append('pinataMetadata', JSON.stringify({ name: file.name }));
+    formData.append('file', file, safeFilename);
+    formData.append('pinataMetadata', JSON.stringify({ name: safeFilename }));
     formData.append('pinataOptions', JSON.stringify({ cidVersion: 1 }));
 
     const response = await fetch(`${PINATA_API_BASE}/pinFileToIPFS`, {

--- a/frontend/tests/ipfsRoutes.test.ts
+++ b/frontend/tests/ipfsRoutes.test.ts
@@ -237,4 +237,15 @@ describe('IPFS upload routes', () => {
             expect(mockRequireInstitutionRequest).toHaveBeenCalledTimes(20);
         });
     });
+
+    describe('filename sanitization (Issue #233)', () => {
+        it('strips CRLF, control characters, quotes and path separators', async () => {
+            const { sanitizePinataFilename } = await import('../src/lib/ipfsServer');
+            expect(sanitizePinataFilename('test\r\nInjected: header.pdf')).toBe('test__Injected: header.pdf');
+            expect(sanitizePinataFilename('../../../etc/passwd.png')).toBe('etc_passwd.png');
+            expect(sanitizePinataFilename('file"with"quotes.jpg')).toBe('file_with_quotes.jpg');
+            expect(sanitizePinataFilename('   ')).toBe('credential_file');
+        });
+    });
 });
+


### PR DESCRIPTION
close #233 

This pull request adds protection against malicious filenames when uploading files to Pinata by introducing a filename sanitization function. It ensures that uploaded filenames are safe and do not contain control characters, path separators, or other problematic characters, and adds tests to verify this behavior.

**Security improvements:**

* Added a new `sanitizePinataFilename` function in `ipfsServer.ts` to strip CRLF, non-printable control characters, quotes, and path separators from filenames, preventing header injection and path traversal attacks.
* Updated the `pinFileToPinata` function to use sanitized filenames for both the file upload and metadata sent to Pinata.

**Testing:**

* Added tests in `ipfsRoutes.test.ts` to verify that `sanitizePinataFilename` correctly removes dangerous characters and handles edge cases.