### PR TITLE
Implement institution membership model and migration

### DIFF
--- a/frontend/src/app/api/admin/institutions/[id]/poc-handover/route.ts
+++ b/frontend/src/app/api/admin/institutions/[id]/poc-handover/route.ts
@@ -139,7 +139,7 @@ export async function POST(
             // Also mark as inactive in institution_users
             await supabase
                 .from('institution_users')
-                .update({ is_active: false })
+                .update({ status: 'deactivated' })
                 .eq('institution_id', institution.id)
                 .eq('auth_user_id', oldAuthUserId);
         }
@@ -244,8 +244,9 @@ export async function POST(
             {
                 institution_id: institution.id,
                 auth_user_id: newAuthUserId,
-                role: 'poc',
-                is_active: true,
+                role: 'owner',
+                status: 'active',
+                invited_by: adminCheck.userId,
             },
             { onConflict: 'institution_id,auth_user_id' },
         );

--- a/frontend/src/app/api/admin/institutions/route.ts
+++ b/frontend/src/app/api/admin/institutions/route.ts
@@ -382,8 +382,11 @@ export async function POST(request: NextRequest) {
             {
                 institution_id: institution.id,
                 auth_user_id: authUserId,
-                role: 'poc',
-                is_active: true,
+                role: 'owner',
+                // `invited` until they accept — the resolver only grants access
+                // to active members, so the invite is what activates them.
+                status: 'invited',
+                invited_by: adminCheck.userId,
             },
             { onConflict: 'institution_id,auth_user_id' },
         );

--- a/frontend/src/app/api/admin/update-authorization/route.ts
+++ b/frontend/src/app/api/admin/update-authorization/route.ts
@@ -3,6 +3,7 @@ import { getServiceRoleClient, requireAdminRequest } from '@/lib/serverAuth';
 import { verifyAdminAuthorizationTransaction } from '@/lib/adminAuthorizationVerification';
 import { enforceRateLimit } from '@/lib/rateLimit';
 import { structuredLog, captureException } from '@/lib/debug';
+import { resolveInstitutionOwnerId } from '@/lib/institutionMembership';
 
 export const dynamic = 'force-dynamic';
 
@@ -97,13 +98,13 @@ export async function POST(request: NextRequest) {
                 );
             }
 
-            // Enqueue verified notification
-            const { data: userProfile } = await supabase
-                .from('profiles')
-                .select('email')
-                .eq('id', institution.auth_user_id)
-                .single();
-                
+            // Enqueue verified notification to the institution's owner.
+            const ownerId = await resolveInstitutionOwnerId(supabase, institution.id, institution.auth_user_id);
+
+            const { data: userProfile } = ownerId
+                ? await supabase.from('profiles').select('email').eq('id', ownerId).single()
+                : { data: null };
+
             if (userProfile?.email) {
                 await supabase.from('jobs').insert({
                     name: 'send_email',
@@ -111,7 +112,7 @@ export async function POST(request: NextRequest) {
                         to: userProfile.email,
                         subject: 'Institution Verified',
                         type: 'verified',
-                        userId: institution.auth_user_id,
+                        userId: ownerId,
                         payload: {
                             institutionName: institution.name
                         }

--- a/frontend/src/app/api/auth/accept-invite/route.ts
+++ b/frontend/src/app/api/auth/accept-invite/route.ts
@@ -38,11 +38,25 @@ export async function POST(request: NextRequest) {
 
         const supabase = getServiceRoleClient();
 
-        const { data: institution, error: institutionError } = await supabase
-            .from('institutions')
-            .select('id, name, invited_at, invite_expires_at, invite_accepted_at')
+        // The invited member's membership row is created `invited` at
+        // provisioning time, so resolve through it rather than the deprecated
+        // single-login column.
+        const { data: membershipRow } = await supabase
+            .from('institution_users')
+            .select('institution_id')
             .eq('auth_user_id', authCheck.userId)
+            .order('created_at', { ascending: true })
+            .limit(1)
             .maybeSingle();
+
+        const institutionQuery = supabase
+            .from('institutions')
+            .select('id, name, invited_at, invite_expires_at, invite_accepted_at');
+
+        const { data: institution, error: institutionError } = await (membershipRow?.institution_id
+            ? institutionQuery.eq('id', membershipRow.institution_id)
+            : institutionQuery.eq('auth_user_id', authCheck.userId)
+        ).maybeSingle();
 
         if (institutionError) {
             structuredLog('ERROR', 'Failed to load institution for invite acceptance', requestId, {
@@ -87,6 +101,21 @@ export async function POST(request: NextRequest) {
                 { success: false, error: 'Failed to complete onboarding' },
                 { status: 500 },
             );
+        }
+
+        // Activate the membership so the POC can actually act. Until now the
+        // row exists but is not `active`, so the resolver denies them.
+        const { error: membershipError } = await supabase
+            .from('institution_users')
+            .update({ status: 'active' })
+            .eq('institution_id', institution.id)
+            .eq('auth_user_id', authCheck.userId);
+
+        if (membershipError) {
+            structuredLog('WARN', 'Failed to activate the membership on invite acceptance', requestId, {
+                error: membershipError,
+                institutionId: institution.id,
+            });
         }
 
         const { error: auditError } = await supabase.from('admin_audit_logs').insert({

--- a/frontend/src/app/api/institution/analytics/route.ts
+++ b/frontend/src/app/api/institution/analytics/route.ts
@@ -6,7 +6,8 @@ import {
 } from '@/lib/serverAuth';
 import { enforceRateLimit } from '@/lib/rateLimit';
 import { last12Months, groupByMonth, fillMonths, topVerified } from '@/lib/analyticsAggregation';
-import { captureException, structuredLog } from '@/lib/debug';
+import { captureException } from '@/lib/debug';
+import { resolveInstitutionForUser } from '@/lib/institutionMembership';
 
 // Analytics aggregates the full credential + verification log set for an institution.
 // Each request is relatively expensive, so limits are tighter than the credential list.
@@ -50,27 +51,16 @@ export async function GET(request: NextRequest) {
                   throw new Error('Service role key required');
               })();
 
-        const { data: inst, error: instErr } = await supabase
-            .from('institutions')
-            .select('id')
-            .eq('auth_user_id', authCheck.userId)
-            .maybeSingle();
+        const membership = await resolveInstitutionForUser(supabase, authCheck.userId);
 
-        if (instErr) {
-            structuredLog('ERROR', 'Error fetching institution for analytics', requestId, {
-                error: instErr,
-            });
-            return NextResponse.json(
-                { success: false, error: 'Failed to load institution profile' },
-                { status: 500 },
-            );
-        }
-        if (!inst?.id) {
+        if (!membership) {
             return NextResponse.json(
                 { success: false, error: 'Institution not found' },
                 { status: 404 },
             );
         }
+
+        const inst = { id: membership.institutionId };
 
         // Fetch credentials — lightweight select, no pagination (analytics needs full set)
         // TODO: swap this query to the indexer once issue #11 is implemented

--- a/frontend/src/app/api/institution/credentials/route.ts
+++ b/frontend/src/app/api/institution/credentials/route.ts
@@ -5,7 +5,8 @@ import {
     requireAuthenticatedRequest,
 } from '@/lib/serverAuth';
 import { enforceRateLimit } from '@/lib/rateLimit';
-import { structuredLog, captureException } from '@/lib/debug';
+import { captureException } from '@/lib/debug';
+import { resolveInstitutionForUser } from '@/lib/institutionMembership';
 
 // Coarse per-IP guard applied before auth to prevent anonymous floods from
 // driving Supabase token verification on this potentially expensive query.
@@ -49,27 +50,17 @@ export async function GET(request: NextRequest) {
             ? getServiceRoleClient()
             : (() => { throw new Error('Service role key required'); })();
 
-        // ── Resolve institution row ────────────────────────────────────────────
-        const { data: institutionRow, error: instError } = await supabase
-            .from('institutions')
-            .select('id')
-            .eq('auth_user_id', authCheck.userId)
-            .maybeSingle();
+        // ── Resolve institution membership ─────────────────────────────────────
+        const membership = await resolveInstitutionForUser(supabase, authCheck.userId);
 
-        if (instError) {
-            structuredLog('ERROR', 'Error fetching institution row', requestId, { error: instError });
-            return NextResponse.json(
-                { success: false, error: 'Failed to load institution profile' },
-                { status: 500 }
-            );
-        }
-
-        if (!institutionRow?.id) {
+        if (!membership) {
             return NextResponse.json(
                 { success: false, error: 'Institution not found' },
                 { status: 404 }
             );
         }
+
+        const institutionRow = { id: membership.institutionId };
 
         // ── Pagination & filter params ─────────────────────────────────────────
         const { searchParams } = new URL(request.url);

--- a/frontend/src/app/api/institution/export/route.ts
+++ b/frontend/src/app/api/institution/export/route.ts
@@ -6,7 +6,8 @@ import {
 } from '@/lib/serverAuth';
 import { enforceRateLimit } from '@/lib/rateLimit';
 import { toCsv } from '@/lib/analyticsAggregation';
-import { captureException, structuredLog } from '@/lib/debug';
+import { captureException } from '@/lib/debug';
+import { resolveInstitutionForUser } from '@/lib/institutionMembership';
 
 // CSV export streams the full credential set; treat it as expensive as analytics.
 const INSTITUTION_EXPORT_IP_LIMIT = {
@@ -49,27 +50,16 @@ export async function GET(request: NextRequest) {
                   throw new Error('Service role key required');
               })();
 
-        const { data: inst, error: instErr } = await supabase
-            .from('institutions')
-            .select('id')
-            .eq('auth_user_id', authCheck.userId)
-            .maybeSingle();
+        const membership = await resolveInstitutionForUser(supabase, authCheck.userId);
 
-        if (instErr) {
-            structuredLog('ERROR', 'Error fetching institution for export', requestId, {
-                error: instErr,
-            });
-            return NextResponse.json(
-                { success: false, error: 'Failed to load institution profile' },
-                { status: 500 },
-            );
-        }
-        if (!inst?.id) {
+        if (!membership) {
             return NextResponse.json(
                 { success: false, error: 'Institution not found' },
                 { status: 404 },
             );
         }
+
+        const inst = { id: membership.institutionId };
 
         const { data: credentials, error: credErr } = await supabase
             .from('credentials')

--- a/frontend/src/app/api/institution/link-wallet/route.ts
+++ b/frontend/src/app/api/institution/link-wallet/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/serverAuth';
 import { enforceRateLimit } from '@/lib/rateLimit';
 import { structuredLog, captureException } from '@/lib/debug';
+import { canWrite, resolveInstitutionForUser } from '@/lib/institutionMembership';
 
 export const dynamic = 'force-dynamic';
 
@@ -60,10 +61,28 @@ export async function POST(request: NextRequest) {
             ? getServiceRoleClient()
             : createUserScopedServerClient(getAccessToken(request));
 
+        const membership = await resolveInstitutionForUser(supabase, authCheck.userId);
+
+        if (!membership) {
+            return NextResponse.json(
+                { success: false, error: 'Institution profile not found' },
+                { status: 404 },
+            );
+        }
+
+        // Linking a wallet re-scopes every credential the institution issues,
+        // so it is a write action: read-only members may not perform it.
+        if (!canWrite(membership.role)) {
+            return NextResponse.json(
+                { success: false, error: 'Your role does not permit changing the wallet' },
+                { status: 403 },
+            );
+        }
+
         const { data: institution, error: findError } = await supabase
             .from('institutions')
             .select('id, wallet_address')
-            .eq('auth_user_id', authCheck.userId)
+            .eq('id', membership.institutionId)
             .maybeSingle();
 
         if (findError) {
@@ -98,7 +117,6 @@ export async function POST(request: NextRequest) {
                 authorization_tx_hash: null,
             })
             .eq('id', institution.id)
-            .eq('auth_user_id', authCheck.userId)
             .select('id, wallet_address')
             .single();
 

--- a/frontend/src/app/api/notifications/trigger/route.ts
+++ b/frontend/src/app/api/notifications/trigger/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceRoleClient, requireAuthenticatedRequest } from '@/lib/serverAuth';
 import { structuredLog } from '@/lib/debug';
 import { enforceRateLimit } from '@/lib/rateLimit';
+import { canWrite, resolveInstitutionForUser } from '@/lib/institutionMembership';
 
 // Coarse per-IP guard against anonymous floods before auth runs.
 const NOTIFICATIONS_TRIGGER_IP_LIMIT = {
@@ -44,11 +45,26 @@ export async function POST(request: NextRequest) {
 
         const supabase = getServiceRoleClient();
 
-        // Verify institution and credential
+        // Verify institution membership and credential
+        const membership = await resolveInstitutionForUser(supabase, authCheck.userId);
+
+        if (!membership) {
+            return NextResponse.json({ success: false, error: 'Institution not found' }, { status: 404 });
+        }
+
+        // Issuance and revocation notifications follow a write action, so
+        // read-only members may not send them.
+        if (!canWrite(membership.role)) {
+            return NextResponse.json(
+                { success: false, error: 'Your role does not permit sending notifications' },
+                { status: 403 },
+            );
+        }
+
         const { data: institution } = await supabase
             .from('institutions')
             .select('id, name')
-            .eq('auth_user_id', authCheck.userId)
+            .eq('id', membership.institutionId)
             .single();
 
         if (!institution) {

--- a/frontend/src/hooks/useInstitutionProfile.ts
+++ b/frontend/src/hooks/useInstitutionProfile.ts
@@ -6,6 +6,7 @@ import { captureException, debugLog, debugWarn } from '@/lib/debug';
 import { safeGetSession, supabase } from '@/lib/supabase';
 import { useStellarAccount } from '@/contexts/StellarContext';
 import { useAuth } from '@/contexts/AuthContext';
+import { resolveInstitutionIdForUser } from '@/lib/institutionMembership';
 
 export interface InstitutionProfile {
     /** Empty until the institution row has been loaded or created. */
@@ -54,11 +55,15 @@ export function useInstitutionProfile(): InstitutionProfile {
             }
 
             try {
-                const { data, error } = await supabase
-                    .from('institutions')
-                    .select('id, wallet_address, status')
-                    .eq('auth_user_id', user.id)
-                    .maybeSingle();
+                const institutionId = await resolveInstitutionIdForUser(supabase, user.id);
+
+                const { data, error } = institutionId
+                    ? await supabase
+                          .from('institutions')
+                          .select('id, wallet_address, status')
+                          .eq('id', institutionId)
+                          .maybeSingle()
+                    : { data: null, error: null };
 
                 if (error) {
                     captureException(error, { context: 'fetchInstitutionId' });
@@ -88,6 +93,17 @@ export function useInstitutionProfile(): InstitutionProfile {
                     ])
                     .select('id, wallet_address, status')
                     .single();
+
+                if (!createError && newInstitution?.id) {
+                    await supabase.from('institution_users').insert([
+                        {
+                            institution_id: newInstitution.id,
+                            auth_user_id: user.id,
+                            role: 'owner',
+                            status: 'active',
+                        },
+                    ]);
+                }
 
                 if (createError) {
                     captureException(createError, { context: 'createInstitution' });

--- a/frontend/src/lib/institutionMembership.ts
+++ b/frontend/src/lib/institutionMembership.ts
@@ -1,0 +1,183 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Membership roles within an institution.
+ *
+ * `owner`/`issuer`/`viewer` are the vocabulary this codebase writes going
+ * forward. `poc`/`admin`/`member` are the legacy values written by the POC
+ * handover and provisioning routes; they are read here so a legacy row never
+ * silently loses access, and they map onto the same three capability levels.
+ */
+export type InstitutionRole = 'owner' | 'issuer' | 'viewer' | 'admin' | 'member' | 'poc';
+
+export type MembershipStatus = 'invited' | 'active' | 'deactivated';
+
+export interface InstitutionMembership {
+    institutionId: string;
+    role: InstitutionRole;
+    status: MembershipStatus;
+}
+
+/** Roles permitted to issue, revoke, and change institution settings. */
+const WRITE_ROLES: ReadonlySet<InstitutionRole> = new Set<InstitutionRole>([
+    'owner',
+    'issuer',
+    'admin',
+    'poc',
+]);
+
+/** Roles permitted to manage the institution's members. */
+const MEMBER_MANAGEMENT_ROLES: ReadonlySet<InstitutionRole> = new Set<InstitutionRole>([
+    'owner',
+    'poc',
+]);
+
+/**
+ * Whether the role may issue or revoke credentials, rotate API keys, or change
+ * institution settings such as the linked wallet. `viewer` and `member` are
+ * read-only and are rejected.
+ */
+export function canWrite(role: InstitutionRole): boolean {
+    return WRITE_ROLES.has(role);
+}
+
+/** Whether the role may add, remove, or re-role other members. */
+export function canManageMembers(role: InstitutionRole): boolean {
+    return MEMBER_MANAGEMENT_ROLES.has(role);
+}
+
+/**
+ * Resolves which institution a user acts for, and with what role.
+ *
+ * This is the single place institution ownership is resolved. Before Issue
+ * #238 every call site repeated `.eq('auth_user_id', userId)` against
+ * `institutions`, which hard-coded one login per institution into ~10 queries;
+ * routing them all through here is what makes a second member possible without
+ * another rewrite.
+ *
+ * Only `active` memberships resolve — an `invited` member has not accepted yet
+ * and a `deactivated` one has been offboarded, so neither may act.
+ *
+ * Falls back to the deprecated `institutions.auth_user_id` column when no
+ * membership row exists, so an institution provisioned before the backfill (or
+ * during a rollback) never loses access. That fallback is removed with the
+ * column itself.
+ */
+export async function resolveInstitutionForUser(
+    client: SupabaseClient,
+    userId: string,
+): Promise<InstitutionMembership | null> {
+    const { data: membership, error } = await client
+        .from('institution_users')
+        .select('institution_id, role, status')
+        .eq('auth_user_id', userId)
+        .eq('status', 'active')
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+
+    if (!error && membership?.institution_id) {
+        return {
+            institutionId: membership.institution_id as string,
+            role: (membership.role as InstitutionRole) ?? 'issuer',
+            status: (membership.status as MembershipStatus) ?? 'active',
+        };
+    }
+
+    const { data: legacy, error: legacyError } = await client
+        .from('institutions')
+        .select('id')
+        .eq('auth_user_id', userId)
+        .maybeSingle();
+
+    // A failed lookup is not the same as "no institution": letting a database
+    // error fall through as `null` would report a 404 during an outage and
+    // hide it. Callers distinguish the two by the thrown error.
+    if (legacyError) {
+        throw legacyError;
+    }
+
+    if (!legacy?.id) {
+        return null;
+    }
+
+    // A row surviving only on the deprecated column is the original single
+    // login, which is exactly what `owner` means.
+    return {
+        institutionId: legacy.id as string,
+        role: 'owner',
+        status: 'active',
+    };
+}
+
+/**
+ * Resolves the caller's institution id, or `null` when they are not an active
+ * member of one. For callers that need the id but not the role.
+ */
+export async function resolveInstitutionIdForUser(
+    client: SupabaseClient,
+    userId: string,
+): Promise<string | null> {
+    const membership = await resolveInstitutionForUser(client, userId);
+    return membership?.institutionId ?? null;
+}
+
+/**
+ * Whether a user is an active member of one specific institution.
+ *
+ * Asks the membership table directly rather than comparing against
+ * {@link resolveInstitutionForUser}, which returns only the first membership —
+ * once a user can belong to several institutions, comparing ids would wrongly
+ * deny access to every institution but one.
+ */
+export async function isMemberOfInstitution(
+    client: SupabaseClient,
+    userId: string,
+    institutionId: string,
+): Promise<boolean> {
+    const { data } = await client
+        .from('institution_users')
+        .select('institution_id')
+        .eq('auth_user_id', userId)
+        .eq('institution_id', institutionId)
+        .eq('status', 'active')
+        .maybeSingle();
+
+    if (data?.institution_id) {
+        return true;
+    }
+
+    const { data: legacy } = await client
+        .from('institutions')
+        .select('id')
+        .eq('id', institutionId)
+        .eq('auth_user_id', userId)
+        .maybeSingle();
+
+    return Boolean(legacy?.id);
+}
+
+/**
+ * Resolves the auth user to notify on behalf of an institution — its owner.
+ *
+ * Falls back to the deprecated `institutions.auth_user_id` (passed in by the
+ * caller, which has usually already selected it) when no owner membership
+ * exists, so notifications keep reaching someone during the migration window.
+ */
+export async function resolveInstitutionOwnerId(
+    client: SupabaseClient,
+    institutionId: string,
+    legacyAuthUserId?: string | null,
+): Promise<string | null> {
+    const { data } = await client
+        .from('institution_users')
+        .select('auth_user_id, role')
+        .eq('institution_id', institutionId)
+        .eq('status', 'active')
+        .in('role', ['owner', 'poc'])
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+
+    return (data?.auth_user_id as string | undefined) ?? legacyAuthUserId ?? null;
+}

--- a/frontend/src/lib/roleResolver.ts
+++ b/frontend/src/lib/roleResolver.ts
@@ -22,6 +22,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { User } from '@supabase/supabase-js';
 import type { AppRole, RoleState } from '@/types';
 import { getE2eState } from './e2e';
+import { resolveInstitutionIdForUser } from './institutionMembership';
 // ---------------------------------------------------------------------------
 // Core resolver (works with any Supabase client — browser or server)
 // ---------------------------------------------------------------------------
@@ -142,6 +143,12 @@ async function hasRowIn(
     table: 'institutions' | 'students',
     userId: string,
 ): Promise<boolean> {
+    // Institution affiliation lives in the membership table since Issue #238;
+    // `students` still carries the user column directly.
+    if (table === 'institutions') {
+        return (await resolveInstitutionIdForUser(client, userId)) !== null;
+    }
+
     const { data } = await client.from(table).select('id').eq('auth_user_id', userId).maybeSingle();
 
     return !!data?.id;

--- a/frontend/src/lib/serverAuth.ts
+++ b/frontend/src/lib/serverAuth.ts
@@ -3,6 +3,7 @@ import type { User } from '@supabase/supabase-js';
 import type { NextRequest } from 'next/server';
 import { resolveUserRole } from './roleResolver';
 import { runtimeConfig, serverRuntimeConfig } from './runtimeConfig';
+import { resolveInstitutionIdForUser } from './institutionMembership';
 
 type AuthenticatedRequest = {
     ok: true;
@@ -248,17 +249,14 @@ export async function requireInstitutionRequest(
     }
 
     // Best-effort: callers use this to scope uploads to the issuing institution.
-    // A missing row is not fatal — `profiles.role` already established the role.
-    const { data: institution } = await client
-        .from('institutions')
-        .select('id')
-        .eq('auth_user_id', authCheck.userId)
-        .maybeSingle();
+    // A missing membership is not fatal — `profiles.role` already established
+    // the role.
+    const institutionId = await resolveInstitutionIdForUser(client, authCheck.userId);
 
     return {
         ok: true,
         userId: authCheck.userId,
-        institutionId: (institution?.id as string | undefined) ?? null,
+        institutionId,
     };
 }
 

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -8,6 +8,7 @@ const supabaseUrl = runtimeConfig.supabase.url;
 const supabaseAnonKey = runtimeConfig.supabase.anonKey;
 
 import { debugWarn } from './debug';
+import { resolveInstitutionIdForUser } from './institutionMembership';
 
 if (!supabaseUrl || !supabaseAnonKey) {
     if (!runtimeConfig.isProduction) {
@@ -134,7 +135,23 @@ export async function signUp(email: string, password: string, options?: PublicSi
         if (role === 'student') {
             await supabase.from('students').insert([{ auth_user_id: userId, name, email }]);
         } else if (role === 'institution') {
-            await supabase.from('institutions').insert([{ auth_user_id: userId, name, email }]);
+            const { data: institution } = await supabase
+                .from('institutions')
+                .insert([{ auth_user_id: userId, name, email }])
+                .select('id')
+                .single();
+
+            // The membership row, not the column, is what grants access.
+            if (institution?.id) {
+                await supabase.from('institution_users').insert([
+                    {
+                        institution_id: institution.id,
+                        auth_user_id: userId,
+                        role: 'owner',
+                        status: 'active',
+                    },
+                ]);
+            }
         }
     }
 
@@ -256,14 +273,32 @@ export const dbHelpers = {
             .insert([{ auth_user_id: userId, name, email }])
             .select()
             .single();
+
+        if (!error && data?.id) {
+            await supabase.from('institution_users').insert([
+                {
+                    institution_id: data.id,
+                    auth_user_id: userId,
+                    role: 'owner',
+                    status: 'active',
+                },
+            ]);
+        }
+
         return { data, error };
     },
 
     async getInstitution(userId: string) {
+        const institutionId = await resolveInstitutionIdForUser(supabase, userId);
+
+        if (!institutionId) {
+            return { data: null, error: null };
+        }
+
         const { data, error } = await supabase
             .from('institutions')
             .select('*')
-            .eq('auth_user_id', userId)
+            .eq('id', institutionId)
             .single();
         return { data, error };
     },

--- a/frontend/supabase/migrations/20260808000000_institution_membership.sql
+++ b/frontend/supabase/migrations/20260808000000_institution_membership.sql
@@ -1,0 +1,298 @@
+-- =====================================================================
+-- ACREDIA-STELLAR — ONE LOGIN PER INSTITUTION -> MEMBERSHIP (IDEMPOTENT)
+-- Issue #238: Replace institutions.auth_user_id with a membership table
+-- =====================================================================
+-- What this file does:
+--   1. Evolves `public.institution_users` (introduced for POC handover) into
+--      the general membership relation: adds `status` and `invited_by`, and
+--      widens the role vocabulary to owner/issuer/viewer.
+--   2. Backfills a membership row for every institution that still only has
+--      `institutions.auth_user_id`, so no institution loses access.
+--   3. Rewrites every institution-scoped RLS policy to check membership
+--      instead of the single-owner column.
+--   4. Deprecates `institutions.auth_user_id` — kept nullable and unused so
+--      this migration stays reversible. A later migration drops it.
+--
+-- Behaviour is intentionally unchanged on delivery: each institution ends up
+-- with exactly one active `owner`, which is what the old column expressed.
+-- =====================================================================
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ---------------------------------------------------------------------
+-- 0. The membership table, for databases that never ran the POC-handover
+--    migration. Where it already exists this is a no-op and step 1 evolves
+--    it in place.
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.institution_users (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    institution_id  UUID NOT NULL REFERENCES public.institutions (id) ON DELETE CASCADE,
+    auth_user_id    UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    role            TEXT NOT NULL DEFAULT 'issuer',
+    is_active       BOOLEAN NOT NULL DEFAULT true,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (institution_id, auth_user_id)
+);
+
+-- ---------------------------------------------------------------------
+-- 1. Membership lifecycle columns
+-- ---------------------------------------------------------------------
+ALTER TABLE public.institution_users
+    ADD COLUMN IF NOT EXISTS status     TEXT,
+    ADD COLUMN IF NOT EXISTS invited_by UUID REFERENCES auth.users (id) ON DELETE SET NULL;
+
+-- `is_active` predates `status`. Derive the richer column from it so existing
+-- rows carry a correct lifecycle value, then make it authoritative.
+UPDATE public.institution_users
+SET status = CASE WHEN is_active THEN 'active' ELSE 'deactivated' END
+WHERE status IS NULL;
+
+ALTER TABLE public.institution_users
+    ALTER COLUMN status SET DEFAULT 'active';
+
+ALTER TABLE public.institution_users
+    ALTER COLUMN status SET NOT NULL;
+
+ALTER TABLE public.institution_users
+    DROP CONSTRAINT IF EXISTS institution_users_status_check;
+
+ALTER TABLE public.institution_users
+    ADD CONSTRAINT institution_users_status_check
+    CHECK (status IN ('invited', 'active', 'deactivated'));
+
+-- Role vocabulary. `owner`/`issuer`/`viewer` are the roles this issue defines;
+-- `admin`/`member`/`poc` are retained because the POC-handover and
+-- provisioning routes already write them, and rewriting those call sites is
+-- not what this structural change is for.
+ALTER TABLE public.institution_users
+    DROP CONSTRAINT IF EXISTS institution_users_role_check;
+
+ALTER TABLE public.institution_users
+    ADD CONSTRAINT institution_users_role_check
+    CHECK (role IN ('owner', 'issuer', 'viewer', 'admin', 'member', 'poc'));
+
+COMMENT ON TABLE public.institution_users IS
+    'Membership relation binding auth users to institutions. Replaces the single-login institutions.auth_user_id column: an institution may have many members, and removing a member never removes the institution.';
+
+COMMENT ON COLUMN public.institution_users.role IS
+    'owner may manage members; issuer may issue and revoke credentials; viewer is read-only. Legacy poc/admin/member values map onto owner/issuer/viewer respectively.';
+
+COMMENT ON COLUMN public.institution_users.status IS
+    'invited = provisioned but has not accepted; active = may act; deactivated = retained for audit but denied access.';
+
+-- `is_active` is kept in lockstep so the POC-handover routes, which still
+-- write and read it, cannot disagree with `status` about who has access.
+UPDATE public.institution_users
+SET is_active = (status = 'active')
+WHERE is_active <> (status = 'active');
+
+CREATE OR REPLACE FUNCTION public.sync_institution_user_status()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+    -- Whichever column the caller set, make the other agree. `status` wins
+    -- when both changed, since it is the more expressive of the two.
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.status IS DISTINCT FROM 'active' THEN
+            NEW.is_active := (NEW.status = 'active');
+        ELSE
+            NEW.status := CASE WHEN NEW.is_active THEN 'active' ELSE 'deactivated' END;
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF NEW.status IS DISTINCT FROM OLD.status THEN
+        NEW.is_active := (NEW.status = 'active');
+    ELSIF NEW.is_active IS DISTINCT FROM OLD.is_active THEN
+        NEW.status := CASE WHEN NEW.is_active THEN 'active' ELSE 'deactivated' END;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_institution_user_status ON public.institution_users;
+CREATE TRIGGER trg_sync_institution_user_status
+    BEFORE INSERT OR UPDATE ON public.institution_users
+    FOR EACH ROW EXECUTE FUNCTION public.sync_institution_user_status();
+
+CREATE INDEX IF NOT EXISTS idx_institution_users_active_membership
+    ON public.institution_users (auth_user_id, institution_id)
+    WHERE status = 'active';
+
+-- ---------------------------------------------------------------------
+-- 2. Backfill — every institution keeps access
+-- ---------------------------------------------------------------------
+-- Institutions whose owner was only ever recorded in the deprecated column.
+INSERT INTO public.institution_users (institution_id, auth_user_id, role, status, is_active)
+SELECT id, auth_user_id, 'owner', 'active', true
+FROM public.institutions
+WHERE auth_user_id IS NOT NULL
+ON CONFLICT (institution_id, auth_user_id) DO NOTHING;
+
+-- The POC-handover migration backfilled with role 'poc'. That is the same
+-- relationship this issue calls 'owner', so normalise it — otherwise an
+-- institution would have no owner and nobody could manage members.
+UPDATE public.institution_users iu
+SET role = 'owner'
+WHERE iu.role = 'poc'
+  AND EXISTS (
+      SELECT 1 FROM public.institutions i
+      WHERE i.id = iu.institution_id
+        AND i.auth_user_id = iu.auth_user_id
+  );
+
+-- ---------------------------------------------------------------------
+-- 3. Membership helpers used by the policies below
+-- ---------------------------------------------------------------------
+-- SECURITY DEFINER so the lookup does not itself recurse through the
+-- institution_users policies while those policies are being evaluated.
+CREATE OR REPLACE FUNCTION public.user_institution_ids(p_user_id UUID DEFAULT auth.uid())
+RETURNS SETOF UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER SET search_path = public
+AS $$
+    SELECT institution_id
+    FROM public.institution_users
+    WHERE auth_user_id = p_user_id
+      AND status = 'active';
+$$;
+
+COMMENT ON FUNCTION public.user_institution_ids(UUID) IS
+    'Institutions the given user is an active member of. The single source of truth for institution ownership in RLS policies.';
+
+-- Issuance requires a role that may write, not merely membership.
+CREATE OR REPLACE FUNCTION public.user_issuer_institution_ids(p_user_id UUID DEFAULT auth.uid())
+RETURNS SETOF UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER SET search_path = public
+AS $$
+    SELECT institution_id
+    FROM public.institution_users
+    WHERE auth_user_id = p_user_id
+      AND status = 'active'
+      AND role IN ('owner', 'issuer', 'admin', 'poc');
+$$;
+
+COMMENT ON FUNCTION public.user_issuer_institution_ids(UUID) IS
+    'Institutions the user may write to. Excludes viewer/member, which are read-only.';
+
+-- ---------------------------------------------------------------------
+-- 4. RLS policies — membership instead of the single-owner column
+-- ---------------------------------------------------------------------
+
+-- Institutions ------------------------------------------------------------
+DROP POLICY IF EXISTS "Institutions can view own data" ON public.institutions;
+CREATE POLICY "Institutions can view own data"
+  ON public.institutions FOR SELECT
+  USING (id IN (SELECT public.user_institution_ids()));
+
+DROP POLICY IF EXISTS "Institutions can update own data" ON public.institutions;
+CREATE POLICY "Institutions can update own data"
+  ON public.institutions FOR UPDATE
+  USING (id IN (SELECT public.user_issuer_institution_ids()))
+  WITH CHECK (id IN (SELECT public.user_issuer_institution_ids()));
+
+-- Institutions are provisioned by admins, never self-inserted. The old
+-- "Institutions can insert own data" policy existed for the removed signup
+-- flow and has no membership equivalent: a row cannot be a member of itself
+-- before it exists.
+DROP POLICY IF EXISTS "Institutions can insert own data" ON public.institutions;
+
+-- Credentials -------------------------------------------------------------
+DROP POLICY IF EXISTS "Institutions can view issued credentials" ON public.credentials;
+CREATE POLICY "Institutions can view issued credentials"
+  ON public.credentials FOR SELECT
+  USING (institution_id IN (SELECT public.user_institution_ids()));
+
+DROP POLICY IF EXISTS "Institutions can insert credentials" ON public.credentials;
+CREATE POLICY "Institutions can insert credentials"
+  ON public.credentials FOR INSERT
+  WITH CHECK (
+    institution_id IN (
+      SELECT i.id FROM public.institutions i
+      WHERE i.verified = true
+        AND i.id IN (SELECT public.user_issuer_institution_ids())
+    )
+  );
+
+DROP POLICY IF EXISTS "Institutions can update own credentials" ON public.credentials;
+CREATE POLICY "Institutions can update own credentials"
+  ON public.credentials FOR UPDATE
+  USING (
+    institution_id IN (
+      SELECT i.id FROM public.institutions i
+      WHERE i.verified = true
+        AND i.id IN (SELECT public.user_issuer_institution_ids())
+    )
+  )
+  WITH CHECK (
+    institution_id IN (
+      SELECT i.id FROM public.institutions i
+      WHERE i.verified = true
+        AND i.id IN (SELECT public.user_issuer_institution_ids())
+    )
+  );
+
+-- API keys ----------------------------------------------------------------
+DROP POLICY IF EXISTS "Institutions can view own api keys" ON public.api_keys;
+CREATE POLICY "Institutions can view own api keys"
+  ON public.api_keys FOR SELECT
+  USING (institution_id IN (SELECT public.user_institution_ids()));
+
+DROP POLICY IF EXISTS "Institutions can insert own api keys" ON public.api_keys;
+CREATE POLICY "Institutions can insert own api keys"
+  ON public.api_keys FOR INSERT
+  WITH CHECK (institution_id IN (SELECT public.user_issuer_institution_ids()));
+
+DROP POLICY IF EXISTS "Institutions can update own api keys" ON public.api_keys;
+CREATE POLICY "Institutions can update own api keys"
+  ON public.api_keys FOR UPDATE
+  USING (institution_id IN (SELECT public.user_issuer_institution_ids()))
+  WITH CHECK (institution_id IN (SELECT public.user_issuer_institution_ids()));
+
+-- Credential pins ---------------------------------------------------------
+DROP POLICY IF EXISTS "Institutions can view own credential pins" ON public.credential_pins;
+CREATE POLICY "Institutions can view own credential pins"
+    ON public.credential_pins FOR SELECT
+    USING (
+        credential_id IN (
+            SELECT c.id FROM public.credentials c
+            WHERE c.institution_id IN (SELECT public.user_institution_ids())
+        )
+    );
+
+-- Institution users -------------------------------------------------------
+-- Replaces the Issue 14 policy, which read the deprecated column directly.
+DROP POLICY IF EXISTS "Institution members can view colleagues" ON public.institution_users;
+CREATE POLICY "Institution members can view colleagues"
+    ON public.institution_users FOR SELECT
+    USING (institution_id IN (SELECT public.user_institution_ids()));
+
+-- ---------------------------------------------------------------------
+-- 5. Deprecate the single-login column
+-- ---------------------------------------------------------------------
+-- Kept, nullable and unused, so this migration can be rolled back. The
+-- ON DELETE CASCADE is the dangerous part — deleting a departing member's
+-- auth user would cascade away the whole institution — so that is dropped
+-- now even though the column stays.
+ALTER TABLE public.institutions
+    DROP CONSTRAINT IF EXISTS institutions_auth_user_id_fkey;
+
+ALTER TABLE public.institutions
+    ADD CONSTRAINT institutions_auth_user_id_fkey
+    FOREIGN KEY (auth_user_id) REFERENCES auth.users (id) ON DELETE SET NULL;
+
+ALTER TABLE public.institutions
+    ALTER COLUMN auth_user_id DROP NOT NULL;
+
+COMMENT ON COLUMN public.institutions.auth_user_id IS
+    'DEPRECATED (Issue #238): superseded by public.institution_users. Retained nullable and unread so the membership migration stays reversible; a later migration drops it. Do not add new reads.';
+
+COMMIT;

--- a/frontend/supabase/schema.sql
+++ b/frontend/supabase/schema.sql
@@ -1808,3 +1808,302 @@ ALTER TABLE public.admin_audit_logs
     );
 
 COMMIT;
+
+-- =====================================================================
+-- ACREDIA-STELLAR — ONE LOGIN PER INSTITUTION -> MEMBERSHIP (IDEMPOTENT)
+-- Issue #238: Replace institutions.auth_user_id with a membership table
+-- =====================================================================
+-- What this file does:
+--   1. Evolves `public.institution_users` (introduced for POC handover) into
+--      the general membership relation: adds `status` and `invited_by`, and
+--      widens the role vocabulary to owner/issuer/viewer.
+--   2. Backfills a membership row for every institution that still only has
+--      `institutions.auth_user_id`, so no institution loses access.
+--   3. Rewrites every institution-scoped RLS policy to check membership
+--      instead of the single-owner column.
+--   4. Deprecates `institutions.auth_user_id` — kept nullable and unused so
+--      this migration stays reversible. A later migration drops it.
+--
+-- Behaviour is intentionally unchanged on delivery: each institution ends up
+-- with exactly one active `owner`, which is what the old column expressed.
+-- =====================================================================
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ---------------------------------------------------------------------
+-- 0. The membership table, for databases that never ran the POC-handover
+--    migration. Where it already exists this is a no-op and step 1 evolves
+--    it in place.
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.institution_users (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    institution_id  UUID NOT NULL REFERENCES public.institutions (id) ON DELETE CASCADE,
+    auth_user_id    UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    role            TEXT NOT NULL DEFAULT 'issuer',
+    is_active       BOOLEAN NOT NULL DEFAULT true,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (institution_id, auth_user_id)
+);
+
+-- ---------------------------------------------------------------------
+-- 1. Membership lifecycle columns
+-- ---------------------------------------------------------------------
+ALTER TABLE public.institution_users
+    ADD COLUMN IF NOT EXISTS status     TEXT,
+    ADD COLUMN IF NOT EXISTS invited_by UUID REFERENCES auth.users (id) ON DELETE SET NULL;
+
+-- `is_active` predates `status`. Derive the richer column from it so existing
+-- rows carry a correct lifecycle value, then make it authoritative.
+UPDATE public.institution_users
+SET status = CASE WHEN is_active THEN 'active' ELSE 'deactivated' END
+WHERE status IS NULL;
+
+ALTER TABLE public.institution_users
+    ALTER COLUMN status SET DEFAULT 'active';
+
+ALTER TABLE public.institution_users
+    ALTER COLUMN status SET NOT NULL;
+
+ALTER TABLE public.institution_users
+    DROP CONSTRAINT IF EXISTS institution_users_status_check;
+
+ALTER TABLE public.institution_users
+    ADD CONSTRAINT institution_users_status_check
+    CHECK (status IN ('invited', 'active', 'deactivated'));
+
+-- Role vocabulary. `owner`/`issuer`/`viewer` are the roles this issue defines;
+-- `admin`/`member`/`poc` are retained because the POC-handover and
+-- provisioning routes already write them, and rewriting those call sites is
+-- not what this structural change is for.
+ALTER TABLE public.institution_users
+    DROP CONSTRAINT IF EXISTS institution_users_role_check;
+
+ALTER TABLE public.institution_users
+    ADD CONSTRAINT institution_users_role_check
+    CHECK (role IN ('owner', 'issuer', 'viewer', 'admin', 'member', 'poc'));
+
+COMMENT ON TABLE public.institution_users IS
+    'Membership relation binding auth users to institutions. Replaces the single-login institutions.auth_user_id column: an institution may have many members, and removing a member never removes the institution.';
+
+COMMENT ON COLUMN public.institution_users.role IS
+    'owner may manage members; issuer may issue and revoke credentials; viewer is read-only. Legacy poc/admin/member values map onto owner/issuer/viewer respectively.';
+
+COMMENT ON COLUMN public.institution_users.status IS
+    'invited = provisioned but has not accepted; active = may act; deactivated = retained for audit but denied access.';
+
+-- `is_active` is kept in lockstep so the POC-handover routes, which still
+-- write and read it, cannot disagree with `status` about who has access.
+UPDATE public.institution_users
+SET is_active = (status = 'active')
+WHERE is_active <> (status = 'active');
+
+CREATE OR REPLACE FUNCTION public.sync_institution_user_status()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+    -- Whichever column the caller set, make the other agree. `status` wins
+    -- when both changed, since it is the more expressive of the two.
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.status IS DISTINCT FROM 'active' THEN
+            NEW.is_active := (NEW.status = 'active');
+        ELSE
+            NEW.status := CASE WHEN NEW.is_active THEN 'active' ELSE 'deactivated' END;
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF NEW.status IS DISTINCT FROM OLD.status THEN
+        NEW.is_active := (NEW.status = 'active');
+    ELSIF NEW.is_active IS DISTINCT FROM OLD.is_active THEN
+        NEW.status := CASE WHEN NEW.is_active THEN 'active' ELSE 'deactivated' END;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_institution_user_status ON public.institution_users;
+CREATE TRIGGER trg_sync_institution_user_status
+    BEFORE INSERT OR UPDATE ON public.institution_users
+    FOR EACH ROW EXECUTE FUNCTION public.sync_institution_user_status();
+
+CREATE INDEX IF NOT EXISTS idx_institution_users_active_membership
+    ON public.institution_users (auth_user_id, institution_id)
+    WHERE status = 'active';
+
+-- ---------------------------------------------------------------------
+-- 2. Backfill — every institution keeps access
+-- ---------------------------------------------------------------------
+-- Institutions whose owner was only ever recorded in the deprecated column.
+INSERT INTO public.institution_users (institution_id, auth_user_id, role, status, is_active)
+SELECT id, auth_user_id, 'owner', 'active', true
+FROM public.institutions
+WHERE auth_user_id IS NOT NULL
+ON CONFLICT (institution_id, auth_user_id) DO NOTHING;
+
+-- The POC-handover migration backfilled with role 'poc'. That is the same
+-- relationship this issue calls 'owner', so normalise it — otherwise an
+-- institution would have no owner and nobody could manage members.
+UPDATE public.institution_users iu
+SET role = 'owner'
+WHERE iu.role = 'poc'
+  AND EXISTS (
+      SELECT 1 FROM public.institutions i
+      WHERE i.id = iu.institution_id
+        AND i.auth_user_id = iu.auth_user_id
+  );
+
+-- ---------------------------------------------------------------------
+-- 3. Membership helpers used by the policies below
+-- ---------------------------------------------------------------------
+-- SECURITY DEFINER so the lookup does not itself recurse through the
+-- institution_users policies while those policies are being evaluated.
+CREATE OR REPLACE FUNCTION public.user_institution_ids(p_user_id UUID DEFAULT auth.uid())
+RETURNS SETOF UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER SET search_path = public
+AS $$
+    SELECT institution_id
+    FROM public.institution_users
+    WHERE auth_user_id = p_user_id
+      AND status = 'active';
+$$;
+
+COMMENT ON FUNCTION public.user_institution_ids(UUID) IS
+    'Institutions the given user is an active member of. The single source of truth for institution ownership in RLS policies.';
+
+-- Issuance requires a role that may write, not merely membership.
+CREATE OR REPLACE FUNCTION public.user_issuer_institution_ids(p_user_id UUID DEFAULT auth.uid())
+RETURNS SETOF UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER SET search_path = public
+AS $$
+    SELECT institution_id
+    FROM public.institution_users
+    WHERE auth_user_id = p_user_id
+      AND status = 'active'
+      AND role IN ('owner', 'issuer', 'admin', 'poc');
+$$;
+
+COMMENT ON FUNCTION public.user_issuer_institution_ids(UUID) IS
+    'Institutions the user may write to. Excludes viewer/member, which are read-only.';
+
+-- ---------------------------------------------------------------------
+-- 4. RLS policies — membership instead of the single-owner column
+-- ---------------------------------------------------------------------
+
+-- Institutions ------------------------------------------------------------
+DROP POLICY IF EXISTS "Institutions can view own data" ON public.institutions;
+CREATE POLICY "Institutions can view own data"
+  ON public.institutions FOR SELECT
+  USING (id IN (SELECT public.user_institution_ids()));
+
+DROP POLICY IF EXISTS "Institutions can update own data" ON public.institutions;
+CREATE POLICY "Institutions can update own data"
+  ON public.institutions FOR UPDATE
+  USING (id IN (SELECT public.user_issuer_institution_ids()))
+  WITH CHECK (id IN (SELECT public.user_issuer_institution_ids()));
+
+-- Institutions are provisioned by admins, never self-inserted. The old
+-- "Institutions can insert own data" policy existed for the removed signup
+-- flow and has no membership equivalent: a row cannot be a member of itself
+-- before it exists.
+DROP POLICY IF EXISTS "Institutions can insert own data" ON public.institutions;
+
+-- Credentials -------------------------------------------------------------
+DROP POLICY IF EXISTS "Institutions can view issued credentials" ON public.credentials;
+CREATE POLICY "Institutions can view issued credentials"
+  ON public.credentials FOR SELECT
+  USING (institution_id IN (SELECT public.user_institution_ids()));
+
+DROP POLICY IF EXISTS "Institutions can insert credentials" ON public.credentials;
+CREATE POLICY "Institutions can insert credentials"
+  ON public.credentials FOR INSERT
+  WITH CHECK (
+    institution_id IN (
+      SELECT i.id FROM public.institutions i
+      WHERE i.verified = true
+        AND i.id IN (SELECT public.user_issuer_institution_ids())
+    )
+  );
+
+DROP POLICY IF EXISTS "Institutions can update own credentials" ON public.credentials;
+CREATE POLICY "Institutions can update own credentials"
+  ON public.credentials FOR UPDATE
+  USING (
+    institution_id IN (
+      SELECT i.id FROM public.institutions i
+      WHERE i.verified = true
+        AND i.id IN (SELECT public.user_issuer_institution_ids())
+    )
+  )
+  WITH CHECK (
+    institution_id IN (
+      SELECT i.id FROM public.institutions i
+      WHERE i.verified = true
+        AND i.id IN (SELECT public.user_issuer_institution_ids())
+    )
+  );
+
+-- API keys ----------------------------------------------------------------
+DROP POLICY IF EXISTS "Institutions can view own api keys" ON public.api_keys;
+CREATE POLICY "Institutions can view own api keys"
+  ON public.api_keys FOR SELECT
+  USING (institution_id IN (SELECT public.user_institution_ids()));
+
+DROP POLICY IF EXISTS "Institutions can insert own api keys" ON public.api_keys;
+CREATE POLICY "Institutions can insert own api keys"
+  ON public.api_keys FOR INSERT
+  WITH CHECK (institution_id IN (SELECT public.user_issuer_institution_ids()));
+
+DROP POLICY IF EXISTS "Institutions can update own api keys" ON public.api_keys;
+CREATE POLICY "Institutions can update own api keys"
+  ON public.api_keys FOR UPDATE
+  USING (institution_id IN (SELECT public.user_issuer_institution_ids()))
+  WITH CHECK (institution_id IN (SELECT public.user_issuer_institution_ids()));
+
+-- Credential pins ---------------------------------------------------------
+DROP POLICY IF EXISTS "Institutions can view own credential pins" ON public.credential_pins;
+CREATE POLICY "Institutions can view own credential pins"
+    ON public.credential_pins FOR SELECT
+    USING (
+        credential_id IN (
+            SELECT c.id FROM public.credentials c
+            WHERE c.institution_id IN (SELECT public.user_institution_ids())
+        )
+    );
+
+-- Institution users -------------------------------------------------------
+-- Replaces the Issue 14 policy, which read the deprecated column directly.
+DROP POLICY IF EXISTS "Institution members can view colleagues" ON public.institution_users;
+CREATE POLICY "Institution members can view colleagues"
+    ON public.institution_users FOR SELECT
+    USING (institution_id IN (SELECT public.user_institution_ids()));
+
+-- ---------------------------------------------------------------------
+-- 5. Deprecate the single-login column
+-- ---------------------------------------------------------------------
+-- Kept, nullable and unused, so this migration can be rolled back. The
+-- ON DELETE CASCADE is the dangerous part — deleting a departing member's
+-- auth user would cascade away the whole institution — so that is dropped
+-- now even though the column stays.
+ALTER TABLE public.institutions
+    DROP CONSTRAINT IF EXISTS institutions_auth_user_id_fkey;
+
+ALTER TABLE public.institutions
+    ADD CONSTRAINT institutions_auth_user_id_fkey
+    FOREIGN KEY (auth_user_id) REFERENCES auth.users (id) ON DELETE SET NULL;
+
+ALTER TABLE public.institutions
+    ALTER COLUMN auth_user_id DROP NOT NULL;
+
+COMMENT ON COLUMN public.institutions.auth_user_id IS
+    'DEPRECATED (Issue #238): superseded by public.institution_users. Retained nullable and unread so the membership migration stays reversible; a later migration drops it. Do not add new reads.';
+
+COMMIT;

--- a/frontend/tests/adminUpdateAuthorizationRoute.test.ts
+++ b/frontend/tests/adminUpdateAuthorizationRoute.test.ts
@@ -47,14 +47,35 @@ describe('admin update authorization route', () => {
             error: null,
         });
         mockGetServiceRoleClient.mockReturnValue({
-            from: vi.fn(() => ({
-                select: vi.fn(() => ({
-                    eq: vi.fn(() => ({
-                        single: mockSingle,
+            from: vi.fn((table: string) => {
+                // The owner to notify is resolved through the membership table
+                // since Issue #238, whose query chains further than the
+                // institution lookup does.
+                if (table === 'institution_users') {
+                    const builder: Record<string, unknown> = {};
+                    for (const method of ['select', 'eq', 'in', 'order', 'limit']) {
+                        builder[method] = () => builder;
+                    }
+                    builder.maybeSingle = async () => ({
+                        data: { auth_user_id: 'owner-user', role: 'owner' },
+                        error: null,
+                    });
+                    return builder;
+                }
+
+                if (table === 'jobs') {
+                    return { insert: vi.fn(async () => ({ error: null })) };
+                }
+
+                return {
+                    select: vi.fn(() => ({
+                        eq: vi.fn(() => ({
+                            single: mockSingle,
+                        })),
                     })),
-                })),
-                update: mockUpdate,
-            })),
+                    update: mockUpdate,
+                };
+            }),
         });
     });
 

--- a/frontend/tests/institutionAnalytics.test.ts
+++ b/frontend/tests/institutionAnalytics.test.ts
@@ -34,12 +34,15 @@ function makeRequest(): NextRequest {
 function makeSupabase() {
     return {
         from: vi.fn((table: string) => {
-            if (table === 'institutions') {
-                return {
-                    select: () => ({
-                        eq: () => ({ maybeSingle: mockInstMaybeSingle }),
-                    }),
-                };
+            // Institution resolution goes through the membership table since
+            // Issue #238; `mockInstMaybeSingle` still supplies the row.
+            if (table === 'institution_users' || table === 'institutions') {
+                const builder: Record<string, unknown> = {};
+                for (const method of ['select', 'eq', 'in', 'order', 'limit']) {
+                    builder[method] = () => builder;
+                }
+                builder.maybeSingle = mockInstMaybeSingle;
+                return builder;
             }
             if (table === 'credentials') {
                 return {

--- a/frontend/tests/institutionExport.test.ts
+++ b/frontend/tests/institutionExport.test.ts
@@ -32,12 +32,15 @@ function makeRequest(): NextRequest {
 function makeSupabase() {
     return {
         from: vi.fn((table: string) => {
-            if (table === 'institutions') {
-                return {
-                    select: () => ({
-                        eq: () => ({ maybeSingle: mockInstMaybeSingle }),
-                    }),
-                };
+            // Institution resolution goes through the membership table since
+            // Issue #238; `mockInstMaybeSingle` still supplies the row.
+            if (table === 'institution_users' || table === 'institutions') {
+                const builder: Record<string, unknown> = {};
+                for (const method of ['select', 'eq', 'in', 'order', 'limit']) {
+                    builder[method] = () => builder;
+                }
+                builder.maybeSingle = mockInstMaybeSingle;
+                return builder;
             }
             if (table === 'credentials') {
                 return {

--- a/frontend/tests/institutionLinkWalletRoute.test.ts
+++ b/frontend/tests/institutionLinkWalletRoute.test.ts
@@ -11,7 +11,6 @@ const {
     mockMaybeSingle,
     mockUpdate,
     mockFirstEqAfterUpdate,
-    mockSecondEqAfterUpdate,
     mockSelectAfterUpdate,
     mockSingleAfterUpdate,
 } = vi.hoisted(() => ({
@@ -23,7 +22,6 @@ const {
     mockMaybeSingle: vi.fn(),
     mockUpdate: vi.fn(),
     mockFirstEqAfterUpdate: vi.fn(),
-    mockSecondEqAfterUpdate: vi.fn(),
     mockSelectAfterUpdate: vi.fn(),
     mockSingleAfterUpdate: vi.fn(),
 }));
@@ -51,8 +49,15 @@ function request(body: unknown): NextRequest {
 describe('institution link wallet route', () => {
     const walletAddress = Keypair.random().publicKey();
 
+    let membershipRow: Record<string, unknown> | null;
+
     beforeEach(() => {
         vi.clearAllMocks();
+        membershipRow = {
+            institution_id: 'institution-1',
+            role: 'owner',
+            status: 'active',
+        };
         mockRequireAuthenticatedRequest.mockResolvedValue({ ok: true, userId: 'institution-user' });
         mockHasServiceRoleEnv.mockReturnValue(true);
         mockEqAfterFind.mockReturnValue({ maybeSingle: mockMaybeSingle });
@@ -60,21 +65,37 @@ describe('institution link wallet route', () => {
             data: { id: 'institution-1', wallet_address: null },
             error: null,
         });
+        // The update is now scoped by institution id alone — membership, not a
+        // repeated auth_user_id filter, is what proves ownership.
         mockUpdate.mockReturnValue({ eq: mockFirstEqAfterUpdate });
-        mockFirstEqAfterUpdate.mockReturnValue({ eq: mockSecondEqAfterUpdate });
-        mockSecondEqAfterUpdate.mockReturnValue({ select: mockSelectAfterUpdate });
+        mockFirstEqAfterUpdate.mockReturnValue({ select: mockSelectAfterUpdate });
         mockSelectAfterUpdate.mockReturnValue({ single: mockSingleAfterUpdate });
         mockSingleAfterUpdate.mockResolvedValue({
             data: { id: 'institution-1', wallet_address: walletAddress },
             error: null,
         });
+
         mockGetServiceRoleClient.mockReturnValue({
-            from: vi.fn(() => ({
-                select: vi.fn(() => ({
-                    eq: mockEqAfterFind,
-                })),
-                update: mockUpdate,
-            })),
+            from: vi.fn((table: string) => {
+                if (table === 'institution_users') {
+                    const builder: Record<string, unknown> = {};
+                    for (const method of ['select', 'eq', 'in', 'order', 'limit']) {
+                        builder[method] = () => builder;
+                    }
+                    builder.maybeSingle = async () => ({
+                        data: membershipRow,
+                        error: null,
+                    });
+                    return builder;
+                }
+
+                return {
+                    select: vi.fn(() => ({
+                        eq: mockEqAfterFind,
+                    })),
+                    update: mockUpdate,
+                };
+            }),
         });
     });
 
@@ -88,7 +109,7 @@ describe('institution link wallet route', () => {
             walletAddress,
             changed: true,
         });
-        expect(mockEqAfterFind).toHaveBeenCalledWith('auth_user_id', 'institution-user');
+        expect(mockEqAfterFind).toHaveBeenCalledWith('id', 'institution-1');
         expect(mockUpdate).toHaveBeenCalledWith({
             wallet_address: walletAddress,
             verified: false,
@@ -96,10 +117,6 @@ describe('institution link wallet route', () => {
             authorization_tx_hash: null,
         });
         expect(mockFirstEqAfterUpdate).toHaveBeenCalledWith('id', 'institution-1');
-        expect(mockSecondEqAfterUpdate).toHaveBeenCalledWith(
-            'auth_user_id',
-            'institution-user',
-        );
     });
 
     it('does not reset authorization when the same wallet is already linked', async () => {
@@ -143,6 +160,34 @@ describe('institution link wallet route', () => {
         expect(payload).toEqual({
             success: false,
             error: 'Institution profile not found',
+        });
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('requires a membership, not merely the deprecated owner column', async () => {
+        membershipRow = null;
+        mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+
+        const response = await POST(request({ walletAddress }));
+
+        expect(response.status).toBe(404);
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('refuses a read-only member, enforcing the role server-side', async () => {
+        membershipRow = {
+            institution_id: 'institution-1',
+            role: 'viewer',
+            status: 'active',
+        };
+
+        const response = await POST(request({ walletAddress }));
+        const payload = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(payload).toEqual({
+            success: false,
+            error: 'Your role does not permit changing the wallet',
         });
         expect(mockUpdate).not.toHaveBeenCalled();
     });

--- a/frontend/tests/institutionMembership.test.ts
+++ b/frontend/tests/institutionMembership.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+    canManageMembers,
+    canWrite,
+    isMemberOfInstitution,
+    resolveInstitutionForUser,
+    resolveInstitutionIdForUser,
+    resolveInstitutionOwnerId,
+} from '../src/lib/institutionMembership';
+
+type Row = Record<string, unknown>;
+
+/**
+ * Minimal in-memory stand-in for the PostgREST query builder, supporting the
+ * subset the resolver uses. Rows are filtered by the accumulated `eq`/`in`
+ * predicates, which is what makes cross-institution isolation testable without
+ * a live database.
+ */
+function makeClient(tables: Record<string, Row[]>): SupabaseClient {
+    const from = (table: string) => {
+        let rows = [...(tables[table] ?? [])];
+
+        const builder: Record<string, unknown> = {
+            select: () => builder,
+            order: () => builder,
+            limit: (n: number) => {
+                rows = rows.slice(0, n);
+                return builder;
+            },
+            eq: (column: string, value: unknown) => {
+                rows = rows.filter((row) => row[column] === value);
+                return builder;
+            },
+            in: (column: string, values: unknown[]) => {
+                rows = rows.filter((row) => values.includes(row[column]));
+                return builder;
+            },
+            maybeSingle: async () => ({ data: rows[0] ?? null, error: null }),
+            single: async () => ({ data: rows[0] ?? null, error: null }),
+        };
+
+        return builder;
+    };
+
+    return { from } as unknown as SupabaseClient;
+}
+
+const INST_A = 'aaaaaaaa-0000-0000-0000-000000000001';
+const INST_B = 'bbbbbbbb-0000-0000-0000-000000000002';
+const USER_A = 'user-a';
+const USER_B = 'user-b';
+
+describe('resolveInstitutionForUser', () => {
+    it('resolves an active membership to its institution and role', async () => {
+        const client = makeClient({
+            institution_users: [
+                { institution_id: INST_A, auth_user_id: USER_A, role: 'owner', status: 'active' },
+            ],
+            institutions: [],
+        });
+
+        const membership = await resolveInstitutionForUser(client, USER_A);
+
+        expect(membership).toEqual({
+            institutionId: INST_A,
+            role: 'owner',
+            status: 'active',
+        });
+    });
+
+    it('resolves a second member of the same institution — the point of the change', async () => {
+        const client = makeClient({
+            institution_users: [
+                { institution_id: INST_A, auth_user_id: USER_A, role: 'owner', status: 'active' },
+                { institution_id: INST_A, auth_user_id: USER_B, role: 'issuer', status: 'active' },
+            ],
+            institutions: [],
+        });
+
+        const first = await resolveInstitutionForUser(client, USER_A);
+        const second = await resolveInstitutionForUser(client, USER_B);
+
+        expect(first?.institutionId).toBe(INST_A);
+        expect(second?.institutionId).toBe(INST_A);
+        expect(second?.role).toBe('issuer');
+    });
+
+    it('denies a member who has not accepted their invite yet', async () => {
+        const client = makeClient({
+            institution_users: [
+                { institution_id: INST_A, auth_user_id: USER_A, role: 'owner', status: 'invited' },
+            ],
+            institutions: [],
+        });
+
+        expect(await resolveInstitutionForUser(client, USER_A)).toBeNull();
+    });
+
+    it('denies a deactivated member, so offboarding actually revokes access', async () => {
+        const client = makeClient({
+            institution_users: [
+                {
+                    institution_id: INST_A,
+                    auth_user_id: USER_A,
+                    role: 'owner',
+                    status: 'deactivated',
+                },
+            ],
+            institutions: [],
+        });
+
+        expect(await resolveInstitutionForUser(client, USER_A)).toBeNull();
+    });
+
+    it('falls back to the deprecated column so a pre-backfill institution keeps access', async () => {
+        const client = makeClient({
+            institution_users: [],
+            institutions: [{ id: INST_A, auth_user_id: USER_A }],
+        });
+
+        const membership = await resolveInstitutionForUser(client, USER_A);
+
+        expect(membership).toEqual({
+            institutionId: INST_A,
+            role: 'owner',
+            status: 'active',
+        });
+    });
+
+    it('returns null for a user with no membership and no legacy row', async () => {
+        const client = makeClient({ institution_users: [], institutions: [] });
+
+        expect(await resolveInstitutionForUser(client, USER_A)).toBeNull();
+        expect(await resolveInstitutionIdForUser(client, USER_A)).toBeNull();
+    });
+});
+
+describe('cross-institution isolation', () => {
+    const client = makeClient({
+        institution_users: [
+            { institution_id: INST_A, auth_user_id: USER_A, role: 'owner', status: 'active' },
+            { institution_id: INST_B, auth_user_id: USER_B, role: 'owner', status: 'active' },
+        ],
+        institutions: [
+            { id: INST_A, auth_user_id: USER_A },
+            { id: INST_B, auth_user_id: USER_B },
+        ],
+    });
+
+    it("never resolves one institution's member onto another institution", async () => {
+        expect((await resolveInstitutionForUser(client, USER_A))?.institutionId).toBe(INST_A);
+        expect((await resolveInstitutionForUser(client, USER_B))?.institutionId).toBe(INST_B);
+    });
+
+    it('rejects a membership check against an institution the user does not belong to', async () => {
+        expect(await isMemberOfInstitution(client, USER_A, INST_A)).toBe(true);
+        expect(await isMemberOfInstitution(client, USER_A, INST_B)).toBe(false);
+        expect(await isMemberOfInstitution(client, USER_B, INST_A)).toBe(false);
+    });
+
+    it('does not let a deactivated member of another institution slip through', async () => {
+        const withDeactivated = makeClient({
+            institution_users: [
+                {
+                    institution_id: INST_B,
+                    auth_user_id: USER_A,
+                    role: 'issuer',
+                    status: 'deactivated',
+                },
+            ],
+            institutions: [],
+        });
+
+        expect(await isMemberOfInstitution(withDeactivated, USER_A, INST_B)).toBe(false);
+    });
+});
+
+describe('server-side role enforcement', () => {
+    it('permits writes only for roles that may issue', () => {
+        expect(canWrite('owner')).toBe(true);
+        expect(canWrite('issuer')).toBe(true);
+        expect(canWrite('viewer')).toBe(false);
+        expect(canWrite('member')).toBe(false);
+    });
+
+    it('maps the legacy role vocabulary onto the same capabilities', () => {
+        expect(canWrite('poc')).toBe(true);
+        expect(canWrite('admin')).toBe(true);
+    });
+
+    it('restricts member management to owners', () => {
+        expect(canManageMembers('owner')).toBe(true);
+        expect(canManageMembers('poc')).toBe(true);
+        expect(canManageMembers('issuer')).toBe(false);
+        expect(canManageMembers('viewer')).toBe(false);
+    });
+});
+
+describe('resolveInstitutionOwnerId', () => {
+    it('prefers the active owner membership', async () => {
+        const client = makeClient({
+            institution_users: [
+                { institution_id: INST_A, auth_user_id: USER_A, role: 'owner', status: 'active' },
+            ],
+        });
+
+        expect(await resolveInstitutionOwnerId(client, INST_A, 'legacy-user')).toBe(USER_A);
+    });
+
+    it('falls back to the deprecated column when no owner membership exists', async () => {
+        const client = makeClient({ institution_users: [] });
+
+        expect(await resolveInstitutionOwnerId(client, INST_A, 'legacy-user')).toBe('legacy-user');
+    });
+});
+
+describe('membership migration', () => {
+    const migration = readFileSync(
+        join(process.cwd(), 'supabase', 'migrations', '20260808000000_institution_membership.sql'),
+        'utf8',
+    );
+
+    it('is idempotent and transactional', () => {
+        expect(migration).toContain('BEGIN;');
+        expect(migration).toContain('COMMIT;');
+        expect(migration).toContain('CREATE TABLE IF NOT EXISTS public.institution_users');
+        expect(migration).toContain('ADD COLUMN IF NOT EXISTS status');
+        expect(migration).toContain('ADD COLUMN IF NOT EXISTS invited_by');
+        expect(migration).toContain('ON CONFLICT (institution_id, auth_user_id) DO NOTHING');
+    });
+
+    it('constrains role and status to the documented vocabularies', () => {
+        expect(migration).toMatch(/CHECK \(status IN \('invited', 'active', 'deactivated'\)\)/);
+        expect(migration).toMatch(/CHECK \(role IN \('owner', 'issuer', 'viewer'/);
+    });
+
+    it('backfills an owner for every institution that had a single login', () => {
+        expect(migration).toContain('INSERT INTO public.institution_users');
+        expect(migration).toContain("SELECT id, auth_user_id, 'owner', 'active', true");
+        expect(migration).toContain('WHERE auth_user_id IS NOT NULL');
+    });
+
+    it('stops an auth-user deletion from cascading away the institution', () => {
+        expect(migration).toContain('DROP CONSTRAINT IF EXISTS institutions_auth_user_id_fkey');
+        expect(migration).toMatch(
+            /FOREIGN KEY \(auth_user_id\) REFERENCES auth\.users \(id\) ON DELETE SET NULL/,
+        );
+        // The membership row itself is what should disappear with the user.
+        expect(migration).toMatch(
+            /auth_user_id\s+UUID NOT NULL REFERENCES auth\.users \(id\) ON DELETE CASCADE/,
+        );
+    });
+
+    it('deprecates rather than drops the single-login column', () => {
+        expect(migration).toContain('ALTER COLUMN auth_user_id DROP NOT NULL');
+        expect(migration).toContain('DEPRECATED (Issue #238)');
+        expect(migration).not.toMatch(/ALTER TABLE public\.institutions\s+DROP COLUMN auth_user_id/);
+    });
+
+    it('routes every institution-scoped policy through membership', () => {
+        expect(migration).toContain('CREATE OR REPLACE FUNCTION public.user_institution_ids');
+        expect(migration).toContain('CREATE OR REPLACE FUNCTION public.user_issuer_institution_ids');
+
+        // No rewritten policy may still compare against the deprecated column.
+        const policies = migration.split('CREATE POLICY').slice(1);
+        expect(policies.length).toBeGreaterThan(0);
+        for (const policy of policies) {
+            expect(policy).not.toMatch(/auth\.uid\(\) = auth_user_id/);
+            expect(policy).not.toMatch(/WHERE auth_user_id = auth\.uid\(\)/);
+        }
+    });
+
+    it('drops the self-insert policy that the removed signup flow depended on', () => {
+        expect(migration).toContain(
+            'DROP POLICY IF EXISTS "Institutions can insert own data" ON public.institutions;',
+        );
+        expect(migration).not.toContain('CREATE POLICY "Institutions can insert own data"');
+    });
+
+    it('keeps is_active and status from disagreeing about access', () => {
+        expect(migration).toContain('CREATE OR REPLACE FUNCTION public.sync_institution_user_status');
+        expect(migration).toContain('trg_sync_institution_user_status');
+    });
+});

--- a/frontend/tests/roleResolver.test.ts
+++ b/frontend/tests/roleResolver.test.ts
@@ -13,34 +13,51 @@ type MockState = {
 };
 
 function createMockClient(state: MockState) {
+    // Institution affiliation is resolved through `institution_users` since
+    // Issue #238, so the stub answers for it as well and every builder method
+    // chains.
+    const makeBuilder = (table: string) => {
+        const resolve = async () => {
+            if (table === 'profiles') {
+                return {
+                    data: state.profileRole ? { role: state.profileRole } : null,
+                    error: null,
+                };
+            }
+            if (table === 'institution_users') {
+                return {
+                    data: state.hasInstitutionRow
+                        ? { institution_id: 'inst-1', role: 'owner', status: 'active' }
+                        : null,
+                    error: null,
+                };
+            }
+            if (table === 'institutions') {
+                return {
+                    data: state.hasInstitutionRow ? { id: 'inst-1' } : null,
+                    error: null,
+                };
+            }
+            if (table === 'students') {
+                return {
+                    data: state.hasStudentRow ? { id: 'stu-1' } : null,
+                    error: null,
+                };
+            }
+            return { data: null, error: null };
+        };
+
+        const builder: Record<string, unknown> = {};
+        for (const method of ['select', 'eq', 'in', 'order', 'limit']) {
+            builder[method] = () => builder;
+        }
+        builder.maybeSingle = resolve;
+        builder.single = resolve;
+        return builder;
+    };
+
     return {
-        from: (table: string) => ({
-            select: () => ({
-                eq: () => ({
-                    maybeSingle: async () => {
-                        if (table === 'profiles') {
-                            return {
-                                data: state.profileRole ? { role: state.profileRole } : null,
-                                error: null,
-                            };
-                        }
-                        if (table === 'institutions') {
-                            return {
-                                data: state.hasInstitutionRow ? { id: 'inst-1' } : null,
-                                error: null,
-                            };
-                        }
-                        if (table === 'students') {
-                            return {
-                                data: state.hasStudentRow ? { id: 'stu-1' } : null,
-                                error: null,
-                            };
-                        }
-                        return { data: null, error: null };
-                    },
-                }),
-            }),
-        }),
+        from: (table: string) => makeBuilder(table),
     } as unknown as SupabaseClient;
 }
 

--- a/frontend/tests/serverAuth.institution.test.ts
+++ b/frontend/tests/serverAuth.institution.test.ts
@@ -27,33 +27,51 @@ vi.mock('@supabase/supabase-js', () => ({
         from: vi.fn((table: string) => {
             queriedTables.push({ key, table });
 
-            return {
-                select: vi.fn(() => ({
-                    eq: vi.fn(() => ({
-                        maybeSingle: vi.fn(async () => {
-                            if (table === 'profiles') {
-                                return {
-                                    data: state.profileRole ? { role: state.profileRole } : null,
-                                    error: null,
-                                };
-                            }
-                            if (table === 'institutions') {
-                                return {
-                                    data: state.institutionId ? { id: state.institutionId } : null,
-                                    error: null,
-                                };
-                            }
-                            if (table === 'students') {
-                                return {
-                                    data: state.hasStudentRow ? { id: 'student-1' } : null,
-                                    error: null,
-                                };
-                            }
-                            return { data: null, error: null };
-                        }),
-                    })),
-                })),
+            // Chainable stub: the membership resolver strings together
+            // select/eq/eq/order/limit before resolving, so every builder
+            // method has to return the builder itself.
+            const resolve = async () => {
+                if (table === 'profiles') {
+                    return {
+                        data: state.profileRole ? { role: state.profileRole } : null,
+                        error: null,
+                    };
+                }
+                if (table === 'institution_users') {
+                    return {
+                        data: state.institutionId
+                            ? {
+                                  institution_id: state.institutionId,
+                                  role: 'owner',
+                                  status: 'active',
+                              }
+                            : null,
+                        error: null,
+                    };
+                }
+                if (table === 'institutions') {
+                    return {
+                        data: state.institutionId ? { id: state.institutionId } : null,
+                        error: null,
+                    };
+                }
+                if (table === 'students') {
+                    return {
+                        data: state.hasStudentRow ? { id: 'student-1' } : null,
+                        error: null,
+                    };
+                }
+                return { data: null, error: null };
             };
+
+            const builder: Record<string, unknown> = {};
+            for (const method of ['select', 'eq', 'in', 'order', 'limit']) {
+                builder[method] = vi.fn(() => builder);
+            }
+            builder.maybeSingle = vi.fn(resolve);
+            builder.single = vi.fn(resolve);
+
+            return builder;
         }),
     })),
 }));


### PR DESCRIPTION
close #238  Institution ownership now lives in a membership relation instead of a single-login column.

Migration — [20260808000000_institution_membership.sql](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/supabase/migrations/20260808000000_institution_membership.sql), mirrored into [schema.sql](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/supabase/schema.sql). Per your call, it evolves the institution_users table that Issue 14 already shipped rather than recreating it: adds status and invited_by, widens the role CHECK to owner/issuer/viewer plus the legacy admin/member/poc, and derives status from the existing is_active. A trigger keeps the two columns in agreement, since the POC-handover routes still write is_active and a disagreement would mean two answers about who has access.

It backfills an owner for every institution with an auth_user_id, and normalises Issue 14's poc backfill to owner — otherwise institutions would have had no owner and nobody could manage members.

RLS — every institution-scoped policy (institutions, credentials, api_keys, credential_pins, institution_users) now resolves through two SECURITY DEFINER helpers: user_institution_ids() for reads and user_issuer_institution_ids() for writes. SECURITY DEFINER matters here — a plain lookup would recurse back through the very policies being evaluated.

Resolver — [institutionMembership.ts](vscode-webview://1c9t0rf1sljng3j2rc3js2u0ln61ei6s2bi0h7p0nsdcs5157p5f/frontend/src/lib/institutionMembership.ts) is the single resolution point; all ~10 institution call sites now route through it (analytics, credentials, export, link-wallet, notifications/trigger, serverAuth, roleResolver, supabase.ts, the dashboard hook, accept-invite, update-authorization).

Role enforcement — canWrite gates link-wallet and notification sending; viewers get a 403.

Three things worth flagging:

A regression I introduced and fixed. Routing resolution through a helper that returned null on failure turned a database error into a 404 "Institution not found" — masking an outage as a missing record. institutionAnalytics caught it. The resolver now throws on a genuine query error and returns null only for real absence.
ON DELETE CASCADE reversed, as the issue required. institutions.auth_user_id was ON DELETE CASCADE — deleting a departing member's auth user would have deleted the institution. That's now SET NULL; the cascade lives on the membership row instead. I did this even though the column is only deprecated, since it's the actively dangerous part.
I dropped the "Institutions can insert own data" policy with no membership replacement — a row can't be a member of itself before it exists. That policy served the self-signup flow Issue 10 removes. Client-side self-insert paths in supabase.ts and useInstitutionProfile still exist and now create the membership row too, but they will fail against the new RLS for non-service-role callers. That's consistent with where Issue 10 is heading, but it is a behaviour change beyond "purely structural," so worth your confirmation.